### PR TITLE
Fix memory leaks, including per-frame leaks in vsMotionDetection (#107)

### DIFF
--- a/src/localmotion2transform.c
+++ b/src/localmotion2transform.c
@@ -118,13 +118,13 @@ double intMean(const int* ds, int len) {
 // only calcates means transform to initialise gradient descent
 VSTransform meanMotions(VSTransformData* td, const LocalMotions* motions){
   int len = vs_vector_size(motions);
-  int* xs = localmotions_getx(motions);
-  int* ys = localmotions_gety(motions);
   VSTransform t = null_transform();
   if(motions==0 || len==0) {
     t.extra = 1; // prob. blank frame or too low contrast, ignore later
     return t;
   }
+  int* xs = localmotions_getx(motions);
+  int* ys = localmotions_gety(motions);
   t.x = intMean(xs,len);
   t.y = intMean(ys,len);
   vs_free(xs);
@@ -283,11 +283,11 @@ VSTransform vsSimpleMotionsToTransform(VSFrameInfo fi, const char* modName,
   VSTransform t = null_transform();
   if(motions==0) return t;
   int num_motions=vs_vector_size(motions);
+  if(num_motions < 1)
+    return t;
   double *angles = (double*) vs_malloc(sizeof(double) * num_motions);
   LocalMotion meanmotion;
   int i;
-  if(num_motions < 1)
-    return t;
 
   // calc center point of all remaining fields
   for (i = 0; i < num_motions; i++) {

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -230,7 +230,13 @@ int vsMotionDetection(VSMotionDetect* md, LocalMotions* motions, VSFrame *frame)
       // through out those with bad match (worse than mean of coarse scan)
       VSArray matchQualities1 = localmotionsGetMatch(&motionscoarse);
       double meanMatch = cleanmean(matchQualities1.dat, matchQualities1.len, NULL, NULL);
-      motionsfine      = vs_vector_filter(&motions2, lm_match_better, &meanMatch);
+      // note: we copy the selected motions (instead of vs_vector_filter, which
+      //  would share the elements with motions2 and leak the rejected ones)
+      for(int i=0; i < vs_vector_size(&motions2); i++){
+        LocalMotion* m = LMGet(&motions2,i);
+        if(lm_match_better(&meanMatch, m))
+          vs_vector_append_dup(&motionsfine, m, sizeof(LocalMotion));
+      }
       if(0){
         printf("\nMatches: mean:  %f | ", meanMatch);
         vs_array_print(matchQualities1, stdout);
@@ -238,7 +244,10 @@ int vsMotionDetection(VSMotionDetect* md, LocalMotions* motions, VSFrame *frame)
         VSArray matchQualities2 = localmotionsGetMatch(&motions2);
         vs_array_print(matchQualities2, stdout);
         printf("\n");
+        vs_array_free(matchQualities2);
       }
+      vs_array_free(matchQualities1);
+      vs_vector_del(&motions2);
     }
     if (md->conf.show) { // draw fields and transforms into frame.
       int num_motions_fine = vs_vector_size(&motionsfine);
@@ -257,6 +266,10 @@ int vsMotionDetection(VSMotionDetect* md, LocalMotions* motions, VSFrame *frame)
         drawFieldTrans(md, LMGet(&motionsfine,i), 64);
     }
     *motions = vs_vector_concat(&motionscoarse,&motionsfine);
+    // the concatenation took over the elements, so only release the
+    //  now unused vector buffers (not the elements themselves)
+    vs_vector_fini(&motionscoarse);
+    vs_vector_fini(&motionsfine);
     //*motions = motionscoarse;
     //*motions = motionsfine;
   } else {

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -475,6 +475,7 @@ int vsReadLocalMotionsFile(FILE* f, VSManyLocalMotions* mlms){
     }
     if(index<1){
       vs_log_info(modname,"VID.STAB file: Frame number < 1 (%i)", index);
+      vs_vector_del(&lms); // the motions are not stored, so release them
     } else {
       vs_vector_set_dup(mlms,index-1,&lms, sizeof(LocalMotions));
     }

--- a/src/transform.c
+++ b/src/transform.c
@@ -301,6 +301,8 @@ int cameraPathGaussian(VSTransformData* td, VSTransformations* trans){
                   );
       }
     }
+    vs_array_free(kernel);
+    vs_free(ts2);
   }
   return VS_OK;
 }


### PR DESCRIPTION
Closes #107.

## Leaks fixed
**`cameraPathGaussian`** (`src/transform.c`) allocated `ts2` via `vs_malloc` and `kernel` via `vs_array_new` and freed neither. Compare `cameraPathAvg`, which does free its `ts2`. This is the **default** camera-path algorithm.

**`vsMotionDetection`** — four leaks that recur **every frame**, so they scale with clip length:
- `matchQualities1` from `localmotionsGetMatch()` was never freed.
- `motionsfine = vs_vector_filter(&motions2, ...)` — `vs_vector_filter` uses `vs_vector_append`, which only *shares* element pointers. So the `motions2` buffer and **every rejected LocalMotion** were orphaned. Replaced with an explicit `vs_vector_append_dup` loop plus `vs_vector_del(&motions2)`.
- After `vs_vector_concat`, added `vs_vector_fini` (buffer only, **not** `_del`) for both source vectors — the concatenation takes over the elements.

**`meanMotions`** and **`vsSimpleMotionsToTransform`** allocated before their early "no motions" return; guards moved above the allocations. **`vsReadLocalMotionsFile`** leaked on the malformed-file path.

## Evidence (valgrind, before → after)
| driver | before | after |
|---|---|---|
| pass 2: 50 transforms through `vsPreprocessTransforms`, both Gaussian and Avg | **2,968 bytes in 2 blocks** | **0 / 0** |
| 4 frames of `vsMotionDetection` | **2,784 definitely + 192 indirectly, 18 blocks** | **0 / 0** |

For scale: `--testMD` on master leaks ~46 MB over its run.

Numeric output is identical before and after in both drivers — same transform values, same motion counts — so this is not a behaviour change. Suite 14/14.

## Suspected, deliberately not fixed
- `vsMotionDetectInit` error paths leave `md->prev` allocated if `initFields` fails — depends on whether callers are expected to call `vsMotionDetectionCleanup` after a failed init, i.e. an API contract question.
- `vsFrameAllocate` leaks earlier planes if a later plane's allocation fails (OOM-only).
- `vs_vector_set_dup` discards the displaced pointer, which leaks only if a `.trf` repeats a frame index.
- Separately noted: `vsMotionDetectInit` reads `md->serializationMode` before the caller has necessarily set it — an uninitialised read, not a leak.
