### PR TITLE
Fix underflows causing white pixels when processing full range formats

### DIFF
--- a/src/transformfixedpoint.c
+++ b/src/transformfixedpoint.c
@@ -74,7 +74,8 @@ inline void interpolateBiLinBorder(uint8_t *rv, fp16 x, fp16 y,
     // pixel at border of source image
     short val_border = PIX(img, img_linesize, VS_MAX(VS_MIN(ix_f, width-1),0),
                            VS_MAX(VS_MIN(iy_f, height-1),0));
-    *rv = (def * c + val_border * (w - c)) / w;
+    int32_t res = (def * c + val_border * (w - c)) / w;
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }else{
     short v1 = PIXEL(img, img_linesize, ix_c, iy_c, width, height, def);
     short v2 = PIXEL(img, img_linesize, ix_c, iy_f, width, height, def);
@@ -86,7 +87,8 @@ inline void interpolateBiLinBorder(uint8_t *rv, fp16 x, fp16 y,
     fp16 y_c = iToFp16(iy_c);
     fp16 s   = fp16To8(v1*(x - x_f)+v3*(x_c - x))*fp16To8(y - y_f) +
       fp16To8(v2*(x - x_f) + v4*(x_c - x))*fp16To8(y_c - y) + 1;
-    *rv = fp16ToIRound(s);
+    int32_t res = fp16ToIRound(s);
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }
 }
 
@@ -151,7 +153,7 @@ inline void interpolateBiCub(uint8_t *rv, fp16 x, fp16 y,
                             PIX(img, img_linesize, ix_f+1, iy_f+2),
                             PIX(img, img_linesize, ix_f+2, iy_f+2));
     short res = bicub_kernel(y-y_f, v1, v2, v3, v4);
-    *rv = res < 255 ? res : 255;
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }
 }
 
@@ -180,7 +182,7 @@ inline void interpolateBiLin(uint8_t *rv, fp16 x, fp16 y,
       fp16To8(v2*(x - x_f) + v4*(x_c - x))*fp16To8(y_c - y);
     // it is underestimated due to truncation, so we add one
     short res = fp16ToI(s);
-    *rv = res < 255 ? res+1 : 255;
+    *rv = (res >= 0) ? ((res < 255) ? res+1 : 255) : 0;
   }
 }
 
@@ -199,7 +201,7 @@ inline void interpolateLin(uint8_t *rv, fp16 x, fp16 y,
   short v2 = PIXEL(img, img_linesize, ix_f, y_n, width, height, def);
   fp16 s   = v1*(x - x_f) + v2*(x_c - x);
   short res = fp16ToI(s);
-  *rv =   res < 255 ? res : 255;
+  *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
 }
 
 /** interpolateZero: nearest neighbor interpolation function, see interpolate */
@@ -209,7 +211,8 @@ inline void interpolateZero(uint8_t *rv, fp16 x, fp16 y,
 {
   int32_t ix_n = fp16ToIRound(x);
   int32_t iy_n = fp16ToIRound(y);
-  *rv = (uint8_t) PIXEL(img, img_linesize, ix_n, iy_n, width, height, def);
+  int32_t res = PIXEL(img, img_linesize, ix_n, iy_n, width, height, def);
+  *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
 }
 
 
@@ -250,7 +253,8 @@ inline void interpolateN(uint8_t *rv, fp16 x, fp16 y,
     fp16 y_c = iToFp16(iy_c);
     fp16 s  = fp16To8(v1*(x - x_f)+v3*(x_c - x))*fp16To8(y - y_f) +
       fp16To8(v2*(x - x_f) + v4*(x_c - x))*fp16To8(y_c - y);
-    *rv = fp16ToIRound(s);
+    int32_t res = fp16ToIRound(s);
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }
 }
 

--- a/src/transformfloat.c
+++ b/src/transformfloat.c
@@ -44,7 +44,8 @@ void _FLT(interpolateBiLinBorder)(uint8_t *rv, float x, float y,
   short v4 = PIXEL(img, img_linesize, x_f, y_f, width, height, def);
   float s  = (v1*(x - x_f)+v3*(x_c - x))*(y - y_f) +
     (v2*(x - x_f) + v4*(x_c - x))*(y_c - y);
-  *rv = (uint8_t)s;
+  int32_t res = (int32_t)s;
+  *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
 }
 
 /** taken from http://en.wikipedia.org/wiki/Bicubic_interpolation for alpha=-0.5
@@ -92,7 +93,8 @@ void _FLT(interpolateBiCub)(uint8_t *rv, float x, float y,
                                   PIX(img, img_linesize, x_f,   y_f+2),
                                   PIX(img, img_linesize, x_f+1, y_f+2),
                                   PIX(img, img_linesize, x_f+2, y_f+2));
-    *rv = (uint8_t)_FLT(bicub_kernel)(y-y_f, v1, v2, v3, v4);
+    int32_t res = (int32_t)_FLT(bicub_kernel)(y-y_f, v1, v2, v3, v4);
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }
 }
 
@@ -115,7 +117,8 @@ void _FLT(interpolateBiLin)(uint8_t *rv, float x, float y,
     short v4 = PIX(img, img_linesize, x_f, y_f);
     float s  = (v1*(x - x_f)+v3*(x_c - x))*(y - y_f) +
       (v2*(x - x_f) + v4*(x_c - x))*(y_c - y);
-    *rv = (uint8_t)s;
+    int32_t res = (int32_t)s;
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }
 }
 
@@ -131,7 +134,8 @@ void _FLT(interpolateLin)(uint8_t *rv, float x, float y,
   float v1 = PIXEL(img, img_linesize, x_c, y_n, width, height, def);
   float v2 = PIXEL(img, img_linesize, x_f, y_n, width, height, def);
   float s  = v1*(x - x_f) + v2*(x_c - x);
-  *rv = (uint8_t)s;
+  int32_t res = (int32_t)s;
+  *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
 }
 
 /** interpolateZero: nearest neighbor interpolation function, see interpolate */
@@ -178,7 +182,8 @@ void _FLT(interpolateN)(uint8_t *rv, float x, float y,
     short v4 = PIXELN(img, img_linesize, x_f, y_f, width, height, N, channel, def);
     float s  = (v1*(x - x_f)+v3*(x_c - x))*(y - y_f) +
       (v2*(x - x_f) + v4*(x_c - x))*(y_c - y);
-    *rv = (uint8_t)s;
+    int32_t res = (int32_t)s;
+    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
   }
 }
 


### PR DESCRIPTION
Feeding a full-range pixel format (e.g. YUVJ*) to vid.stab without converting to standard 16-255 YUV can cause bright pixels in dark areas due to underflow causing a slightly negative value to becomes a very large value when cast to uint8.

Adding these checks allows processing of modern camera files, GoPro etc, without requiring FFMPEG to insert a pre- and post-scale filter that converts the Y ranges from 0-255 to 16-255 and back again, losing definition in the process.  Most users won't even be aware this is happening because FFMPEG does it without prompting.

This also makes it less likely to end up with washed-out black levels when encoding the output of YUVJ input files to YUV. The auto-scaler filters loses track of the color range and space when converting to standard YUV.

To actually test this in FFMPEG you need to have a version with a patched vf_vidstabdetect filter, vf_vidstabtransform filter, and vidstabutils. I have a branch with the required changes at https://github.com/TouchMonkey/FFmpeg/tree/vidstab_full_range.