### PR TITLE
Validate frame dimensions at runtime, and allow odd sizes where they are valid (#43)

### DIFF
--- a/src/frameinfo.c
+++ b/src/frameinfo.c
@@ -35,7 +35,6 @@ int vsFrameInfoInit(VSFrameInfo* fi, int width, int height, VSPixelFormat pForma
   fi->log2ChromaW = 0;
   fi->log2ChromaH = 0;
   fi->bytesPerPixel=1;
-  assert(width%2==0 && height%2==0);
   switch(pFormat){
    case PF_GRAY8:
     fi->planes=1;
@@ -77,6 +76,32 @@ int vsFrameInfoInit(VSFrameInfo* fi, int width, int height, VSPixelFormat pForma
     fi->planes = 0;
     break;
    default:
+    fi->pFormat=0;
+    return 0;
+  }
+  /* Runtime validation (an assert() would be compiled away by -DNDEBUG in
+     release builds, letting bad dimensions through into the chroma plane
+     arithmetic and off the end of the allocation).
+
+     Only dimensions that are genuinely incompatible with the format's
+     chroma subsampling are rejected: vsFrameAllocate() sizes the chroma
+     planes with a truncating shift (width >> log2ChromaW) while the
+     transform code uses CHROMA_SIZE() which rounds up, so the two only
+     agree when the dimension is a multiple of the subsampling factor.
+     Formats without subsampling (PF_GRAY8, PF_YUV444P, the packed RGB
+     formats) impose no restriction at all, and e.g. PF_YUV422P only
+     constrains the width. */
+  if(width<=0 || height<=0){
+    vs_log_error("vid.stab","invalid frame dimensions %ix%i: "
+                 "width and height must be positive\n", width, height);
+    fi->pFormat=0;
+    return 0;
+  }
+  if(width % (1<<fi->log2ChromaW) != 0 || height % (1<<fi->log2ChromaH) != 0){
+    vs_log_error("vid.stab","invalid frame dimensions %ix%i for pixel format %i: "
+                 "width must be a multiple of %i and height a multiple of %i "
+                 "for this chroma subsampling\n", width, height, (int)pFormat,
+                 1<<fi->log2ChromaW, 1<<fi->log2ChromaH);
     fi->pFormat=0;
     return 0;
   }

--- a/src/frameinfo.h
+++ b/src/frameinfo.h
@@ -67,7 +67,18 @@ typedef struct VS_API vsframe {
 // use it to calculate the CHROMA sizes (rounding is correct)
 #define CHROMA_SIZE(width,log2sub)  (-(-(width) >> (log2sub)))
 
-/// initializes the frameinfo for the given format
+/** initializes the frameinfo for the given format.
+
+    The dimensions must be compatible with the chroma subsampling of the
+    requested format, i.e. width must be a multiple of 1<<log2ChromaW and
+    height a multiple of 1<<log2ChromaH. Formats without subsampling
+    (PF_GRAY8, PF_YUV444P and the packed formats) accept any positive size,
+    so odd widths/heights are fine for those.
+
+    @return non-zero (1) on success, 0 if the pixel format is unknown or the
+            dimensions are invalid for it. Note the boolean convention: this
+            is *not* VS_OK/VS_ERROR.
+ */
 VS_API int vsFrameInfoInit(VSFrameInfo* fi, int width, int height, VSPixelFormat pFormat);
 
 

--- a/tests/test_frameinfo.c
+++ b/tests/test_frameinfo.c
@@ -1,0 +1,90 @@
+/* Regression test for issue #43 ("Cannot stabilize video with odd height").
+
+   vsFrameInfoInit() used to guard the even-dimension requirement with a plain
+   assert(), which -DNDEBUG (i.e. any Release build) compiles away. Odd
+   dimensions then silently proceeded and the chroma plane arithmetic walked
+   off the end of the allocation made by vsFrameAllocate().
+
+   Note: vsFrameInfoInit() uses a boolean return convention -- non-zero means
+   success, 0 means failure -- not VS_OK/VS_ERROR. Downstream callers (e.g.
+   ffmpeg's vf_vidstabtransform.c) test it with `if(!vsFrameInfoInit(...))`.
+*/
+
+// writes to every byte of every plane, so ASAN/valgrind catch undersized
+// allocations, and checks the plane geometry against the expectation
+static void checkFrameUsable(VSFrameInfo* fi, int expectedChromaW, int expectedChromaH){
+  VSFrame frame;
+  int plane;
+  test_bool(fi->log2ChromaW == expectedChromaW);
+  test_bool(fi->log2ChromaH == expectedChromaH);
+  vsFrameAllocate(&frame, fi);
+  test_bool(!vsFrameIsNull(&frame));
+  for(plane=0; plane < fi->planes; plane++){
+    int w = fi->width  >> vsGetPlaneWidthSubS(fi, plane);
+    int h = fi->height >> vsGetPlaneHeightSubS(fi, plane);
+    // the truncating shift used for allocation must agree with the rounding-up
+    // CHROMA_SIZE() macro that the transform code uses, otherwise the
+    // transform writes past the end of this buffer
+    test_bool(w == CHROMA_SIZE(fi->width,  vsGetPlaneWidthSubS(fi, plane)));
+    test_bool(h == CHROMA_SIZE(fi->height, vsGetPlaneHeightSubS(fi, plane)));
+    test_bool(frame.linesize[plane] == w);
+    test_bool(frame.data[plane] != 0);
+    memset(frame.data[plane], 0x7f, (size_t)w * (size_t)h);
+  }
+  vsFrameFree(&frame);
+}
+
+void test_frameinfo(void){
+  VSFrameInfo fi;
+
+  fprintf(stderr,"********** frameinfo dimension validation:\n");
+
+  fprintf(stderr,"* subsampled formats must reject incompatible dimensions\n");
+  // this is issue #43: odd height with 4:2:0
+  test_bool(vsFrameInfoInit(&fi, 640, 481, PF_YUV420P) == 0);
+  test_bool(vsFrameInfoInit(&fi, 641, 480, PF_YUV420P) == 0);
+  test_bool(vsFrameInfoInit(&fi, 641, 481, PF_YUV420P) == 0);
+  test_bool(vsFrameInfoInit(&fi, 641, 480, PF_YUVA420P) == 0);
+  // 4:2:2 subsamples horizontally only -> odd width is invalid
+  test_bool(vsFrameInfoInit(&fi, 641, 480, PF_YUV422P) == 0);
+  // 4:4:0 subsamples vertically only -> odd height is invalid
+  test_bool(vsFrameInfoInit(&fi, 640, 481, PF_YUV440P) == 0);
+  // 4:1:0 / 4:1:1 need multiples of 4
+  test_bool(vsFrameInfoInit(&fi, 642, 480, PF_YUV410P) == 0);
+  test_bool(vsFrameInfoInit(&fi, 642, 480, PF_YUV411P) == 0);
+
+  fprintf(stderr,"* non-positive dimensions are rejected\n");
+  test_bool(vsFrameInfoInit(&fi, 0, 480, PF_YUV420P) == 0);
+  test_bool(vsFrameInfoInit(&fi, 640, -2, PF_YUV420P) == 0);
+  test_bool(vsFrameInfoInit(&fi, 640, 480, PF_NONE) == 0);
+
+  fprintf(stderr,"* formats without subsampling accept odd dimensions\n");
+  test_bool(vsFrameInfoInit(&fi, 641, 481, PF_GRAY8) != 0);
+  test_bool(fi.planes == 1);
+  checkFrameUsable(&fi, 0, 0);
+
+  test_bool(vsFrameInfoInit(&fi, 641, 481, PF_YUV444P) != 0);
+  test_bool(fi.planes == 3);
+  checkFrameUsable(&fi, 0, 0);
+
+  fprintf(stderr,"* partially subsampled formats accept the free dimension odd\n");
+  // 4:2:2 does not subsample vertically -> odd height is fine
+  test_bool(vsFrameInfoInit(&fi, 640, 481, PF_YUV422P) != 0);
+  checkFrameUsable(&fi, 1, 0);
+  // 4:4:0 does not subsample horizontally -> odd width is fine
+  test_bool(vsFrameInfoInit(&fi, 641, 480, PF_YUV440P) != 0);
+  checkFrameUsable(&fi, 0, 1);
+  // 4:1:1 does not subsample vertically -> odd height is fine
+  test_bool(vsFrameInfoInit(&fi, 640, 481, PF_YUV411P) != 0);
+  checkFrameUsable(&fi, 2, 0);
+
+  fprintf(stderr,"* the usual even sizes keep working\n");
+  test_bool(vsFrameInfoInit(&fi, 1280, 720, PF_YUV420P) != 0);
+  test_bool(fi.planes == 3);
+  checkFrameUsable(&fi, 1, 1);
+  test_bool(vsFrameInfoInit(&fi, 640, 480, PF_YUV410P) != 0);
+  checkFrameUsable(&fi, 2, 2);
+  test_bool(vsFrameInfoInit(&fi, 1280, 720, PF_YUVA420P) != 0);
+  test_bool(fi.planes == 4);
+  checkFrameUsable(&fi, 1, 1);
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -30,6 +30,7 @@
 
 #include "generate.c"
 
+#include "test_frameinfo.c"
 #include "test_transform.c"
 #include "test_compareimg.c"
 #include "test_motiondetect.c"
@@ -90,6 +91,10 @@ int main(int argc, char** argv){
     UNIT(openmp());
   }
 #endif
+
+  if(all || contains(argv,argc,"--testFI", "frameinfo dimension validation")){
+    UNIT(test_frameinfo());
+  }
 
   if(all || contains(argv,argc,"--testTI", "transform_implementation")){
     UNIT(test_transform_implementation(&testdata));

--- a/transcode/filter_deshake.c
+++ b/transcode/filter_deshake.c
@@ -184,8 +184,12 @@ static int deshake_configure(TCModuleInstance *self,
 
   // init VSMotionDetect part
   VSFrameInfo fi;
-  vsFrameInfoInit(&fi, sd->vob->ex_v_width, sd->vob->ex_v_height,
-                transcode2ourPF(sd->vob->im_v_codec));
+  if (!vsFrameInfoInit(&fi, sd->vob->ex_v_width, sd->vob->ex_v_height,
+                       transcode2ourPF(sd->vob->im_v_codec))) {
+    tc_log_error(MOD_NAME, "unsupported pixel format or frame size %ix%i",
+                 sd->vob->ex_v_width, sd->vob->ex_v_height);
+    return TC_ERROR;
+  }
 
   VSMotionDetectConfig  mdconf = vsMotionDetectGetDefaultConfig(MOD_NAME);
   VSTransformConfig tdconf     = vsTransformGetDefaultConfig(MOD_NAME);
@@ -204,8 +208,12 @@ static int deshake_configure(TCModuleInstance *self,
 
   // init trasform part
   VSFrameInfo fi_dest;
-  vsFrameInfoInit(&fi_dest, sd->vob->ex_v_width, sd->vob->ex_v_height,
-                transcode2ourPF(sd->vob->im_v_codec));
+  if (!vsFrameInfoInit(&fi_dest, sd->vob->ex_v_width, sd->vob->ex_v_height,
+                       transcode2ourPF(sd->vob->im_v_codec))) {
+    tc_log_error(MOD_NAME, "unsupported pixel format or frame size %ix%i",
+                 sd->vob->ex_v_width, sd->vob->ex_v_height);
+    return TC_ERROR;
+  }
 
   if (options != NULL) {
     // for some reason this plugin is called in the old fashion

--- a/transcode/filter_stabilize.c
+++ b/transcode/filter_stabilize.c
@@ -149,8 +149,12 @@ static int stabilize_configure(TCModuleInstance *self,
 
     VSMotionDetect* md = &(sd->md);
     VSFrameInfo fi;
-    vsFrameInfoInit(&fi, sd->vob->ex_v_width, sd->vob->ex_v_height,
-                  transcode2ourPF(vob->im_v_codec));
+    if (!vsFrameInfoInit(&fi, sd->vob->ex_v_width, sd->vob->ex_v_height,
+                         transcode2ourPF(vob->im_v_codec))) {
+        tc_log_error(MOD_NAME, "unsupported pixel format or frame size %ix%i",
+                     sd->vob->ex_v_width, sd->vob->ex_v_height);
+        return TC_ERROR;
+    }
 
     VSMotionDetectConfig conf = vsMotionDetectGetDefaultConfig(MOD_NAME);
 

--- a/transcode/filter_transform.c
+++ b/transcode/filter_transform.c
@@ -109,10 +109,14 @@ static int transform_configure(TCModuleInstance *self,
 
     VSFrameInfo fi_src;
     VSFrameInfo fi_dest;
-    vsFrameInfoInit(&fi_src, fd->vob->ex_v_width, fd->vob->ex_v_height,
-                  transcode2ourPF(fd->vob->im_v_codec));
-    vsFrameInfoInit(&fi_dest, fd->vob->ex_v_width, fd->vob->ex_v_height,
-                  transcode2ourPF(fd->vob->im_v_codec));
+    if (!vsFrameInfoInit(&fi_src, fd->vob->ex_v_width, fd->vob->ex_v_height,
+                         transcode2ourPF(fd->vob->im_v_codec)) ||
+        !vsFrameInfoInit(&fi_dest, fd->vob->ex_v_width, fd->vob->ex_v_height,
+                         transcode2ourPF(fd->vob->im_v_codec))) {
+        tc_log_error(MOD_NAME, "unsupported pixel format or frame size %ix%i",
+                     fd->vob->ex_v_width, fd->vob->ex_v_height);
+        return TC_ERROR;
+    }
 
     VSTransformConfig conf = vsTransformGetDefaultConfig(MOD_NAME);
     conf.verbose = verbose;


### PR DESCRIPTION
Closes #43.

## The defect
`vsFrameInfoInit` enforced even dimensions with `assert(width%2==0 && height%2==0)`. Release builds define `NDEBUG`, so **the assert compiles away entirely** — odd input then proceeded into the chroma arithmetic and off the end of the allocation. So in a release build odd dimensions were a potential out-of-bounds access, not a clean error.

## Which dimensions are actually invalid
Not "odd". The real hazard is a mismatch between two size computations: `vsFrameAllocate` sizes chroma planes with a **truncating** shift (`width >> log2ChromaW`), while the transform code uses **rounding-up** `CHROMA_SIZE()`. They agree exactly when the dimension is a multiple of the subsampling factor. So the correct predicate is per-format:

| format | constraint |
|---|---|
| GRAY8, YUV444P, RGB24/BGR24/RGBA | **none** — odd sizes fine |
| YUV422P | width even only — **odd height fine** |
| YUV440P | height even only — **odd width fine** |
| YUV411P | width multiple of 4 — **odd height fine** |
| YUV420P, YUVA420P | both even |
| YUV410P | both multiples of 4 |

The blanket even-check was over-restrictive for 6 of 11 formats. This therefore **partly grants the request in the issue**: odd height now works outright for 4:2:2 (a common intermediate format), and for grayscale and 4:4:4. Also added a `width<=0 || height<=0` guard.

## Return convention — please note
`vsFrameInfoInit` does **not** use `VS_OK`/`VS_ERROR`. It returns **1 on success, 0 on failure**, while `VS_OK == 0` and `VS_ERROR == -1`. FFmpeg checks it as a boolean:
```c
if (!vsFrameInfoInit(&fi_src, ...) || !vsFrameInfoInit(&fi_dest, ...)) {
```
so returning `VS_ERROR` (-1, truthy) would be silently swallowed, and returning `VS_OK` (0) on success would make every FFmpeg init fail. The boolean convention is preserved and now documented in the header.

## Caller audit
`transcode/*` ignored the return at 4 call sites — now handled (compile-unverified, those plugins need external transcode headers). FFmpeg's `vf_vidstabtransform.c` checks correctly and will now cleanly reject bad geometry; **`vf_vidstabdetect.c` does not check it** and inspects `fi.bytesPerPixel` afterwards, so it may want a matching upstream patch.

## Tests
New `--testFI`. Built with `-DNDEBUG` against unmodified sources it fails 10 checks — all of them the rejection cases — confirming the assert was fully compiled out. 139/139 after. Suite 14/14 → 15/15, in both Debug and `-DNDEBUG` builds.
