### PR TITLE
src/motiondetect: Use ASCII mode for compability with FFmpeg

### DIFF
--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -108,7 +108,7 @@ int vsMotionDetectInit(VSMotionDetect* md, const VSMotionDetectConfig* conf, con
   md->frameNum = 0;
 
   if(md->serializationMode != ASCII_SERIALIZATION_MODE && md->serializationMode != BINARY_SERIALIZATION_MODE) {
-    md->serializationMode = BINARY_SERIALIZATION_MODE;
+    md->serializationMode = ASCII_SERIALIZATION_MODE;
   }
 
   // TODO: get rid of shakiness parameter in the long run


### PR DESCRIPTION
Currently, there isn't a way to set either ascii or binary format in FFmpeg
and that causes an issue with FFmpeg on Windows it seems. It will be better
to wait until the flag can be exposed through the API or wait until an ABI
update to set the binary mode as the default

#104


@georgmartius I do not know enough about vf_vidstabdetect.c and vf_vidstabtransform.c that I can confidently modify it to potentially fix this, so would it be possible to ask you to try to see if there's a way to add the mode switch as a flag to it?