### PR TITLE
Make detection and transform output deterministic (#111)

### DIFF
--- a/src/localmotion2transform.c
+++ b/src/localmotion2transform.c
@@ -228,7 +228,12 @@ VSArray vsGradientDescent(double (*eval)(VSArray, void*),
   for(int i=0; i< N*dim && v > threshold; i++){
     int k=i%dim;
     VSArray x2 = vs_array_copy(x);
-    double h = rand()%2 ? 1e-6 : -1e-6;
+    /* Alternate the sign of the finite-difference step deterministically.
+       Using rand() here made the result depend on the global RNG state and
+       therefore differ between runs (issue #111). Alternating per sweep over
+       the dimensions preserves the original behaviour of probing from both
+       sides without introducing randomness. */
+    double h = ((i/dim)%2) ? 1e-6 : -1e-6;
     x2.dat[k]+=h;
     double v2 = eval(x2, dat);
     vs_array_zero(&grad);

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -725,27 +725,39 @@ LocalMotions calcTransFields(VSMotionDetect* md,
 #endif
 
   VSVector goodflds = selectfields(md, fields, contrastfunc);
+  int numfields = vs_vector_size(&goodflds);
+  /* Each thread stores its result in its own slot, so that the order of the
+     resulting local motions only depends on the order of goodflds and not on
+     the thread scheduling (issue #111). */
+  LocalMotion* motionbuf = (LocalMotion*)vs_malloc(sizeof(LocalMotion) * (numfields > 0 ? numfields : 1));
+
   // use all "good" fields and calculate optimal match to previous frame
   //MSVC requires the OpenMP loop index to be a signed integer, declared in the same function, and visible if not declared inside the loop.
   int index;
 #ifdef USE_OMP
   omp_set_num_threads(md->conf.numThreads);
-#pragma omp parallel for shared(goodflds, md, localmotions)
+#pragma omp parallel for shared(goodflds, md, motionbuf)
 #endif
-  for(index=0; index < vs_vector_size(&goodflds); index++){
+  for(index=0; index < numfields; index++){
     int i = ((contrast_idx*)vs_vector_get(&goodflds,index))->index;
     LocalMotion m;
     m = fieldfunc(md, fields, &fields->fields[i], i); // e.g. calcFieldTransPlanar
     if(m.match >= 0){
       m.contrast = ((contrast_idx*)vs_vector_get(&goodflds,index))->contrast;
 #ifdef STABVERBOSE
+#pragma omp critical(localmotions_debugout)
       fprintf(file, "%i %i\n%f %f %f %f\n \n\n", m.f.x, m.f.y,
               m.f.x + m.v.x, m.f.y + m.v.y, m.match, m.contrast);
 #endif
-#pragma omp critical(localmotions_append)
-      vs_vector_append_dup(&localmotions, &m, sizeof(LocalMotion));
     }
+    motionbuf[index] = m;
   }
+  /* serially append in field order: deterministic, independent of thread count */
+  for(index=0; index < numfields; index++){
+    if(motionbuf[index].match >= 0)
+      vs_vector_append_dup(&localmotions, &motionbuf[index], sizeof(LocalMotion));
+  }
+  vs_free(motionbuf);
   vs_vector_del(&goodflds);
 
 #ifdef STABVERBOSE

--- a/tests/test_determinism.c
+++ b/tests/test_determinism.c
@@ -1,0 +1,140 @@
+/* Regression test for issue #111: the output of vidstabdetect/vidstabtransform
+   must not depend on the state of the global RNG nor on the number of threads. */
+
+static double determinism_quadratic(VSArray p, void* _dat){
+  double val=0;
+  for(int k=0; k<p.len; k++){
+    val += (k+1)*3*(p.dat[k]-0.3*k)*(p.dat[k]-0.3*k);
+  }
+  return val;
+}
+
+/* run vsGradientDescent on a fixed problem; the RNG is seeded differently
+   before each run, so any use of rand() inside shows up as a difference */
+static VSArray determinism_run_gd(unsigned seed, double* residual){
+  srand(seed);
+  int dim=4;
+  VSArray params = vs_array_new(dim);
+  VSArray stepsizes = vs_array_new(dim);
+  for(int k=0; k<dim; k++){
+    params.dat[k]= 7.0-k;
+    stepsizes.dat[k]= 0.1;
+  }
+  VSArray result = vsGradientDescent(determinism_quadratic, params, NULL, 12,
+                                     stepsizes, 1e-15, residual);
+  vs_array_free(params);
+  return result;
+}
+
+/* the second pass (vidstabtransform) must produce identical transforms
+   for identical local motions, whatever the RNG state is */
+static VSTransform determinism_run_m2t(VSTransformData* td,
+                                      const LocalMotions* lms, unsigned seed){
+  srand(seed);
+  return vsMotionsToTransform(td, lms, 0);
+}
+
+static int determinism_lm_equal(const LocalMotion* a, const LocalMotion* b){
+  return a->v.x==b->v.x && a->v.y==b->v.y
+    && a->f.x==b->f.x && a->f.y==b->f.y
+    && a->f.size==b->f.size
+    && a->contrast==b->contrast && a->match==b->match;
+}
+
+static void determinism_print_lm(const LocalMotion* m, FILE* f){
+  fprintf(f,"LM: field (%i,%i,%i) v (%i,%i) contrast %f match %f\n",
+          m->f.x, m->f.y, m->f.size, m->v.x, m->v.y, m->contrast, m->match);
+}
+
+void test_determinism(TestData* testdata){
+  fprintf(stderr,"********** Determinism Test (issue #111):\n");
+
+  /* --- cause A: the gradient descent must not use randomness --- */
+  double res1, res2;
+  VSArray r1 = determinism_run_gd(1, &res1);
+  VSArray r2 = determinism_run_gd(987654321u, &res2);
+  fprintf(stderr,"gradient descent: residual run1 %lg, run2 %lg\n", res1, res2);
+  test_bool(r1.len == r2.len);
+  int identical=1;
+  for(int k=0; k<r1.len && k<r2.len; k++){
+    if(r1.dat[k] != r2.dat[k]){
+      identical=0;
+      fprintf(stderr,"  param %i differs: %.17g != %.17g\n", k, r1.dat[k], r2.dat[k]);
+    }
+  }
+  if(res1 != res2)
+    fprintf(stderr,"  residual differs: %.17g != %.17g\n", res1, res2);
+  test_bool(identical);
+  test_bool(res1 == res2);
+  vs_array_free(r1);
+  vs_array_free(r2);
+
+  /* --- cause B: the order of the local motions must not depend on threads --- */
+  int threads2=2;
+#ifdef USE_OMP
+  if(omp_get_max_threads() > 2) threads2 = omp_get_max_threads();
+  omp_set_dynamic(1);
+#endif
+  fprintf(stderr,"motion detection with 1 vs %i threads\n", threads2);
+
+  int loglevel=vs_log_level;
+  vs_log_level=0;
+  VSMotionDetectConfig mdconf1 = vsMotionDetectGetDefaultConfig("test_determinism1");
+  VSMotionDetectConfig mdconf2 = vsMotionDetectGetDefaultConfig("test_determinism2");
+  VSMotionDetect md1, md2;
+  test_bool(vsMotionDetectInit(&md1, &mdconf1, &testdata->fi) == VS_OK);
+  test_bool(vsMotionDetectInit(&md2, &mdconf2, &testdata->fi) == VS_OK);
+  md1.conf.numThreads=1;
+  md2.conf.numThreads=threads2;
+  vs_log_level=loglevel;
+
+  VSTransformConfig tdconf = vsTransformGetDefaultConfig("test_determinism-trans");
+  VSTransformData td;
+  test_bool(vsTransformDataInit(&td, &tdconf, &testdata->fi, &testdata->fi) == VS_OK);
+
+  int numruns=3;
+  for(int i=0; i<numruns; i++){
+    LocalMotions lms1, lms2;
+    test_bool(vsMotionDetection(&md1, &lms1, &testdata->frames[i]) == VS_OK);
+    test_bool(vsMotionDetection(&md2, &lms2, &testdata->frames[i]) == VS_OK);
+
+    int n1=vs_vector_size(&lms1);
+    int n2=vs_vector_size(&lms2);
+    if(n1!=n2)
+      fprintf(stderr,"  frame %i: different number of motions %i != %i\n", i, n1, n2);
+    test_bool(n1==n2);
+    int sameorder=1;
+    for(int k=0; k<n1 && k<n2; k++){
+      if(!determinism_lm_equal(LMGet(&lms1,k), LMGet(&lms2,k))){
+        if(sameorder){ /* report only the first difference */
+          fprintf(stderr,"  frame %i: motion %i differs (order depends on threads):\n    ",i,k);
+          determinism_print_lm(LMGet(&lms1,k),stderr);
+          fprintf(stderr,"    ");
+          determinism_print_lm(LMGet(&lms2,k),stderr);
+        }
+        sameorder=0;
+      }
+    }
+    test_bool(sameorder);
+
+    /* and the resulting transform must be bit-identical, too */
+    VSTransform t1 = determinism_run_m2t(&td, &lms1, 4711);
+    VSTransform t2 = determinism_run_m2t(&td, &lms2, 42);
+    int samet = t1.x==t2.x && t1.y==t2.y && t1.alpha==t2.alpha
+      && t1.zoom==t2.zoom && t1.extra==t2.extra;
+    if(!samet){
+      fprintf(stderr,"  frame %i: transforms differ:\n    ",i);
+      storeVSTransform(stderr,&t1);
+      fprintf(stderr,"    ");
+      storeVSTransform(stderr,&t2);
+    }
+    test_bool(samet);
+
+    vs_vector_del(&lms1);
+    vs_vector_del(&lms2);
+  }
+
+  vsMotionDetectionCleanup(&md1);
+  vsMotionDetectionCleanup(&md2);
+  fprintf(stderr,"*** determinism test done ***\n");
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -39,6 +39,7 @@
 #include "test_omp.c"
 #include "test_gradientoptimizer.c"
 #include "test_localmotion2transform.c"
+#include "test_determinism.c"
 
 #define FRAMENUM 5
 
@@ -131,6 +132,10 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testGO", "gradient optimizer")){
     UNIT(test_gradientoptimizer());
+  }
+
+  if(all || contains(argv,argc,"--testDET", "deterministic output")){
+    UNIT(test_determinism(&testdata));
   }
 
   // free


### PR DESCRIPTION
Closes #111.

Two independent causes. The thread found the first; the second is what actually explained the reporter's real complaint.

## Cause A — `rand()` in `vsGradientDescent`
`src/localmotion2transform.c` used `double h = rand()%2 ? 1e-6 : -1e-6;` to sign the finite-difference step, so the fit landed on slightly different parameters every run. **This is why pass 2 produced different video even when given a byte-identical `.trf`** — the part nobody in the issue could explain. Now alternates deterministically per sweep over the dimensions, preserving the original intent of probing from both sides.

No quality regression — `--testGO` residuals are **strictly better in all 10 dimensions**, worst case improving from 3.7e-12 to 8.3e-16:

| dim | before | after |
|---|---|---|
| 1D | 1.73e-13 | 6.06e-17 |
| 4D | 4.62e-13 | 6.03e-16 |
| 6D | 3.72e-12 | 4.32e-16 |
| 10D | 1.90e-13 | 8.34e-16 |

Fitted transforms move only at the 1e-6 level, well inside `--testLM`'s tolerance.

## Cause B — OpenMP append order
`calcTransFields` appended under `#pragma omp critical`, so local-motion order in the `.trf` followed thread scheduling. Each iteration now writes into its own slot and a short serial pass appends in field order. The parallel loop itself is untouched — `--testMD` speedup curve is unchanged (1 thread 480 ms → 12 threads 156 ms, 3.08x).

## Tests
New `--testDET`, covering both causes: identical results under different RNG seeds, and identical count/order/values with 1 vs 12 threads. It fails reproducibly before the fix (4 failed checks per run, e.g. first motion field `(415,148,80)` vs `(415,466,80)`).

End-to-end check: detection output is byte-identical across 1/2/4/8 threads. Suite 14/14 → 15/15.
