### PR TITLE
cmake: Use CMAKE_BUILD_TYPE instead of forcing -On/-g

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required (VERSION 2.8.5)
 project (vid.stab)
 
-SET(CMAKE_BUILTTYPE None)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 
 include (FindSSE)
@@ -13,13 +11,17 @@ set(MINOR_VERSION 1)
 set(PATCH_VERSION 0)
 set(VIDSTAB_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}${PATCH_VERSION})
 
+# Default to release builds if no explicit build type specified.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 option(BUILD_SHARED_LIBS "build shared libraries instead of static libraries"
        ON)
 
 option(USE_OMP "use parallelization use OMP" ON)
 
-add_definitions( -Wall -O3 -g -Wno-pointer-sign -fPIC -std=gnu99)
-# add_definitions(  -Wall -O0 -g -Wno-pointer-sign )
+add_definitions(-Wall -Wno-pointer-sign -fPIC -std=gnu99)
 
 ### ORC is not used in any active code at the moment  ###
 # I tried it with 0.4.14

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,13 +5,16 @@
 cmake_minimum_required (VERSION 2.6)
 project (vid.stab)
 
-SET(CMAKE_BUILTTYPE None)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../CMakeModules/")
 
 option(USE_OMP "use parallelization use OMP" ON)
 
-#add_definitions( -Wall -O3 -Wno-pointer-sign -DTESTING  -std=gnu99)
-add_definitions(  -Wall -O0 -g -Wno-pointer-sign -DTESTING -std=gnu99)
+# Default to debug builds if no explicit build type specified.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+add_definitions(-Wall -Wno-pointer-sign -DTESTING -std=gnu99)
 find_package(Orc)
 if(ORC_FOUND)
 add_definitions( -DUSE_ORC ${ORC_DEFINITIONS})

--- a/transcode/CMakeLists.txt
+++ b/transcode/CMakeLists.txt
@@ -1,16 +1,17 @@
 cmake_minimum_required (VERSION 2.6)
 project (vid.stab.transcode)
 
-SET(CMAKE_BUILTTYPE None)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../CMakeModules/")
 
 # set your transcode path here!
 set(TRANSCODE_ROOT ../../transcode)
 
+# Default to release builds if no explicit build type specified.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
 
-add_definitions( -Wall -O3 -Wno-pointer-sign -DTRANSCODE -std=gnu99)
-#add_definitions(  -Wall -O0 -g -Wno-pointer-sign )
+add_definitions(-Wall -Wno-pointer-sign -DTRANSCODE -std=gnu99)
 # I tried it with 0.4.14
 #  0.4.10 did not work (not all opcode implemented)
 # find_package(Orc)  // it actually not used by any active code


### PR DESCRIPTION
Set a default CMAKE_BUILD_TYPE instead of explicitly forcing -On/-g
flags.  The correct value of build type automatically sets appropriate
flags, while also providing a clean interface for overriding them.
Default to 'Release' in main and transcode projects, and to 'Debug'
in tests.

Also remove CMAKE_BUILTTYPE which looks like a typo.