### PR TITLE
Use OpenMP only if available in test_motiondetect

### DIFF
--- a/tests/test_motiondetect.c
+++ b/tests/test_motiondetect.c
@@ -19,7 +19,9 @@ void test_motionDetect(TestData* testdata){
     int i;
 
     int start = timeOfDayinMS();
+#ifdef USE_OMP
     omp_set_dynamic( 1 );
+#endif
     md.conf.numThreads=threads;
 
     for(i=0; i<numruns; i++){


### PR DESCRIPTION
Only call `omp_set_dynamic( 1 );` if `USE_OMP`

Fixes `undefined reference to `omp_set_dynamic'` when not using OpenMP

Originally reported in Gentoo at https://bugs.gentoo.org/675190#c6