### PR TITLE
Restrict alpha to values from -pi to pi in new_transform

### DIFF
--- a/src/transformtype.c
+++ b/src/transformtype.c
@@ -39,6 +39,12 @@ VSTransform new_transform(double x, double y, double alpha,
   VSTransform t;
   t.x        = x;
   t.y        = y;
+  while (alpha < -M_PI){
+    alpha += 2.0*M_PI;
+  }
+  while (alpha > M_PI){
+    alpha -= 2.0*M_PI;
+  }
   t.alpha    = alpha;
   t.zoom     = zoom;
   t.barrel   = barrel;


### PR DESCRIPTION
Hi,

I sometimes observed a frame-flipping issue when using vid.stab with ffmpeg, i.e. the video would turn upside-down and then back to normal again.
After some investigation, I found out that the reason was that the rotation angle that was found in the gradient descent procedure (within ``vsMotionsToTransform``) was around 2 pi for a frame. Then, during the averaging process in ``cameraPathGaussian``, a transformation of a frame with an angle of ca. 0 rad was averaged with an angle of ca. 2 pi, resulting in an angle of ca. pi, i.e., a flip. (In reality, of course, the averaging is more complicated as there are more terms with different weights).

I found that restricting the angle to values from -pi to pi in ``new_transform`` fixes that problem.

Regards,
Gernot


