### PR TITLE
CMake: Use cmake's way of setting std and don't set fPIC if windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ option(USE_OMP "use parallelization use OMP" ON)
 
 set(CMAKE_C_STANDARD 99)
 
-add_definitions(-Wall -Wno-pointer-sign -fPIC)
+add_definitions(-Wall -Wno-pointer-sign)
+
+if(NOT WIN32)
+  add_definitions(-fPIC)
+endif()
 
 ### ORC is not used in any active code at the moment  ###
 # I tried it with 0.4.14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static libraries"
 
 option(USE_OMP "use parallelization use OMP" ON)
 
-add_definitions(-Wall -Wno-pointer-sign -fPIC -std=gnu99)
+set(CMAKE_C_STANDARD 99)
+
+add_definitions(-Wall -Wno-pointer-sign -fPIC)
 
 ### ORC is not used in any active code at the moment  ###
 # I tried it with 0.4.14


### PR DESCRIPTION
I can revert `CMake: Use CMAKE_C_STANDARD to set the std flag` if wanted since I do not see it in cmake 2.8.5's doc and it seems to mainly be available from 3.1

on windows, clang will error out if `-fPIC` is set, gcc will warn that it doesn't have any effect and will treat it as a noop 