### PR TITLE
Fix the packed pixel format (RGB24/BGR24/RGBA) code paths

### DIFF
--- a/src/frameinfo.c
+++ b/src/frameinfo.c
@@ -67,14 +67,18 @@ int vsFrameInfoInit(VSFrameInfo* fi, int width, int height, VSPixelFormat pForma
     fi->log2ChromaH = 1;
     fi->planes = 4;
     break;
+    /* For the packed formats everything lives in plane 0 (see VSFrame), so
+       there is exactly one plane. It must not be 0: all the plane loops are
+       `for(plane=0; plane<fi->planes; plane++)`, with planes==0 nothing gets
+       allocated and nothing gets copied. */
    case PF_RGB24:
    case PF_BGR24:
     fi->bytesPerPixel=3;
-    fi->planes = 0;
+    fi->planes = 1;
     break;
    case PF_RGBA:
     fi->bytesPerPixel=4;
-    fi->planes = 0;
+    fi->planes = 1;
     break;
    default:
     fi->pFormat=0;
@@ -138,7 +142,8 @@ void vsFrameCopyPlane(VSFrame* dest, const VSFrame* src,
   else {
     uint8_t* d = dest->data[plane];
     const uint8_t* s = src->data[plane];
-    int w = fi->width  >> vsGetPlaneWidthSubS(fi, plane);
+    // number of *bytes* per row of actual image data (bytesPerPixel is 1 for planar)
+    int w = (fi->width  >> vsGetPlaneWidthSubS(fi, plane)) * fi->bytesPerPixel;
     for (; h>0; h--) {
       memcpy(d,s,sizeof(uint8_t) * w);
       d += dest->linesize[plane];

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -379,6 +379,33 @@ double contrastSubImg(unsigned char* const I, const Field* field, int linesize,
   return (maxi - mini) / (maxi + mini + 0.1); // +0.1 to avoid division by 0
 }
 
+/* Where to centre the search for one field, as a *displacement* of the field
+   centre (that is what compareSubImg()'s d_x/d_y and LocalMotion.v are).
+   fs->offset is the transform found by the coarse scan; transform_vec() maps a
+   point to its new *absolute* position, so the original position has to be
+   subtracted to turn it into a displacement.
+   Returns 0 if the shifted field plus its search window would leave the frame,
+   in which case the field has to be discarded. Shared by the planar and the
+   packed variant below so that the two cannot drift apart again.
+*/
+static int fieldSearchOffset(Vec* offset, const VSMotionDetect* md,
+                             const VSMotionDetectFields* fs, const Field* field) {
+  offset->x = 0;
+  offset->y = 0;
+  if (!fs->useOffset)
+    return 1;
+  // Todo: we could put the preparedtransform into fs
+  PreparedTransform pt = prepare_transform(&fs->offset, &md->fi);
+  Vec fieldpos = {field->x, field->y};
+  *offset = sub_vec(transform_vec(&pt, &fieldpos), fieldpos);
+  // is the field still in the frame?
+  int border = field->size/2 + fs->maxShift + fs->stepSize;
+  int x = fieldpos.x + offset->x;
+  int y = fieldpos.y + offset->y;
+  return !(x - border < 0 || x + border >= md->fi.width ||
+           y - border < 0 || y + border >= md->fi.height);
+}
+
 /* calculates the optimal transformation for one field in Planar frames
  * (only luminance)
  */
@@ -392,22 +419,11 @@ LocalMotion calcFieldTransPlanar(VSMotionDetect* md, VSMotionDetectFields* fs,
   int i, j;
   int stepSize = fs->stepSize;
   int maxShift = fs->maxShift;
-  Vec offset = { 0, 0};
+  Vec offset;
   LocalMotion lm = null_localmotion();
-  if(fs->useOffset){
-    // Todo: we could put the preparedtransform into fs
-    PreparedTransform pt = prepare_transform(&fs->offset, &md->fi);
-    Vec fieldpos = {field->x, field->y};
-    offset = sub_vec(transform_vec(&pt, &fieldpos), fieldpos);
-    // is the field still in the frame
-    int s2 = field->size/2;
-    if(unlikely(fieldpos.x+offset.x-s2-maxShift-stepSize < 0 ||
-                fieldpos.x+offset.x+s2+maxShift+stepSize >= md->fi.width ||
-                fieldpos.y+offset.y-s2-maxShift-stepSize < 0 ||
-                fieldpos.y+offset.y+s2+maxShift+stepSize >= md->fi.height)){
-      lm.match=-1;
-      return lm;
-    }
+  if(unlikely(!fieldSearchOffset(&offset, md, fs, field))){
+    lm.match=-1;
+    return lm;
   }
 
 #ifdef STABVERBOSE
@@ -557,24 +573,11 @@ LocalMotion calcFieldTransPacked(VSMotionDetect* md, VSMotionDetectFields* fs,
   int stepSize = fs->stepSize;
   int maxShift = fs->maxShift;
 
-  Vec offset = { 0, 0};
+  Vec offset;
   LocalMotion lm = null_localmotion();
-  if(fs->useOffset){
-    // Todo: we could put the preparedtransform into fs
-    PreparedTransform pt = prepare_transform(&fs->offset, &md->fi);
-    Vec fieldpos = {field->x, field->y};
-    // offset is used as a *relative* shift below, so subtract the field position
-    //  (transform_vec returns an absolute position). Same as calcFieldTransPlanar.
-    offset = sub_vec(transform_vec(&pt, &fieldpos), fieldpos);
-    // is the field still in the frame
-    int s2 = field->size/2;
-    if(unlikely(fieldpos.x+offset.x-s2-maxShift-stepSize < 0 ||
-                fieldpos.x+offset.x+s2+maxShift+stepSize >= md->fi.width ||
-                fieldpos.y+offset.y-s2-maxShift-stepSize < 0 ||
-                fieldpos.y+offset.y+s2+maxShift+stepSize >= md->fi.height)){
-      lm.match=-1;
-      return lm;
-    }
+  if(unlikely(!fieldSearchOffset(&offset, md, fs, field))){
+    lm.match=-1;
+    return lm;
   }
 
   /* Here we improve speed by checking first the most probable position

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -336,28 +336,30 @@ double contrastSubImgPlanar(VSMotionDetect* md, const Field* field) {
 }
 
 /**
-   \see contrastSubImg_Michelson three times called with bytesPerPixel=3
-   for all channels
+   \see contrastSubImg called once per colour channel with the packed
+   bytesPerPixel as the pixel stride. Only the three colour channels are used,
+   a (constant) alpha channel would only dilute the result.
 */
 double contrastSubImgPacked(VSMotionDetect* md, const Field* field) {
   unsigned char* const I = md->curr.data[0];
-  int linesize2 = md->curr.linesize[0]/3; // linesize in pixels
-  return (contrastSubImg(I, field, linesize2, md->fi.height, 3)
-          + contrastSubImg(I + 1, field, linesize2, md->fi.height, 3)
-          + contrastSubImg(I + 2, field, linesize2, md->fi.height, 3)) / 3;
+  int linesize = md->curr.linesize[0]; // linesize in bytes
+  int bpp      = md->fi.bytesPerPixel;
+  return (contrastSubImg(I,     field, linesize, md->fi.height, bpp)
+          + contrastSubImg(I + 1, field, linesize, md->fi.height, bpp)
+          + contrastSubImg(I + 2, field, linesize, md->fi.height, bpp)) / 3;
 }
 
 /**
    calculates Michelson-contrast in the given small part of the given image
    to be more compatible with the absolute difference formula this is scaled by 0.1
 
-   \param I pointer to framebuffer
+   \param I pointer to framebuffer (offset to the wanted channel for packed data)
    \param field Field specifies position(center) and size of subimage
-   \param width width of frame (linesize in pixels)
+   \param linesize distance between two rows in BYTES (see vidstabdefines.h)
    \param height height of frame
-   \param bytesPerPixel calc contrast for only for first channel
+   \param bytesPerPixel distance between two pixels in bytes, 1 for planar
 */
-double contrastSubImg(unsigned char* const I, const Field* field, int width,
+double contrastSubImg(unsigned char* const I, const Field* field, int linesize,
                       int height, int bytesPerPixel) {
   int k, j;
   unsigned char* p = NULL;
@@ -365,14 +367,14 @@ double contrastSubImg(unsigned char* const I, const Field* field, int width,
   unsigned char mini = 255;
   unsigned char maxi = 0;
 
-  p = I + ((field->x - s2) + (field->y - s2) * width) * bytesPerPixel;
+  p = I + (field->x - s2) * bytesPerPixel + (field->y - s2) * linesize;
   for (j = 0; j < field->size; j++) {
     for (k = 0; k < field->size; k++) {
       mini = (mini < *p) ? mini : *p;
       maxi = (maxi > *p) ? maxi : *p;
       p += bytesPerPixel;
     }
-    p += (width - field->size) * bytesPerPixel;
+    p += linesize - field->size * bytesPerPixel;
   }
   return (maxi - mini) / (maxi + mini + 0.1); // +0.1 to avoid division by 0
 }
@@ -548,8 +550,9 @@ LocalMotion calcFieldTransPacked(VSMotionDetect* md, VSMotionDetectFields* fs,
   int tx = 0;
   int ty = 0;
   uint8_t *I_c = md->curr.data[0], *I_p = md->prev.data[0];
-  int width1 = md->curr.linesize[0]/3; // linesize in pixels
-  int width2 = md->prev.linesize[0]/3; // linesize in pixels
+  // linesizes are in bytes, compareSubImg() scales the column by bytesPerPixel
+  int linesize_c = md->curr.linesize[0], linesize_p = md->prev.linesize[0];
+  int bpp = md->fi.bytesPerPixel;
   int i, j;
   int stepSize = fs->stepSize;
   int maxShift = fs->maxShift;
@@ -557,11 +560,18 @@ LocalMotion calcFieldTransPacked(VSMotionDetect* md, VSMotionDetectFields* fs,
   Vec offset = { 0, 0};
   LocalMotion lm = null_localmotion();
   if(fs->useOffset){
+    // Todo: we could put the preparedtransform into fs
     PreparedTransform pt = prepare_transform(&fs->offset, &md->fi);
-    offset = transform_vec(&pt, (Vec*)field);
+    Vec fieldpos = {field->x, field->y};
+    // offset is used as a *relative* shift below, so subtract the field position
+    //  (transform_vec returns an absolute position). Same as calcFieldTransPlanar.
+    offset = sub_vec(transform_vec(&pt, &fieldpos), fieldpos);
     // is the field still in the frame
-    if(unlikely(offset.x-maxShift-stepSize < 0 || offset.x+maxShift+stepSize >= md->fi.width ||
-                offset.y-maxShift-stepSize < 0 || offset.y+maxShift+stepSize >= md->fi.height)){
+    int s2 = field->size/2;
+    if(unlikely(fieldpos.x+offset.x-s2-maxShift-stepSize < 0 ||
+                fieldpos.x+offset.x+s2+maxShift+stepSize >= md->fi.width ||
+                fieldpos.y+offset.y-s2-maxShift-stepSize < 0 ||
+                fieldpos.y+offset.y+s2+maxShift+stepSize >= md->fi.height)){
       lm.match=-1;
       return lm;
     }
@@ -570,15 +580,15 @@ LocalMotion calcFieldTransPacked(VSMotionDetect* md, VSMotionDetectFields* fs,
   /* Here we improve speed by checking first the most probable position
      then the search paths are most effectively cut. (0,0) is a simple start
   */
-  unsigned int minerror = compareSubImg(I_c, I_p, field, width1, width2, md->fi.height,
-                                        3, offset.x, offset.y, UINT_MAX);
+  unsigned int minerror = compareSubImg(I_c, I_p, field, linesize_c, linesize_p, md->fi.height,
+                                        bpp, offset.x, offset.y, UINT_MAX);
   // check all positions...
   for (i = -maxShift; i <= maxShift; i += stepSize) {
     for (j = -maxShift; j <= maxShift; j += stepSize) {
       if( i==0 && j==0 )
         continue; //no need to check this since already done
-      unsigned int error = compareSubImg(I_c, I_p, field, width1, width2,
-                                         md->fi.height, 3, i + offset.x, j + offset.y, minerror);
+      unsigned int error = compareSubImg(I_c, I_p, field, linesize_c, linesize_p,
+                                         md->fi.height, bpp, i + offset.x, j + offset.y, minerror);
       if (error < minerror) {
         minerror = error;
         tx = i;
@@ -594,8 +604,8 @@ LocalMotion calcFieldTransPacked(VSMotionDetect* md, VSMotionDetectFields* fs,
       for (j = tyc - r; j <= tyc + r; j += 1) {
         if (i == txc && j == tyc)
           continue; //no need to check this since already done
-        unsigned int error = compareSubImg(I_c, I_p, field, width1, width2,
-                                           md->fi.height, 3, i + offset.x, j + offset.y, minerror);
+        unsigned int error = compareSubImg(I_c, I_p, field, linesize_c, linesize_p,
+                                           md->fi.height, bpp, i + offset.x, j + offset.y, minerror);
         if (error < minerror) {
           minerror = error;
           tx = i;
@@ -894,7 +904,7 @@ void drawLine(unsigned char* I, int width, int height, int bytesPerPixel,
 
 /// plain C implementation of compareSubImg
 unsigned int compareSubImg_thr(unsigned char* const I1, unsigned char* const I2,
-                               const Field* field, int width1, int width2, int height,
+                               const Field* field, int linesize1, int linesize2, int height,
            int bytesPerPixel, int d_x, int d_y,
            unsigned int threshold) {
   int k, j;
@@ -903,9 +913,9 @@ unsigned int compareSubImg_thr(unsigned char* const I1, unsigned char* const I2,
   int s2 = field->size / 2;
   unsigned int sum = 0;
 
-  p1 = I1 + ((field->x - s2) + (field->y - s2) * width1) * bytesPerPixel;
-  p2 = I2 + ((field->x - s2 + d_x) + (field->y - s2 + d_y) * width2)
-    * bytesPerPixel;
+  p1 = I1 + (field->x - s2) * bytesPerPixel + (field->y - s2) * linesize1;
+  p2 = I2 + (field->x - s2 + d_x) * bytesPerPixel
+    + (field->y - s2 + d_y) * linesize2;
   for (j = 0; j < field->size; j++) {
     for (k = 0; k < field->size * bytesPerPixel; k++) {
       sum += abs((int) *p1 - (int) *p2);
@@ -914,8 +924,8 @@ unsigned int compareSubImg_thr(unsigned char* const I1, unsigned char* const I2,
     }
     if( sum > threshold) // no need to calculate any longer: worse than the best match
       break;
-    p1 += (width1 - field->size) * bytesPerPixel;
-    p2 += (width2 - field->size) * bytesPerPixel;
+    p1 += linesize1 - field->size * bytesPerPixel;
+    p2 += linesize2 - field->size * bytesPerPixel;
   }
   return sum;
 }

--- a/src/motiondetect_internal.h
+++ b/src/motiondetect_internal.h
@@ -46,8 +46,10 @@ VS_API int initFields(VSMotionDetect* md, VSMotionDetectFields* fs,
 
 VS_API double contrastSubImgPlanar(VSMotionDetect* md, const Field* field);
 VS_API double contrastSubImgPacked(VSMotionDetect* md, const Field* field);
+/// \param linesize distance between two rows in BYTES (see vidstabdefines.h)
+/// \param bytesPerPixel distance between two pixels in bytes, 1 for planar
 VS_API double contrastSubImg(unsigned char* const I, const Field* field,
-                      int width, int height, int bytesPerPixel);
+                      int linesize, int height, int bytesPerPixel);
 
 
 VS_API int cmp_contrast_idx(const void *ci1, const void* ci2);
@@ -74,8 +76,10 @@ VS_API void drawRectangle(unsigned char* I, int width, int height, int bytesPerP
 VS_API void drawLine(unsigned char* I, int width, int height, int bytesPerPixel,
               Vec* a, Vec* b, int thickness, unsigned char color);
 
+/// \param linesize1,linesize2 distance between two rows in BYTES of I1 resp. I2
+/// \param bytesPerPixel distance between two pixels in bytes, 1 for planar
 VS_API unsigned int compareSubImg_thr(unsigned char* const I1, unsigned char* const I2,
-                               const Field* field, int width1, int width2, int height,
+                               const Field* field, int linesize1, int linesize2, int height,
                                int bytesPerPixel,
                                int d_x, int d_y, unsigned int threshold);
 

--- a/src/motiondetect_opt.c
+++ b/src/motiondetect_opt.c
@@ -45,7 +45,7 @@
    \see contrastSubImg using SSE2 optimization, Planar (1 byte per channel) only
 */
 double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
-                           int width, int height)
+                           int linesize, int height)
 {
   int k, j;
   unsigned char* p = NULL;
@@ -53,7 +53,7 @@ double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
 
   static unsigned char full[16] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-  p = I + ((field->x - s2) + (field->y - s2)*width);
+  p = I + (field->x - s2) + (field->y - s2)*linesize;
 
   __m128i mmin, mmax;
 
@@ -68,7 +68,7 @@ double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
       mmax = _mm_max_epu8(mmax, xmm0);
       p += 16;
     }
-    p += (width - field->size);
+    p += linesize - field->size;
   }
 
   __m128i xmm1;
@@ -98,7 +98,7 @@ double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
 
 /// plain C implementation of variance based contrastSubImg
 double contrastSubImg_variance_C(unsigned char* const I,
-                                 const Field* field, int width, int height) {
+                                 const Field* field, int linesize, int height) {
   int k, j;
   unsigned char* p = NULL;
   unsigned char* pstart = NULL;
@@ -108,13 +108,13 @@ double contrastSubImg_variance_C(unsigned char* const I,
   int var=0;
   int numpixel = field->size*field->size;
 
-  pstart = I + ((field->x - s2) + (field->y - s2) * width);
+  pstart = I + (field->x - s2) + (field->y - s2) * linesize;
   p = pstart;
   for (j = 0; j < field->size; j++) {
     for (k = 0; k < field->size; k++, p++) {
       sum+=*p;
     }
-    p += (width - field->size);
+    p += linesize - field->size;
   }
   mean=sum/numpixel;
   p = pstart;
@@ -122,7 +122,7 @@ double contrastSubImg_variance_C(unsigned char* const I,
     for (k = 0; k < field->size; k++, p++) {
       var+=abs(*p-mean);
     }
-    p += (width - field->size);
+    p += linesize - field->size;
   }
   return (double)var/numpixel/255.0;
 }
@@ -130,7 +130,7 @@ double contrastSubImg_variance_C(unsigned char* const I,
 #ifdef USE_SSE2
 unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* const I2,
                                     const Field* field,
-                                    int width1, int width2, int height,
+                                    int linesize1, int linesize2, int height,
                                     int bytesPerPixel, int d_x, int d_y,
                                     unsigned int treshold) {
   int k, j;
@@ -149,8 +149,8 @@ unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* cons
   xmmsum = _mm_setzero_si128();
   xmmmask = _mm_loadu_si128((__m128i const*)mask);
 
-  p1=I1 + ((field->x - s2) + (field->y - s2)*width1)*bytesPerPixel;
-  p2=I2 + ((field->x - s2 + d_x) + (field->y - s2 + d_y)*width2)*bytesPerPixel;
+  p1=I1 + (field->x - s2)*bytesPerPixel + (field->y - s2)*linesize1;
+  p2=I2 + (field->x - s2 + d_x)*bytesPerPixel + (field->y - s2 + d_y)*linesize2;
   for (j = 0; j < field->size; j++){
     for (k = 0; k < field->size * bytesPerPixel; k+=16){
       {
@@ -201,8 +201,8 @@ unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* cons
     }
     if (sum > treshold)
       break;
-    p1 += (width1 - field->size) * bytesPerPixel;
-    p2 += (width2 - field->size) * bytesPerPixel;
+    p1 += linesize1 - field->size * bytesPerPixel;
+    p2 += linesize2 - field->size * bytesPerPixel;
   }
 
 #if (SSE2_CMP_SUM_ROWS != 1) && (SSE2_CMP_SUM_ROWS != 2) && (SSE2_CMP_SUM_ROWS != 4) \
@@ -239,7 +239,7 @@ unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* cons
 #ifdef USE_SSE2_ASM
 unsigned int compareSubImg_thr_sse2_asm(unsigned char* const I1, unsigned char* const I2,
                                         const Field* field,
-                                        int width1, int width2, int height,
+                                        int linesize1, int linesize2, int height,
                                         int bytesPerPixel, int d_x, int d_y,
                                         unsigned int treshold) {
   unsigned char* p1 = NULL;
@@ -248,8 +248,8 @@ unsigned int compareSubImg_thr_sse2_asm(unsigned char* const I1, unsigned char* 
   unsigned int sum = 0;
 
   static unsigned char mask[16] = {0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00};
-  p1=I1 + ((field->x - s2) + (field->y - s2)*width1)*bytesPerPixel;
-  p2=I2 + ((field->x - s2 + d_x) + (field->y - s2 + d_y)*width2)*bytesPerPixel;
+  p1=I1 + (field->x - s2)*bytesPerPixel + (field->y - s2)*linesize1;
+  p2=I2 + (field->x - s2 + d_x)*bytesPerPixel + (field->y - s2 + d_y)*linesize2;
   asm (
     "xor %0,%0\n"
     "pxor %%xmm4,%%xmm4\n"         //8 x 16bit partial sums
@@ -313,10 +313,10 @@ unsigned int compareSubImg_thr_sse2_asm(unsigned char* const I1, unsigned char* 
     "jnz 1b\n"                   //if not, continue looping
     "3:\n"
     :"=r"(sum)
-    :"r"(p1),"r"(p2),"r"(mask),"g"(field->size * bytesPerPixel / 16),"g"((unsigned char*)((width1 - field->size) * bytesPerPixel)),"g"(field->size), "g"(treshold), "0"(sum)
+    :"r"(p1),"r"(p2),"r"(mask),"g"(field->size * bytesPerPixel / 16),"g"((unsigned char*)(long)(linesize1 - field->size * bytesPerPixel)),"g"(field->size), "g"(treshold), "0"(sum)
     :"%xmm0","%xmm1","%xmm2","%xmm3","%xmm4","%ecx","%edx"
     );
-  // TODO width2 is not properly used here
+  // TODO linesize2 is not properly used here
   return sum;
 }
 #endif // USE_SSE2_ASM

--- a/src/motiondetect_opt.h
+++ b/src/motiondetect_opt.h
@@ -39,23 +39,24 @@
 #endif
 
 #ifdef USE_SSE2
+/// \param linesize distance between two rows in BYTES (see vidstabdefines.h)
 VS_API double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
-                           int width, int height);
+                           int linesize, int height);
 #endif
 
 VS_API double contrastSubImg_variance_C(unsigned char* const I, const Field* field,
-                        int width, int height);
+                        int linesize, int height);
 
 #ifdef USE_SSE2
 VS_API unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* const I2,
-                                    const Field* field, int width1, int width2, int height,
+                                    const Field* field, int linesize1, int linesize2, int height,
                                     int bytesPerPixel, int d_x, int d_y,
                                     unsigned int threshold);
 #endif
 
 #ifdef USE_SSE2_ASM
 unsigned int compareSubImg_thr_sse2_asm(unsigned char* const I1, unsigned char* const I2,
-                                        const Field* field, int width1, int width2,
+                                        const Field* field, int linesize1, int linesize2,
                                         int height, int bytesPerPixel,
                                         int d_x, int d_y, unsigned int threshold);
 #endif

--- a/src/transformfixedpoint.c
+++ b/src/transformfixedpoint.c
@@ -221,8 +221,9 @@ inline void interpolateZero(uint8_t *rv, fp16 x, fp16 y,
  *            x,y: the source coordinates in the image img. Note this
  *                 are real-value coordinates, that's why we interpolate
  *            img: source image
- *   width,height: dimension of image
- *              N: number of channels
+ *   img_linesize: distance between two rows in BYTES (see vidstabdefines.h)
+ *   width,height: dimension of image in PIXELS
+ *              N: number of channels (bytes per pixel)
  *        channel: channel number (0..N-1)
  *            def: default value if coordinates are out of range
  * Return value:  None
@@ -235,15 +236,18 @@ inline void interpolateN(uint8_t *rv, fp16 x, fp16 y,
 {
   int32_t ix_f = fp16ToI(x);
   int32_t iy_f = fp16ToI(y);
+  // fp16ToI is an arithmetic shift, so it floors: negative x give negative ix_f
   if (ix_f < 0 || ix_f > width-1 || iy_f < 0 || iy_f > height - 1) {
     *rv = def;
   } else {
     int32_t ix_c = ix_f + 1;
     int32_t iy_c = iy_f + 1;
-    short v1 = PIXN(img, img_linesize, ix_c, iy_c, N, channel);
-    short v2 = PIXN(img, img_linesize, ix_c, iy_f, N, channel);
-    short v3 = PIXN(img, img_linesize, ix_f, iy_c, N, channel);
-    short v4 = PIXN(img, img_linesize, ix_f, iy_f, N, channel);
+    /* the "ceil" neighbours may be one past the last row/column; use the
+       range checked accessor, their interpolation weight is 0 in that case */
+    short v1 = PIXELN(img, img_linesize, ix_c, iy_c, width, height, N, channel, def);
+    short v2 = PIXELN(img, img_linesize, ix_c, iy_f, width, height, N, channel, def);
+    short v3 = PIXELN(img, img_linesize, ix_f, iy_c, width, height, N, channel, def);
+    short v4 = PIXELN(img, img_linesize, ix_f, iy_f, width, height, N, channel, def);
     fp16 x_f = iToFp16(ix_f);
     fp16 x_c = iToFp16(ix_c);
     fp16 y_f = iToFp16(iy_f);
@@ -269,6 +273,16 @@ int transformPacked(VSTransformData* td, VSTransform t)
 {
   int x = 0, y = 0, k = 0;
   uint8_t *D_1, *D_2;
+
+  if (t.alpha==0 && t.x==0 && t.y==0 && t.zoom == 0){
+    // identity: like transformPlanar, do not run the interpolation at all
+    if(vsFramesEqual(&td->src,&td->destbuf))
+      return VS_OK; // noop
+    else {
+      vsFrameCopy(&td->destbuf, &td->src, &td->fiSrc);
+      return VS_OK;
+    }
+  }
 
   D_1  = td->src.data[0];
   D_2  = td->destbuf.data[0];
@@ -300,7 +314,8 @@ int transformPacked(VSTransformData* td, VSTransform t)
       fp16 y_s  = -zsin_a * x_d1 + zcos_a * y_d1 + c_ty;
 
       for (k = 0; k < channels; k++) { // iterate over colors
-        uint8_t *dest = &D_2[x + y * td->destbuf.linesize[0]+k];
+        // linesize is in bytes, only the column is scaled by the channel count
+        uint8_t *dest = &D_2[x * channels + y * td->destbuf.linesize[0] + k];
         interpolateN(dest, x_s, y_s, D_1, td->src.linesize[0],
                      td->fiSrc.width, td->fiSrc.height,
                      channels, k, td->conf.crop ? 16 : *dest);

--- a/src/transformfloat.c
+++ b/src/transformfloat.c
@@ -157,8 +157,9 @@ void _FLT(interpolateZero)(uint8_t *rv, float x, float y,
  *            x,y: the source coordinates in the image img. Note this
  *                 are real-value coordinates, that's why we interpolate
  *            img: source image
- *   width,height: dimension of image
- *              N: number of channels
+ *   img_linesize: distance between two rows in BYTES (see vidstabdefines.h)
+ *   width,height: dimension of image in PIXELS
+ *              N: number of channels (bytes per pixel)
  *        channel: channel number (0..N-1)
  *            def: default value if coordinates are out of range
  * Return value:  None
@@ -169,6 +170,8 @@ void _FLT(interpolateN)(uint8_t *rv, float x, float y,
                         uint8_t N, uint8_t channel,
                         uint8_t def)
 {
+  // myfloor() below floors, so negative coordinates stay negative and are
+  //  rejected by the range check inside PIXELN
   if (x < - 1 || x > width || y < -1 || y > height) {
     *rv = def;
   } else {
@@ -232,7 +235,8 @@ int _FLT(transformPacked)(VSTransformData* td, VSTransform t)
         float y_s  = -sin(-t.alpha) * x_d1
           + cos(-t.alpha) * y_d1 + c_s_y -t.y;
         for (z = 0; z < channels; z++) { // iterate over colors
-          uint8_t *dest = &D_2[x + y * td->destbuf.linesize[0]+z];
+          // linesize is in bytes, only the column is scaled by the channel count
+          uint8_t *dest = &D_2[x * channels + y * td->destbuf.linesize[0] + z];
           _FLT(interpolateN)(dest, x_s, y_s, D_1, td->src.linesize[0],
                              td->fiSrc.width, td->fiSrc.height,
                              channels, z, crop ? 16 : *dest);
@@ -252,15 +256,15 @@ int _FLT(transformPacked)(VSTransformData* td, VSTransform t)
                            td->fiSrc.width, td->fiSrc.height, channels, z, -1);
           if (p == -1) {
             if (crop == 1)
-              D_2[(x + y * td->destbuf.linesize[0])*channels+z] = 16;
+              D_2[x * channels + y * td->destbuf.linesize[0] + z] = 16;
           } else {
-            D_2[(x + y * td->destbuf.linesize[0])*channels+z] = (uint8_t)p;
+            D_2[x * channels + y * td->destbuf.linesize[0] + z] = (uint8_t)p;
           }
         }
       }
     }
   }
-  return 1;
+  return VS_OK; // was `return 1`, which is not VS_OK (== 0)
 }
 
 /**

--- a/src/vidstabdefines.h
+++ b/src/vidstabdefines.h
@@ -46,16 +46,36 @@
 
 #define VS_DEBUG 2
 
+/**** Pixel access ***********************************************************
+ *
+ * UNIT CONVENTION (holds for all PIX* macros below, for VSFrame::linesize and
+ * for every function in this library that takes a linesize):
+ *
+ *   `linesize` is the distance between the start of two consecutive rows
+ *   measured in BYTES -- exactly like FFmpeg's AVFrame::linesize. It may be
+ *   larger than width*bytesPerPixel (padding).
+ *
+ * Consequently only the COLUMN index is scaled by the number of channels
+ * (N == bytesPerPixel for the packed formats), never the row offset:
+ *
+ *   byte offset = x*N + y*linesize + channel
+ *
+ * Never pass a linesize that was pre-divided by the number of channels.
+ *****************************************************************************/
+
 /// pixel in single layer image
 #define PIXEL(img, linesize, x, y, w, h, def) \
   (((x) < 0 || (y) < 0 || (x) >= (w) || (y) >= (h)) ? (def) : img[(x) + (y) * (linesize)])
 /// pixel in single layer image without rangecheck
 #define PIX(img, linesize, x, y) (img[(x) + (y) * (linesize)])
 /// pixel in N-channel image. channel in {0..N-1}
-#define PIXELN(img, linesize, x, y, w, h, N, channel, def) \
-  (((x) < 0 || (y) < 0 || (x) >= (w) || (y) >= (h)) ? (def) : img[((x) + (y) * (linesize))*(N) + (channel)])
+#define PIXELN(img, linesize, x, y, w, h, N, channel, def)                     \
+  (((x) < 0 || (y) < 0 || (x) >= (w) || (y) >= (h)                             \
+    || (channel) < 0 || (channel) >= (N))                                      \
+   ? (def) : img[(x)*(N) + (y) * (linesize) + (channel)])
 /// pixel in N-channel image without rangecheck. channel in {0..N-1}
-#define PIXN(img, linesize, x, y, N, channel) (img[((x) + (y) * (linesize))*(N) + (channel)])
+#define PIXN(img, linesize, x, y, N, channel) \
+  (img[(x)*(N) + (y) * (linesize) + (channel)])
 
 /**** Configurable memory and logging functions. Defined in libvidstab.c ****/
 

--- a/tests/test_packed.c
+++ b/tests/test_packed.c
@@ -1,0 +1,313 @@
+/* ---------------------------------------------------------------------------
+   Unit tests for the packed pixel formats PF_RGB24 / PF_BGR24 / PF_RGBA.
+
+   These formats are advertised by FFmpeg's vidstab filters
+   (ff_vidstab_pix_fmts contains AV_PIX_FMT_RGB24, AV_PIX_FMT_BGR24 and
+   AV_PIX_FMT_RGBA) so they really do reach this library.
+
+   The convention that is verified here (see vidstabdefines.h):
+     VSFrame::linesize is *always* a byte offset between two rows. Only the
+     column index is scaled by bytesPerPixel, never the row offset.
+   --------------------------------------------------------------------------- */
+
+static uint8_t* packedPixel(const VSFrame* f, const VSFrameInfo* fi, int x, int y){
+  return f->data[0] + y * f->linesize[0] + x * fi->bytesPerPixel;
+}
+
+/** blocky test image, every channel carries a clearly different pattern so that
+    a stride/channel mixup shows up as a large difference and not as noise */
+static void fillPackedBlocks(VSFrame* f, const VSFrameInfo* fi){
+  int x,y,c;
+  for(y=0; y<fi->height; y++){
+    for(x=0; x<fi->width; x++){
+      uint8_t* p = packedPixel(f,fi,x,y);
+      int bx = x/16, by = y/16;
+      p[0] = (uint8_t)( 30 + 37*((bx*5+by*3)%6));
+      p[1] = (uint8_t)(200 - 23*((bx*2+by*7)%7));
+      p[2] = (uint8_t)( 80 + 11*((bx+by)%13));
+      for(c=3; c<fi->bytesPerPixel; c++)
+        p[c] = (uint8_t)(255 - 4*((bx+by)%9));
+    }
+  }
+}
+
+/** randomly coloured tiles: high contrast and a unique fingerprint per field,
+    but with a correlation length of BLOCK pixels so that the coarse grid search
+    of the motion detection actually has a gradient to follow */
+#define PACKED_BLOCK 8
+static void fillPackedNoise(VSFrame* f, const VSFrameInfo* fi, unsigned int seed){
+  int x,y,c;
+  int bw = fi->width/PACKED_BLOCK + 1;
+  int bh = fi->height/PACKED_BLOCK + 1;
+  uint8_t* blocks = vs_zalloc(bw*bh*4);
+  srand(seed);
+  for(y=0; y<bw*bh*4; y++) blocks[y] = (uint8_t)(rand()%256);
+  for(y=0; y<fi->height; y++){
+    for(x=0; x<fi->width; x++){
+      uint8_t* p = packedPixel(f,fi,x,y);
+      uint8_t* b = blocks + ((x/PACKED_BLOCK) + (y/PACKED_BLOCK)*bw)*4;
+      for(c=0; c<fi->bytesPerPixel; c++)
+        p[c] = b[c];
+    }
+  }
+  vs_free(blocks);
+}
+
+/** copies src shifted by (dx,dy): dest(x,y) = src(x-dx,y-dy), black outside */
+static void shiftPacked(VSFrame* dest, const VSFrame* src, const VSFrameInfo* fi,
+                        int dx, int dy){
+  int x,y,c;
+  for(y=0; y<fi->height; y++){
+    for(x=0; x<fi->width; x++){
+      uint8_t* d = packedPixel(dest,fi,x,y);
+      int sx = x-dx, sy = y-dy;
+      if(sx<0 || sy<0 || sx>=fi->width || sy>=fi->height){
+        for(c=0; c<fi->bytesPerPixel; c++) d[c]=0;
+      }else{
+        const uint8_t* s = packedPixel(src,fi,sx,sy);
+        for(c=0; c<fi->bytesPerPixel; c++) d[c]=s[c];
+      }
+    }
+  }
+}
+
+/** counts channels that differ by more than tol, reports the first few */
+static int packedCountDiff(const VSFrame* a, const VSFrame* b,
+                           const VSFrameInfo* fi, int tol, const char* what){
+  int x,y,c,bad=0;
+  for(y=0; y<fi->height; y++){
+    for(x=0; x<fi->width; x++){
+      const uint8_t* pa = packedPixel(a,fi,x,y);
+      const uint8_t* pb = packedPixel(b,fi,x,y);
+      for(c=0; c<fi->bytesPerPixel; c++){
+        int diff = (int)pa[c] - (int)pb[c];
+        if(abs(diff)>tol){
+          if(bad<8)
+            fprintf(stderr,"  %s: mismatch at (%i,%i) channel %i: %i != %i\n",
+                    what, x, y, c, (int)pa[c], (int)pb[c]);
+          bad++;
+        }
+      }
+    }
+  }
+  fprintf(stderr,"  %s: %i deviating channel values (tolerance %i)\n", what, bad, tol);
+  return bad;
+}
+
+static const char* packedFormatName(VSPixelFormat pf){
+  switch(pf){
+   case PF_RGB24: return "PF_RGB24";
+   case PF_BGR24: return "PF_BGR24";
+   case PF_RGBA:  return "PF_RGBA";
+   default:       return "?";
+  }
+}
+
+/* --- frame info / allocation / copy ------------------------------------- */
+
+static void test_packed_frameinfo(void){
+  VSPixelFormat fmts[3] = {PF_RGB24, PF_BGR24, PF_RGBA};
+  int bpps[3]           = {3,3,4};
+  int i,k;
+  fprintf(stderr,"--- packed VSFrameInfo / allocation ---\n");
+  for(i=0; i<3; i++){
+    VSFrameInfo fi;
+    VSFrame f, g;
+    int bytes;
+    long sum = 0;
+    test_bool(vsFrameInfoInit(&fi, 64, 32, fmts[i]) == 1);
+    fprintf(stderr,"%s: planes=%i bytesPerPixel=%i\n",
+            packedFormatName(fmts[i]), fi.planes, fi.bytesPerPixel);
+    /* everything is in plane 0 for packed data, so there is exactly one plane.
+       With planes==0 nothing is allocated/copied at all. */
+    test_bool(fi.planes == 1);
+    test_bool(fi.bytesPerPixel == bpps[i]);
+
+    vsFrameAllocate(&f, &fi);
+    test_bool(!vsFrameIsNull(&f));
+    test_bool(f.linesize[0] == 64*bpps[i]);
+    bytes = f.linesize[0]*fi.height;
+    /* touch every byte: catches an undersized allocation under ASan */
+    for(k=0; k<bytes; k++) sum += f.data[0][k];
+    test_bool(sum == 0); /* vs_zalloc */
+
+    fillPackedBlocks(&f,&fi);
+    vsFrameAllocate(&g, &fi);
+    test_bool(!vsFrameIsNull(&g));
+    vsFrameCopy(&g, &f, &fi);
+    test_bool(memcmp(g.data[0], f.data[0], bytes) == 0);
+    vsFrameFree(&f);
+    vsFrameFree(&g);
+
+    { /* vsFrameFillFromBuffer must describe one packed plane */
+      uint8_t* buf = vs_zalloc(bytes);
+      VSFrame h;
+      vsFrameFillFromBuffer(&h, buf, &fi);
+      test_bool(h.data[0] == buf);
+      test_bool(h.linesize[0] == 64*bpps[i]);
+      test_bool(h.data[1] == 0);
+      vs_free(buf);
+    }
+  }
+}
+
+/* --- identity transform must reproduce the input bit for bit ------------- */
+
+static void test_packed_identity(VSPixelFormat pf){
+  VSFrameInfo fi;
+  VSFrame src, dest;
+  VSTransformConfig conf = vsTransformGetDefaultConfig("test_packed_identity");
+  VSTransformData td;
+  fprintf(stderr,"--- identity transform, %s ---\n", packedFormatName(pf));
+  test_bool(vsFrameInfoInit(&fi, 128, 64, pf) == 1);
+  vsFrameAllocate(&src,&fi);
+  vsFrameAllocate(&dest,&fi);
+  test_bool(!vsFrameIsNull(&src) && !vsFrameIsNull(&dest));
+  fillPackedBlocks(&src,&fi);
+  vsFrameCopy(&dest,&src,&fi);
+
+  test_bool(vsTransformDataInit(&td, &conf, &fi, &fi) == VS_OK);
+  test_bool(vsTransformPrepare(&td,&dest,&dest) == VS_OK);
+  test_bool(vsDoTransform(&td, null_transform()) == VS_OK);
+  test_bool(vsTransformFinish(&td) == VS_OK);
+  test_bool(packedCountDiff(&dest,&src,&fi,0,"identity") == 0);
+
+  vsTransformDataCleanup(&td);
+  vsFrameFree(&src);
+  vsFrameFree(&dest);
+}
+
+/* --- pure integer translation, no channel smearing ---------------------- */
+
+static void test_packed_translate(VSPixelFormat pf){
+  VSFrameInfo fi;
+  VSFrame src, dest, ref, fltres;
+  VSTransformConfig conf = vsTransformGetDefaultConfig("test_packed_translate");
+  VSTransformData td;
+  VSTransform t = null_transform();
+  const int dx = 8, dy = -4;
+  int x,y,c,bad=0;
+
+  fprintf(stderr,"--- integer translation (%i,%i), %s ---\n", dx, dy,
+          packedFormatName(pf));
+  test_bool(vsFrameInfoInit(&fi, 128, 64, pf) == 1);
+  vsFrameAllocate(&src,&fi);
+  vsFrameAllocate(&dest,&fi);
+  vsFrameAllocate(&ref,&fi);
+  vsFrameAllocate(&fltres,&fi);
+  fillPackedBlocks(&src,&fi);
+  t.x = dx;
+  t.y = dy;
+
+  /* the float implementation takes the exact integer copy path for alpha==0,
+     so it is an exact oracle: dest(x,y) = src(x-dx,y-dy), border keeps src */
+  vsFrameCopy(&dest,&src,&fi);
+  test_bool(vsTransformDataInit(&td, &conf, &fi, &fi) == VS_OK);
+  test_bool(vsTransformPrepare(&td,&dest,&dest) == VS_OK);
+  test_bool(transformPacked_float(&td, t) == VS_OK);
+  test_bool(vsTransformFinish(&td) == VS_OK);
+  vsFrameCopy(&fltres,&dest,&fi);
+  vsTransformDataCleanup(&td);
+
+  /* build the expected image */
+  for(y=0; y<fi.height; y++){
+    for(x=0; x<fi.width; x++){
+      uint8_t* d = packedPixel(&ref,&fi,x,y);
+      int sx = x-dx, sy = y-dy;
+      const uint8_t* s = (sx<0||sy<0||sx>=fi.width||sy>=fi.height)
+        ? packedPixel(&src,&fi,x,y)   /* VSKeepBorder: previous frame content */
+        : packedPixel(&src,&fi,sx,sy);
+      for(c=0; c<fi.bytesPerPixel; c++) d[c]=s[c];
+    }
+  }
+  test_bool(packedCountDiff(&fltres,&ref,&fi,0,"translate/float") == 0);
+
+  /* the fixed point implementation interpolates, allow the usual +-2 */
+  vsFrameCopy(&dest,&src,&fi);
+  test_bool(vsTransformDataInit(&td, &conf, &fi, &fi) == VS_OK);
+  test_bool(vsTransformPrepare(&td,&dest,&dest) == VS_OK);
+  test_bool(transformPacked(&td, t) == VS_OK);
+  test_bool(vsTransformFinish(&td) == VS_OK);
+  test_bool(packedCountDiff(&dest,&ref,&fi,2,"translate/fixedpoint") == 0);
+  vsTransformDataCleanup(&td);
+
+  /* channels must not leak into each other: a stride bug mixes them up, which
+     always produces differences far bigger than the interpolation rounding */
+  for(y=0; y<fi.height; y++){
+    for(x=0; x<fi.width; x++){
+      const uint8_t* pd = packedPixel(&dest,&fi,x,y);
+      const uint8_t* pr = packedPixel(&ref,&fi,x,y);
+      for(c=0; c<fi.bytesPerPixel; c++)
+        if(abs((int)pd[c]-(int)pr[c]) > 16) bad++;
+    }
+  }
+  fprintf(stderr,"  gross (channel swap) errors: %i\n", bad);
+  test_bool(bad == 0);
+
+  vsFrameFree(&src);
+  vsFrameFree(&dest);
+  vsFrameFree(&ref);
+  vsFrameFree(&fltres);
+}
+
+/* --- motion detection on packed frames ---------------------------------- */
+
+static void test_packed_motiondetect(VSPixelFormat pf){
+  VSFrameInfo fi;
+  VSFrame f1, f2;
+  VSMotionDetectConfig mdconf = vsMotionDetectGetDefaultConfig("test_packed_md");
+  VSMotionDetect md;
+  LocalMotions lms;
+  const int dx = 8, dy = -6;
+  VSTransform t;
+
+  fprintf(stderr,"--- motion detection, %s, shift (%i,%i) ---\n",
+          packedFormatName(pf), dx, dy);
+  test_bool(vsFrameInfoInit(&fi, 320, 240, pf) == 1);
+  vsFrameAllocate(&f1,&fi);
+  vsFrameAllocate(&f2,&fi);
+  test_bool(!vsFrameIsNull(&f1) && !vsFrameIsNull(&f2));
+  fillPackedNoise(&f1,&fi,42);
+  shiftPacked(&f2,&f1,&fi,dx,dy);
+
+  test_bool(vsMotionDetectInit(&md, &mdconf, &fi) == VS_OK);
+  md.conf.numThreads = 1;
+  test_bool(vsMotionDetection(&md, &lms, &f1) == VS_OK);
+  vs_vector_del(&lms);
+  test_bool(vsMotionDetection(&md, &lms, &f2) == VS_OK);
+  fprintf(stderr,"  found %i local motions\n", vs_vector_size(&lms));
+  test_bool(vs_vector_size(&lms) > 4);
+  t = vsSimpleMotionsToTransform(fi, "test_packed_md", &lms);
+  fprintf(stderr,"  recovered transform: ");
+  storeVSTransform(stderr,&t);
+  /* the content moved by (dx,dy), so the compensating shift is (-dx,-dy) */
+  test_bool(fabs(t.x + dx) < 2);
+  test_bool(fabs(t.y + dy) < 2);
+  test_bool(fabs(t.alpha) < 0.01);
+  vs_vector_del(&lms);
+  vsMotionDetectionCleanup(&md);
+  vsFrameFree(&f1);
+  vsFrameFree(&f2);
+}
+
+void test_packed(void){
+  test_packed_frameinfo();
+  test_packed_identity(PF_RGB24);
+  test_packed_identity(PF_RGBA);
+  test_packed_translate(PF_RGB24);
+  test_packed_translate(PF_BGR24);
+  test_packed_translate(PF_RGBA);
+  test_packed_motiondetect(PF_RGB24);
+  test_packed_motiondetect(PF_RGBA);
+}
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -41,6 +41,7 @@
 #include "test_gradientoptimizer.c"
 #include "test_localmotion2transform.c"
 #include "test_determinism.c"
+#include "test_packed.c"
 
 #define FRAMENUM 5
 
@@ -133,6 +134,10 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testCT", "contrastImg")){
     UNIT(test_contrastImg(&testdata));
+  }
+
+  if(all || contains(argv,argc,"--testPK", "packed pixel formats")){
+    UNIT(test_packed());
   }
 
   if(all || contains(argv,argc,"--testGO", "gradient optimizer")){


### PR DESCRIPTION
Builds on #31 by @Karry, and goes further. Supersedes it.

## Why this matters
The packed paths are **reachable in production**: upstream FFmpeg's `libavfilter/vidstabutils.c` advertises `AV_PIX_FMT_RGB24, AV_PIX_FMT_BGR24, AV_PIX_FMT_RGBA` in `ff_vidstab_pix_fmts`, used by both filters, and `ff_av2vs_pixfmt` maps them to `PF_RGB24/PF_BGR24/PF_RGBA`. `transformPacked` is the real implementation (the `_FLT` twin is `-DTESTING` only). There was **zero** packed test coverage.

## Defects fixed
| Where | Defect |
|---|---|
| `frameinfo.c` | `PF_RGB24/BGR24/RGBA` set `planes = 0`. Every plane loop is `for(plane=0; plane<planes; plane++)`, so `vsFrameCopy` was a **no-op** — detection ran on an all-zero image — and `vsFrameAllocate` tripped its own `assert(planes==1)`. |
| `vidstabdefines.h` | `PIXELN`/`PIXN` computed `((x)+(y)*linesize)*N`, multiplying the **row stride** by the channel count. Heap buffer overflow, confirmed under ASan. |
| `transformfixedpoint.c` | The write side was `&D_2[x + y*linesize + k]` — never scaled `x` by channels. |
| `transformfloat.c` | Both the rotation and translation branches had the same class of error. |
| `motiondetect.c` | `PF_RGBA` was hardcoded as 3 bytes/pixel — both the pixel and row stride wrong for RGBA. |
| `motiondetect.c` | `calcFieldTransPacked` used `transform_vec()`'s **absolute** position as the **relative** search offset. The planar twin was fixed in c12e30d; the packed one never was. Second ASan overflow, and it made the fine scan return noise. |
| `frameinfo.c` | `vsFrameCopyPlane` copied `width` instead of `width*bytesPerPixel` bytes per row. |

Also added the identity shortcut `transformPacked` was missing, guarded `channel` in `PIXELN`, made `interpolateN` use the range-checked accessor for its ceil-neighbours, and fixed `transformPacked_float` returning `1` where `VS_OK == 0`.

## Unit convention (documented in the header)
`linesize` is **always bytes**, matching `AVFrame::linesize`; only the column is scaled by channels: `x*N + y*linesize + channel`. All the compensating `/3` divisions are gone. Bonus: padded linesizes now work — `linesize/3` used to truncate them.

## Evidence
Before (with only `planes=1` applied so it gets past the assert):
```
==681632==ERROR: AddressSanitizer: heap-buffer-overflow
    #0 in interpolateN    src/transformfixedpoint.c:243
    #1 in transformPacked src/transformfixedpoint.c:304
```
Identity round-trip, RGB24: **8164 deviating channel values, then segfault** → **0 deviating** (tolerance 0), for both RGB24 and RGBA. Detection recovers an injected (8,−6) shift exactly.

## Tests
New `--testPK`: allocation sanity, identity round-trip at tolerance 0, pure translation without channel smearing, and detection on packed input. Planar suite unaffected (14/14 → 15/15).

## Not fixed here (deliberate)
- A pre-existing ASan overflow in `interpolateBiLin_float` (`transformfloat.c:114`), reachable from `--testTI`. `-DTESTING`-only reference code; changing its edge behaviour would move the float oracle the fixed-point comparison is calibrated against.
- SSE2 `compareSubImg` steps 16 bytes up to `field->size*bytesPerPixel`, only safe when that product is a multiple of 16. True for every size vid.stab picks, but not enforced.
