### PR TITLE
Add GCC macros for byte order

### DIFF
--- a/src/serialize.c
+++ b/src/serialize.c
@@ -31,6 +31,7 @@
 #include "motiondetect.h"
 
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+    defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ || \
     defined(__BIG_ENDIAN__) || \
     defined(__ARMEB__) || \
     defined(__THUMBEB__) || \
@@ -56,6 +57,7 @@ static double byteSwapDouble(double v)
     return result;
 }
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+    defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ || \
     defined(__LITTLE_ENDIAN__) || \
     defined(__ARMEL__) || \
     defined(__THUMBEL__) || \


### PR DESCRIPTION
Add the feature test macros from GCC for the byte order detection.
Reference is here: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html