### PR TITLE
tests should exit with code 0 on success

### DIFF
--- a/tests/testframework.c
+++ b/tests/testframework.c
@@ -36,7 +36,7 @@ int unittest_summary(){
   fprintf(stderr, "UNIT TESTs succeeded:\t %s%i/%i\033[0m\n",
           units_failed>0 ? "\033[1;31m" : "\033[1;32m",
           units_success, units_success + units_failed);
-  return units_failed==0;
+  return units_failed!=0;
 
 }
 


### PR DESCRIPTION
Exit code 0 indicates success, anything else indicates failure. Therefore, unittest_summary() should return 0 if no tests failed.