### PR TITLE
CMake pc file - libgomp requires pthreads for static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(PKG_EXTRA_LIBS "${PKG_EXTRA_LIBS} ${ORC_LIBRARIES}")
 endif()
 if(USE_OMP)
 target_link_libraries(vidstab gomp)
-set(PKG_EXTRA_LIBS "${PKG_EXTRA_LIBS} -lgomp")
+set(PKG_EXTRA_LIBS "${PKG_EXTRA_LIBS} -lgomp -lpthread")
 endif()
 
 


### PR DESCRIPTION
Libgomp uses pthreads internally and it's usually sufficient to to specify `-fopenmp` in CFLAGS to pick up the required libs. Some configure scripts (e.g. ffmpeg) don't pass these through from pkg-config and only use `--libs`, so setting it here is necessary for static builds.