### PR TITLE
Adding settable seek range for stabilizing larger shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Make sure that you use [unsharp](http://www.ffmpeg.org/ffmpeg-filters.html#unsha
   <dd>Set the path to the file used to write the transforms information. Default value is <b>transforms.trf</b>.</dd>
   <dt><b>shakiness</b></dt>
   <dd>Set the shakiness of input video or quickness of camera. It accepts an integer in the range 1-10, a value of 1 means little shakiness, a value of 10 means strong shakiness. Default value is 5.</dd>
+  <dt><b>seek_range</b></dt>
+  <dd>Set the pixel range in which to seek for matches. Default value (-1) means that the range is (1/7) of the smaller dimension of the input. Accepts integers from 0 to 1000</dd>
   <dt><b>accuracy</b></dt>
   <dd>Set the accuracy of the detection process. It must be a value in the range 1-15. A value of 1 means low accuracy, a value of 15 means high accuracy. Default value is 15.</dd>
   <dt><b>stepsize</b></dt>

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -60,6 +60,7 @@ VSMotionDetectConfig vsMotionDetectGetDefaultConfig(const char* modName){
   conf.stepSize          = 6;
   conf.accuracy          = 15;
   conf.shakiness         = 5;
+  conf.seek_range        = -1;
   conf.virtualTripod     = 0;
   conf.contrastThreshold = 0.25;
   conf.show              = 0;
@@ -130,7 +131,11 @@ int vsMotionDetectInit(VSMotionDetect* md, const VSMotionDetectConfig* conf, con
 //  md->fieldSize = VS_MAX(4,VS_MIN(minDimension/6, (minDimension*md->conf.shakiness)/40));
 
   // fixed size and shift now
-  int maxShift      = VS_MAX(16, minDimension/7);
+  int maxShift;
+  if ( md->conf.seek_range < 0 )
+    maxShift = VS_MAX(16, minDimension/7);
+  else 
+    maxShift = md->conf.seek_range;
   int fieldSize     = VS_MAX(16, minDimension/10);
   int fieldSizeFine = VS_MAX(6, minDimension/60);
 #if defined(USE_SSE2) || defined(USE_SSE2_ASM)

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -293,8 +293,8 @@ int initFields(VSMotionDetect* md, VSMotionDetectFields* fs,
   fs->useOffset = 0;
   fs->contrastThreshold = contrastThreshold;
 
-  int rows = VS_MAX(3,(md->fi.height - fs->maxShift*2)/(size+spacing)-1);
-  int cols = VS_MAX(3,(md->fi.width - fs->maxShift*2)/(size+spacing)-1);
+  int rows = VS_MAX(3,(md->fi.height - fs->fieldSize*2)/(size+spacing)-1);
+  int cols = VS_MAX(3,(md->fi.width - fs->fieldSize*2)/(size+spacing)-1);
   // make sure that the remaining rows have the same length
   fs->fieldNum = rows * cols;
   fs->fieldRows = rows;
@@ -309,7 +309,7 @@ int initFields(VSMotionDetect* md, VSMotionDetectFields* fs,
     // have to be away from the image boundary
     // (stepsize is added in case shift is increased through stepsize)
     if(keepBorder)
-      border = size / 2 + fs->maxShift + fs->stepSize;
+      border = size / 2 + fs->fieldSize + fs->stepSize;
     int step_x = (md->fi.width  - 2 * border) / VS_MAX(cols-1,1);
     int step_y = (md->fi.height - 2 * border) / VS_MAX(rows-1,1);
     for (j = 0; j < rows; j++) {

--- a/src/motiondetect.h
+++ b/src/motiondetect.h
@@ -42,6 +42,7 @@
 typedef struct _vsmotiondetectconfig {
   /* meta parameter for maxshift and fieldsize between 1 and 15 */
   int         shakiness;
+  int         seek_range;       // user-selected maximum range in pixels for finding matches
   int         accuracy;         // meta parameter for number of fields between 1 and 10
   int         stepSize;         // stepsize of field transformation detection
   int         algo;             // deprecated
@@ -101,6 +102,8 @@ static const char vs_motiondetect_help[] = ""
     "                  (def:inputfile.stab)\n"
     "    'shakiness'   how shaky is the video and how quick is the camera?\n"
     "                  1: little (fast) 10: very strong/quick (slow) (def: 5)\n"
+    "    'seek_range'  How far (in pixels) can we search for local matches?\n"
+    "                  (def: 1/7 of the smallest image dimension )\n"
     "    'accuracy'    accuracy of detection process (>=shakiness)\n"
     "                  1: low (fast) 15: high (slow) (def: 9)\n"
     "    'stepsize'    stepsize of search process, region around minimum \n"

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -82,7 +82,7 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm);
 LocalMotions vsRestoreLocalmotionsText(FILE* f);
 LocalMotions vsRestoreLocalmotionsBinary(FILE* f);
 LocalMotion restoreLocalmotionText(FILE* f);
-LocalMotion restoreLocalmotionBinary(FILE* f,int i);
+LocalMotion restoreLocalmotionBinary(FILE* f);
 int vsReadFileVersionText(FILE* f);
 int vsReadFileVersionBinary(FILE* f);
 int vsReadFromFileText(FILE* f, LocalMotions* lms);
@@ -161,7 +161,7 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm) {
 }
 
 /// restore local motion from file
-LocalMotion restoreLocalmotion(FILE* f, const int serializationMode,int i){
+LocalMotion restoreLocalmotion(FILE* f, const int serializationMode){
   if(serializationMode == BINARY_SERIALIZATION_MODE) {
     return restoreLocalmotionBinary(f,i);
   } else {
@@ -185,7 +185,7 @@ LocalMotion restoreLocalmotionText(FILE* f){
   return lm;
 }
 
-LocalMotion restoreLocalmotionBinary(FILE* f, int i){
+LocalMotion restoreLocalmotionBinary(FILE* f){
   LocalMotion lm;
 
   if (readInt16(&lm.v.x, f)<=0) goto parse_error_handling;
@@ -256,7 +256,7 @@ LocalMotions vsRestoreLocalmotionsText(FILE* f){
     vs_vector_init(&lms,len);
     for (i=0; i<len; i++){
       if(i>0) while((c=fgetc(f)) && c!=',' && c!=EOF);
-      LocalMotion lm = restoreLocalmotion(f,ASCII_SERIALIZATION_MODE,i);
+      LocalMotion lm = restoreLocalmotion(f,ASCII_SERIALIZATION_MODE);
       vs_vector_append_dup(&lms,&lm,sizeof(LocalMotion));
     }
   }
@@ -284,7 +284,7 @@ LocalMotions vsRestoreLocalmotionsBinary(FILE* f){
   if (len>0){
     vs_vector_init(&lms,len);
     for (i=0; i<len; i++){
-      LocalMotion lm = restoreLocalmotion(f,BINARY_SERIALIZATION_MODE,i);
+      LocalMotion lm = restoreLocalmotion(f,BINARY_SERIALIZATION_MODE);
       vs_vector_append_dup(&lms,&lm,sizeof(LocalMotion));
     }
   }

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -163,7 +163,7 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm) {
 /// restore local motion from file
 LocalMotion restoreLocalmotion(FILE* f, const int serializationMode){
   if(serializationMode == BINARY_SERIALIZATION_MODE) {
-    return restoreLocalmotionBinary(f,i);
+    return restoreLocalmotionBinary(f);
   } else {
     return restoreLocalmotionText(f);
   }

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -307,6 +307,7 @@ int vsPrepareFileText(const VSMotionDetect* md, FILE* f){
   fprintf(f, "VID.STAB %i\n", LIBVIDSTAB_FILE_FORMAT_VERSION);
   fprintf(f, "#      accuracy = %d\n", md->conf.accuracy);
   fprintf(f, "#     shakiness = %d\n", md->conf.shakiness);
+  fprintf(f, "#     seek_range = %d\n", md->conf.seek_range);
   fprintf(f, "#      stepsize = %d\n", md->conf.stepSize);
   fprintf(f, "#   mincontrast = %f\n", md->conf.contrastThreshold);
   return VS_OK;
@@ -318,6 +319,7 @@ int vsPrepareFileBinary(const VSMotionDetect* md, FILE* f){
   fprintf(f, "TRF%hhu", kFileFormatVersion);
   writeInt32(&md->conf.accuracy, f);
   writeInt32(&md->conf.shakiness, f);
+  writeInt32(&md->conf.seek_range, f);
   writeInt32(&md->conf.stepSize, f);
   writeDouble(&md->conf.contrastThreshold, f);
   return VS_OK;

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -82,7 +82,7 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm);
 LocalMotions vsRestoreLocalmotionsText(FILE* f);
 LocalMotions vsRestoreLocalmotionsBinary(FILE* f);
 LocalMotion restoreLocalmotionText(FILE* f);
-LocalMotion restoreLocalmotionBinary(FILE* f);
+LocalMotion restoreLocalmotionBinary(FILE* f,int i);
 int vsReadFileVersionText(FILE* f);
 int vsReadFileVersionBinary(FILE* f);
 int vsReadFromFileText(FILE* f, LocalMotions* lms);
@@ -161,9 +161,9 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm) {
 }
 
 /// restore local motion from file
-LocalMotion restoreLocalmotion(FILE* f, const int serializationMode){
+LocalMotion restoreLocalmotion(FILE* f, const int serializationMode,int i){
   if(serializationMode == BINARY_SERIALIZATION_MODE) {
-    return restoreLocalmotionBinary(f);
+    return restoreLocalmotionBinary(f,i);
   } else {
     return restoreLocalmotionText(f);
   }
@@ -185,7 +185,7 @@ LocalMotion restoreLocalmotionText(FILE* f){
   return lm;
 }
 
-LocalMotion restoreLocalmotionBinary(FILE* f){
+LocalMotion restoreLocalmotionBinary(FILE* f, int i){
   LocalMotion lm;
 
   if (readInt16(&lm.v.x, f)<=0) goto parse_error_handling;
@@ -256,7 +256,7 @@ LocalMotions vsRestoreLocalmotionsText(FILE* f){
     vs_vector_init(&lms,len);
     for (i=0; i<len; i++){
       if(i>0) while((c=fgetc(f)) && c!=',' && c!=EOF);
-      LocalMotion lm = restoreLocalmotion(f,ASCII_SERIALIZATION_MODE);
+      LocalMotion lm = restoreLocalmotion(f,ASCII_SERIALIZATION_MODE,i);
       vs_vector_append_dup(&lms,&lm,sizeof(LocalMotion));
     }
   }
@@ -284,7 +284,7 @@ LocalMotions vsRestoreLocalmotionsBinary(FILE* f){
   if (len>0){
     vs_vector_init(&lms,len);
     for (i=0; i<len; i++){
-      LocalMotion lm = restoreLocalmotion(f,BINARY_SERIALIZATION_MODE);
+      LocalMotion lm = restoreLocalmotion(f,BINARY_SERIALIZATION_MODE,i);
       vs_vector_append_dup(&lms,&lm,sizeof(LocalMotion));
     }
   }
@@ -388,9 +388,10 @@ int vsReadFileVersionBinary(FILE* f){
   unsigned char version;
   VSMotionDetectConfig conf;
 
-  if(fscanf(f, "TRF%hhu\n", &version)!=LIBVIDSTAB_FILE_FORMAT_VERSION) goto parse_error_handling;
+  if(fscanf(f, "TRF%hhu", &version)!=LIBVIDSTAB_FILE_FORMAT_VERSION) goto parse_error_handling;
   if(readInt32(&conf.accuracy, f)<=0) goto parse_error_handling;
   if(readInt32(&conf.shakiness, f)<=0) goto parse_error_handling;
+  if(readInt32(&conf.seek_range, f)<=0) goto parse_error_handling;
   if(readInt32(&conf.stepSize, f)<=0) goto parse_error_handling;
   if(readDouble(&conf.contrastThreshold, f)<=0) goto parse_error_handling;
   

--- a/transcode/filter_stabilize.c
+++ b/transcode/filter_stabilize.c
@@ -176,6 +176,7 @@ static int stabilize_configure(TCModuleInstance *self,
         optstr_get(options, "fileformat", "%d", &md->serializationMode);
         optstr_get(options, "result",     "%[^:]", sd->result);
         optstr_get(options, "shakiness",  "%d", &conf.shakiness);
+        optstr_get(options, "seek_range", "%d", &conf.seek_range);
         optstr_get(options, "accuracy",   "%d", &conf.accuracy);
         optstr_get(options, "stepsize",   "%d", &conf.stepSize);
         optstr_get(options, "algo",       "%d", &conf.algo);
@@ -193,6 +194,7 @@ static int stabilize_configure(TCModuleInstance *self,
     if (verbose) {
         tc_log_info(MOD_NAME, "Image Stabilization Settings:");
         tc_log_info(MOD_NAME, "     shakiness = %d", conf.shakiness);
+        tc_log_info(MOD_NAME, "    seek_range = %d", conf.seek_range);
         tc_log_info(MOD_NAME, "      accuracy = %d", conf.accuracy);
         tc_log_info(MOD_NAME, "      stepsize = %d", conf.stepSize);
         tc_log_info(MOD_NAME, "          algo = %d", conf.algo);
@@ -303,6 +305,7 @@ static int stabilize_inspect(TCModuleInstance *self,
     vsMotionDetectGetConfig(&conf,md);
 
     CHECKPARAM("shakiness","shakiness=%d", conf.shakiness);
+    CHECKPARAM("seek_range","seek_range=%d", conf.seek_range);
     CHECKPARAM("accuracy", "accuracy=%d",  conf.accuracy);
     CHECKPARAM("stepsize", "stepsize=%d",  conf.stepSize);
     CHECKPARAM("algo",     "algo=%d",      conf.algo);

--- a/transcode/filter_stabilize.c
+++ b/transcode/filter_stabilize.c
@@ -172,7 +172,6 @@ static int stabilize_configure(TCModuleInstance *self,
             tc_log_info(MOD_NAME,vs_motiondetect_help);
             return(TC_IMPORT_ERROR);
         }
-        printf("GOT OPTIONS");
 
         optstr_get(options, "fileformat", "%d", &md->serializationMode);
         optstr_get(options, "result",     "%[^:]", sd->result);

--- a/transcode/filter_stabilize.c
+++ b/transcode/filter_stabilize.c
@@ -172,6 +172,7 @@ static int stabilize_configure(TCModuleInstance *self,
             tc_log_info(MOD_NAME,vs_motiondetect_help);
             return(TC_IMPORT_ERROR);
         }
+        printf("GOT OPTIONS");
 
         optstr_get(options, "fileformat", "%d", &md->serializationMode);
         optstr_get(options, "result",     "%[^:]", sd->result);


### PR DESCRIPTION
Adding an option for the user to override the "(1/7) of the shortest side" match seek range.
The new parameter `seek_range` has integer input defining the maximum pixel distance, with -1 (default) meaning that the original 1/7 range is used.
I needed this to "tripod-style" stabilize a panning downward view from drone across longer distance.
Some users may have other uses for it.
This requires  [this](https://github.com/ViktorWalter/FFmpeg) fork of FFmpeg to accept the new parameter.