### PR TITLE
Minor issues with transcode filter compilation

### DIFF
--- a/transcode/CMakeLists.txt
+++ b/transcode/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library (filter_transform SHARED filter_transform.c
 	../src/localmotion2transform.c) #  orc/transformorc.c)
 add_library (filter_stabilize SHARED filter_stabilize.c
   ../src/transformtype.c ../src/libvidstab.c ../src/motiondetect.c
-	../src/orc/motiondetectorc.c ../src/motiondetect_opt.c
+	../src/orc/motiondetectorc.c ../src/motiondetect_opt.c ../src/localmotion2transform.c
   ../src/boxblur.c ../src/vsvector.c ../src/serialize.c  ../src/frameinfo.c)
 add_library (filter_deshake SHARED filter_deshake.c
   ../src/transformtype.c ../src/libvidstab.c ../src/motiondetect.c

--- a/transcode/filter_deshake.c
+++ b/transcode/filter_deshake.c
@@ -310,7 +310,7 @@ static int deshake_filter_video(TCModuleInstance *self,
       tc_log_error(MOD_NAME, "cannot write to file!");
       return TC_ERROR;
   }
-  motion = vsSimpleMotionsToTransform(td, &localmotions);
+  motion = vsSimpleMotionsToTransform(td->fiSrc, td->conf.modName, &localmotions);
   vs_vector_del(&localmotions);
 
   vsTransformPrepare(td, &vsFrame, &vsFrame);


### PR DESCRIPTION
Hi,

I've encountered a couple of minor issues when compiling recent version of vid.stab transcode plugin, the linking one and the one related to chage in `vsSimpleMotionsToTransform` function signature change in c12e30d6e81e63c0f4c5cddc391f217b80a18825.
