### PR TITLE
Remove strndup

### DIFF
--- a/src/libvidstab.c
+++ b/src/libvidstab.c
@@ -58,7 +58,6 @@ vs_free_t vs_free       = free;
 vs_zalloc_t vs_zalloc   = _zalloc;
 
 vs_strdup_t vs_strdup   = strdup;
-vs_strndup_t vs_strndup = strndup;
 
 vs_log_t vs_log         = _vs_log;
 int VS_ERROR_TYPE = 0;

--- a/src/vidstabdefines.h
+++ b/src/vidstabdefines.h
@@ -57,7 +57,6 @@ typedef void* (*vs_zalloc_t) (size_t size);
 typedef int (*vs_log_t) (int type, const char* tag, const char* format, ...);
 
 typedef char* (*vs_strdup_t) (const char* s);
-typedef char* (*vs_strndup_t) (const char* s, size_t len);
 
 extern vs_log_t vs_log;
 
@@ -67,7 +66,6 @@ extern vs_free_t vs_free;
 extern vs_zalloc_t vs_zalloc;
 
 extern vs_strdup_t vs_strdup;
-extern vs_strndup_t vs_strndup;
 
 extern int VS_ERROR_TYPE;
 extern int VS_WARN_TYPE;


### PR DESCRIPTION
Never used, and causes problems compiling on MinGW (see #7 )
