### PR TITLE
fix(cmake): Use CMAKE_CURRENT_SOURCE_DIR for robust subproject integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 2.8.5)
 project (vid.stab C)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/")
 
 include (FindSSE)
 include (GNUInstallDirs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required (VERSION 2.6)
 project (vid.stab)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../CMakeModules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../CMakeModules/")
 
 include (FindSSE)
 

--- a/transcode/CMakeLists.txt
+++ b/transcode/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 2.6)
 project (vid.stab.transcode)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/../CMakeModules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../CMakeModules/")
 
 # set your transcode path here!
 set(TRANSCODE_ROOT ../../transcode)


### PR DESCRIPTION
This commit replaces instances of `CMAKE_SOURCE_DIR` with `CMAKE_CURRENT_SOURCE_DIR` in the `CMakeLists.txt`.

**Reasoning:**

When this project is included as a subproject in a larger CMake build (e.g., via `add_subdirectory` or `FetchContent`), `CMAKE_SOURCE_DIR` incorrectly points to the top-level project's root. This causes path resolution errors.

Using `CMAKE_CURRENT_SOURCE_DIR` ensures that all paths are resolved relative to this project's own source tree, making it a robust and reliable CMake subproject.