### PR TITLE
added support for negative zoom with optZoom = 2

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -459,7 +459,7 @@ int vsPreprocessTransforms(VSTransformData* td, VSTransformations* trans)
     double prezoom = 0.;
     double postzoom = 0.;
     if(td->conf.zoom>0.){
-      prezoom = td->conf.zoom
+      prezoom = td->conf.zoom;
     } else if(td->conf.zoom < 0.){
       postzoom = td->conf.zoom;
     }

--- a/src/transform.c
+++ b/src/transform.c
@@ -455,7 +455,16 @@ int vsPreprocessTransforms(VSTransformData* td, VSTransformations* trans)
     for (int i = 0; i < trans->len; i++) {
       zooms[i] = transform_get_required_zoom(&ts[i], w, h);
     }
-    meanzoom = mean(zooms, trans->len) + td->conf.zoom; // add global zoom
+
+    double prezoom = 0.;
+    double postzoom = 0.;
+    if(td->conf.zoom>0.){
+      prezoom = td->conf.zoom
+    } else if(td->conf.zoom < 0.){
+      postzoom = td->conf.zoom;
+    }
+
+    meanzoom = mean(zooms, trans->len) + prezoom; // add global zoom
     // forward - propagation (to make the zooming smooth)
     req = meanzoom;
     for (int i = 0; i < trans->len; i++) {
@@ -467,7 +476,7 @@ int vsPreprocessTransforms(VSTransformData* td, VSTransformations* trans)
     req = meanzoom;
     for (int i = trans->len-1; i >= 0; i--) {
       req = VS_MAX(req, zooms[i]);
-      ts[i].zoom=VS_MAX(ts[i].zoom,req);
+      ts[i].zoom=VS_MAX(ts[i].zoom,req) + postzoom;
       req= VS_MAX(meanzoom, req - td->conf.zoomSpeed);
     }
     vs_free(zooms);


### PR DESCRIPTION
**Problem**: 

With optzoom=2 you practically can not zoom out

**Solution**: 

If optzoom=2 and zoom < 0, then zoom is applied after optzoom 

**use case**: 

with videos, that are shaky *and* pre-zoomed, you'd lose a lot if image information when stabilizing without negative zoom. If you apply a negative zoom to those videos, you sometimes see background, but you gain a lot more information at the border of the video. 

With my stabilizing-bot, I use a -5% zoom together with optzoom=2. A result video of this configuration can be found [here](https://www.reddit.com/r/gifs/comments/6wszpk/obstacle_course_jump_level_100/dmb9fgq/)

**testing**:

My stabilizer-bot already uses this PR: [configuration](https://gitlab.com/wotanii/stabbot/blob/204d20803558886b3cf1c8978b1e4816b6d6a5a7/stabVid.py#L80), [build](https://gitlab.com/wotanii/stabbot/blob/204d20803558886b3cf1c8978b1e4816b6d6a5a7/Dockerfile#L58)