### PR TITLE
serialize: document the binary-mode contract and report truncation clearly

### DIFF
--- a/ISSUE-104-ANALYSIS.md
+++ b/ISSUE-104-ANALYSIS.md
@@ -1,0 +1,237 @@
+# Issue #104 "Windows Builds: Cannot parse localmotion!" - diagnosis
+
+**Short version:** FFmpeg's vidstab filters open the `.trf` transform file with
+`fopen(..., "w")` / `fopen(..., "r")` - i.e. in **text mode** - but since
+vid.stab 1.1.x the default transform file format is **binary**. On Windows,
+MSVCRT/UCRT stop reading a text-mode stream at the first `0x1A` (Ctrl-Z) byte,
+which it interprets as end-of-file. A binary `.trf` contains such a byte roughly
+every 700 bytes, so the file is silently truncated a few frames in and the
+second pass fails with a flood of `Cannot parse localmotion!`. On Linux/macOS
+text and binary mode are identical, which is why the very same command works
+there.
+
+The fix belongs in **FFmpeg** (two characters); vid.stab can only improve the
+diagnostics and document the contract, which this branch does.
+
+## 1. Why FFmpeg users always get the binary format
+
+`libavfilter/vf_vidstabdetect.c` contains no reference to `serializationMode`.
+Its private context is allocated zeroed by FFmpeg, so `md->serializationMode == 0`
+when `vsMotionDetectInit()` runs, and `src/motiondetect.c` then does:
+
+```c
+if(md->serializationMode != ASCII_SERIALIZATION_MODE &&
+   md->serializationMode != BINARY_SERIALIZATION_MODE)
+  md->serializationMode = BINARY_SERIALIZATION_MODE;
+```
+
+So **every** FFmpeg user gets the binary format and there is no filter option to
+choose ASCII (which is why the `fileformat=1` workaround mentioned in the thread
+only works for callers other than FFmpeg's own filters; FFmpeg's `vidstabdetect`
+has no such option).
+
+Side note (separate contract/UB nit): `vsMotionDetectInit()` *reads* the public
+field `md->serializationMode` before it is initialised. The caller is nowhere
+told that it must set this field before calling init, and for a caller that does
+not zero the struct this is indeterminate. The intended contract ("set
+`md.serializationMode` before `vsMotionDetectInit`") should be documented, or the
+field should move into `VSMotionDetectConfig` where all other user-settable
+values live.
+
+## 2. The two FFmpeg lines that cause the bug
+
+```
+libavfilter/vf_vidstabdetect.c:145    sd->f = fopen(sd->result, "w");
+libavfilter/vf_vidstabtransform.c:211 f = fopen(tc->input, "r");
+```
+
+No `b` in the mode string. On POSIX that is harmless. On Windows, per
+Microsoft's `fopen` documentation, a text-mode stream
+
+* expands `0x0A` to `0x0D 0x0A` when writing and collapses `0x0D 0x0A` to `0x0A`
+  when reading, and
+* **treats `0x1A` (Ctrl-Z) as end-of-file when reading**.
+
+Note that the CRLF translation alone is *not* the problem: write-then-read is a
+symmetric round trip, so CRLF cannot corrupt the data (a frequent misdiagnosis).
+The lossy, asymmetric part is the Ctrl-Z-as-EOF rule.
+
+Whether a MinGW/MSYS2 build actually ends up in text mode also depends on the
+CRT and on the startup default for `_fmode`, which plausibly explains why some
+Windows builds in the thread reproduce the bug and others do not.
+
+## 3. Empirical proof (on Linux, by emulating MSVCRT text-mode semantics)
+
+Driver: generate 300 frames x 100 local motions with realistic values (field
+grid coordinates, small motion vectors, `contrast`/`match` in [0,1]), write with
+`vsPrepareFile`/`vsWriteToFile` in binary mode, read back with
+`vsReadLocalMotionsFile`.
+
+```
+=== 1. write binary .trf (300 frames x 100 local motions) ===
+  file size 782424 bytes; 0x1A count = 1167 (first at offset 2524);
+                          0x0A count = 3976; 0x0D count = 1139
+=== 2. plain binary read-back (Linux, fopen "rb") ===
+  -> vsReadLocalMotionsFile = VS_OK, frames restored = 300      # fine
+=== 3. emulate MSVCRT TEXT-mode READ: truncate at first 0x1A (Ctrl-Z = EOF) ===
+  truncated to 2524 of 782424 bytes (0.32%)
+  -> vsReadLocalMotionsFile = VS_OK, frames restored = 1
+     [with the code as of master: "Cannot parse localmotion!" x 5, then
+      nothing else, and stabilisation continues with garbage]
+=== 4. emulate text-mode WRITE (LF->CRLF) then BINARY read ===
+  expanded 782424 -> 786400 bytes
+  -> "Cannot parse localmotion!" x 16,641,545   # does NOT match the reports
+=== 5. emulate FULL MSVCRT round trip (text write + text read) ===
+  disk bytes 786400, text-read yields 2524 logical bytes (of 782424 written)
+  -> byte-identical to the stage-3 file; frames restored = 1
+```
+
+Conclusions:
+
+* **Stage 3/5 reproduce the reported failure exactly**: N repetitions of
+  `Cannot parse localmotion!` and then *no further error message*, followed by
+  the transform pass running on almost no data ("not enough transforms found,
+  use last transformation!", nonsense final zoom). The absence of a follow-up
+  message is a distinguishing detail: the old `vsRestoreLocalmotionsBinary()`
+  appended a `null_localmotion()` for every failed record, so the
+  `len != vs_vector_size` check never fired, and the next `readInt32(frameNum)`
+  hit EOF and ended the loop quietly. N equals the number of local motions left
+  in the frame where truncation happened - matching the arbitrary counts in the
+  reports (132, 236, 256, ...).
+* **Stage 5 is byte-identical to stage 3**, confirming that CRLF translation is a
+  perfect involution and that Ctrl-Z truncation is the whole mechanism.
+* **Stage 4** (mixed toolchain: text-mode write, binary read - what you get when
+  a `.trf` is moved between systems) produces millions of messages, i.e. it is a
+  real corruption too, but it is *not* what the reporters saw.
+
+### How likely is a `0x1A` byte? Effectively certain.
+
+In the 782,424-byte file above there are **1167** `0x1A` bytes (0.149% of all
+bytes), and the first one appears at offset 2524, i.e. inside the *second*
+frame. Provenance:
+
+```
+total = 1167   in frameNum/len int32s = 2
+               in the five int16 fields = 0
+               in the contrast/match doubles = 1165
+```
+
+The `double` mantissas are effectively random bytes, so with 16 double-bytes per
+local motion, `P(no 0x1A anywhere)` for any file with more than a couple of
+hundred local motions is indistinguishable from zero. Every real video is
+affected, and truncation happens within the first frames - consistent with
+"output identical to input".
+
+## 4. Where the fix belongs
+
+### FFmpeg (the actual bug) - one character per line
+
+```diff
+--- a/libavfilter/vf_vidstabdetect.c
++++ b/libavfilter/vf_vidstabdetect.c
+-    sd->f = fopen(sd->result, "w");
++    sd->f = fopen(sd->result, "wb");
+--- a/libavfilter/vf_vidstabtransform.c
++++ b/libavfilter/vf_vidstabtransform.c
+-    f = fopen(tc->input, "r");
++    f = fopen(tc->input, "rb");
+```
+
+(Even better inside libavfilter: `avpriv_fopen_utf8(path, "wb"/"rb")`, which
+additionally fixes non-ASCII paths on Windows.)
+
+This is safe for the ASCII format as well - with the vid.stab change in §5.3,
+legacy ASCII `.trf` files with CRLF line endings still parse from a binary
+handle.
+
+### vid.stab cannot fix this unilaterally
+
+The library only ever receives a `FILE*`; it cannot change the mode of a stream
+it did not open (`_setmode()` on a stdio stream is Windows-specific and would
+require the fd, and vid.stab is not the owner of the handle). What vid.stab
+*can* do is documented below.
+
+## 5. Changes made in vid.stab on this branch
+
+1. **`src/serialize.h`**: documented the contract - all `FILE*` passed to the
+   serialization API must be opened in **binary** mode (`"wb"`/`"rb"`) - with a
+   short explanation of the Ctrl-Z and CRLF failure modes. *Recommended: yes.*
+   This is the one thing that would have prevented the bug.
+2. **`src/serialize.c` - honest, non-repeating errors.** The binary reader now
+   distinguishes truncation from a malformed record and reports it once per
+   frame instead of once per record:
+
+   ```
+   Cannot parse localmotion: unexpected end of file. The transform file is
+   truncated or corrupt. Make sure it is written and read through a file handle
+   opened in *binary* mode (fopen(..., "wb") / fopen(..., "rb")).
+   Cannot parse the given number of localmotions (got 95 of 100)!
+   ```
+
+   It also stops filling the list with `null_localmotion()` placeholders after a
+   failed read (those placeholders were fed into the stabilisation as if they
+   were measurements) and rejects an implausible list length
+   (`> 1<<20`) instead of allocating it and emitting millions of errors. In
+   stage 4 above this reduces 16.6 million log lines to a single actionable one.
+   *Recommended: yes* - purely diagnostic, no format change.
+3. **`src/serialize.c` - ASCII reader tolerates `\r`/`\t`** between records, so
+   that ASCII `.trf` files written through a Windows text-mode handle remain
+   readable once callers switch to `"rb"`. *Recommended: yes* - required for the
+   FFmpeg patch above to be fully backward compatible.
+4. **Test** `tests/test_serialize_robust.c` (`./tests --testSRO`, also part of
+   `--all`): binary round trip; truncation at the first `0x1A` must not invent
+   localmotions; corrupt list length must be rejected; ASCII file with CRLF must
+   parse. Suite: **15/15 units pass** (14/14 before, +1 new unit).
+
+### Not changed: the default serialization mode
+
+Should `serializationMode == 0` still default to BINARY? Arguments:
+
+* *For switching the default to ASCII:* the reader auto-detects the format
+  (`vsGuessSerializationMode`), so ASCII output is fully backward/forward
+  compatible, and it is immune to text-mode handles. Flipping this default would
+  fix every FFmpeg build in the wild without an FFmpeg release - the pragmatic
+  escape hatch if the FFmpeg patch takes a long time to reach users.
+* *Against:* it silently reverts the ~40% file-size win the binary format was
+  introduced for, and it papers over a caller bug that is trivially fixable.
+
+Recommendation: keep BINARY as the default, land the FFmpeg two-character fix,
+and expose `fileformat` as a `vidstabdetect` filter option in FFmpeg so users
+have a documented workaround. If the maintainers prefer a zero-coordination fix,
+flipping the default to ASCII is defensible and safe - it is a one-line change in
+`vsMotionDetectInit()`.
+
+## 6. Loose ends / honest caveats
+
+* This mechanism explains the **Windows** reports (the subject of the issue) and
+  is proven by emulation, not by running on Windows (no Windows host available
+  here). The one prediction to verify on Windows: with the two-character FFmpeg
+  patch the second pass succeeds; without it, `transforms.trf` written by
+  `vidstabdetect` is larger on Windows than on Linux by exactly the number of
+  `0x0A` bytes in the payload (~0.5%), which is itself a cheap smoking-gun test.
+* It does **not** explain the macOS and Linux-static-build comments in the same
+  thread (`fopen` has no text mode there). Those are a different (or a stale
+  `.trf`) problem; note that one reporter later retracted, and that a genuine
+  cross-platform asymmetry did exist before June 2022: the reader used
+  `fscanf(f, "TRF%hhu\n", &version)` while the writer wrote no newline, so the
+  trailing whitespace directive ate one payload byte whenever the low byte of
+  `accuracy` was whitespace. Measured on the header layout:
+
+  ```
+  accuracy = 1..8, 14, 15  -> stream position 4 (correct)
+  accuracy = 9,10,11,12,13 -> stream position 5  <== STREAM SHIFTED, file unreadable
+  ```
+
+  That affected every platform and matches "works with accuracy=10, breaks
+  everything downstream"; it was fixed by commit 1fe9f83 (June 2022). Anyone
+  still reporting the error on a non-Windows platform should confirm they are
+  running vid.stab with that fix.
+* `vsGuessSerializationMode()` uses `ftell`/`fgetc`x3/`fseek`. In text mode this
+  happens to be safe because it is only ever called at offset 0 and seeks back
+  to a value returned by `ftell` (the only thing MSVCRT guarantees in text
+  mode). No change needed.
+* `vsReadFileVersionBinary()` compares `fscanf(...)` against
+  `LIBVIDSTAB_FILE_FORMAT_VERSION`, i.e. it compares a conversion *count* with a
+  version *number*. It works only because both happen to be 1; it should be
+  `!= 1` (or the version should be checked separately). Cosmetic today, a trap
+  for format version 2. Left untouched deliberately.

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -82,6 +82,14 @@ static double byteSwapDouble(double v)
 
 const char* modname = "vid.stab - serialization";
 
+/*
+ * sanity limit for the number of localmotions of a single frame in the binary
+ * format. Even 8k material with the smallest measurement fields stays far
+ * below this; a larger value means the file is corrupt and we must not try to
+ * allocate/parse it (which would also flood the log with parse errors).
+ */
+#define VS_MAX_LOCALMOTIONS_PER_FRAME (1<<20)
+
 int vsPrepareFileText(const VSMotionDetect* md, FILE* f);
 int vsPrepareFileBinary(const VSMotionDetect* md, FILE* f);
 int vsWriteToFileText(const VSMotionDetect* md, FILE* f, const LocalMotions* lms);
@@ -93,7 +101,7 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm);
 LocalMotions vsRestoreLocalmotionsText(FILE* f);
 LocalMotions vsRestoreLocalmotionsBinary(FILE* f);
 LocalMotion restoreLocalmotionText(FILE* f);
-LocalMotion restoreLocalmotionBinary(FILE* f);
+int restoreLocalmotionBinary(FILE* f, LocalMotion* lm);
 int vsReadFileVersionText(FILE* f);
 int vsReadFileVersionBinary(FILE* f);
 int vsReadFromFileText(FILE* f, LocalMotions* lms);
@@ -171,10 +179,33 @@ int storeLocalmotionBinary(FILE* f, const LocalMotion* lm) {
   return 1;
 }
 
+/*
+ * logs why reading a binary record failed. A truncated file is by far the most
+ * common cause: a FILE* that was opened in text mode (missing "b" in the fopen
+ * mode string) makes MSVCRT stop reading at the first 0x1A (Ctrl-Z) byte, and
+ * such bytes occur in nearly every binary transform file. See issue #104.
+ */
+static void logBinaryReadError(FILE* f, const char* what){
+  if(f && feof(f)){
+    vs_log_error(modname, "Cannot parse %s: unexpected end of file. The "
+                 "transform file is truncated or corrupt. Make sure it is "
+                 "written and read through a file handle opened in *binary* "
+                 "mode (fopen(..., \"wb\") / fopen(..., \"rb\")).\n", what);
+  } else {
+    vs_log_error(modname, "Cannot parse %s: read error or malformed record!\n",
+                 what);
+  }
+}
+
 /// restore local motion from file
 LocalMotion restoreLocalmotion(FILE* f, const int serializationMode){
   if(serializationMode == BINARY_SERIALIZATION_MODE) {
-    return restoreLocalmotionBinary(f);
+    LocalMotion lm;
+    if(!restoreLocalmotionBinary(f, &lm)){
+      logBinaryReadError(f, "localmotion");
+      return null_localmotion();
+    }
+    return lm;
   } else {
     return restoreLocalmotionText(f);
   }
@@ -196,22 +227,16 @@ LocalMotion restoreLocalmotionText(FILE* f){
   return lm;
 }
 
-LocalMotion restoreLocalmotionBinary(FILE* f){
-  LocalMotion lm;
-
-  if (readInt16(&lm.v.x, f)<=0) goto parse_error_handling;
-  if (readInt16(&lm.v.y, f)<=0) goto parse_error_handling;
-  if (readInt16(&lm.f.x, f)<=0) goto parse_error_handling;
-  if (readInt16(&lm.f.y, f)<=0) goto parse_error_handling;
-  if (readInt16(&lm.f.size, f)<=0) goto parse_error_handling;
-  if (readDouble(&lm.contrast, f)<=0) goto parse_error_handling;
-  if (readDouble(&lm.match, f)<=0) goto parse_error_handling;
-
-  return lm;
-
-parse_error_handling:
-  vs_log_error(modname, "Cannot parse localmotion!\n");
-  return null_localmotion();
+/// reads one binary localmotion record, returns 1 on success and 0 on failure
+int restoreLocalmotionBinary(FILE* f, LocalMotion* lm){
+  if (readInt16(&lm->v.x, f)<=0) return 0;
+  if (readInt16(&lm->v.y, f)<=0) return 0;
+  if (readInt16(&lm->f.x, f)<=0) return 0;
+  if (readInt16(&lm->f.y, f)<=0) return 0;
+  if (readInt16(&lm->f.size, f)<=0) return 0;
+  if (readDouble(&lm->contrast, f)<=0) return 0;
+  if (readDouble(&lm->match, f)<=0) return 0;
+  return 1;
 }
 
 int vsStoreLocalmotions(FILE* f, const LocalMotions* lms, const int serializationMode){
@@ -289,18 +314,30 @@ LocalMotions vsRestoreLocalmotionsBinary(FILE* f){
   int len;
   vs_vector_init(&lms,0);
   if(readInt32(&len, f) <= 0) {
-    vs_log_error(modname, "Cannot parse localmotions list!\n");
+    logBinaryReadError(f, "localmotions list");
+    return lms;
+  }
+  if (len<0 || len>VS_MAX_LOCALMOTIONS_PER_FRAME){
+    vs_log_error(modname, "Implausible number of localmotions (%i): the "
+                 "transform file is corrupt (see the note on binary file "
+                 "handles in serialize.h)!\n", len);
     return lms;
   }
   if (len>0){
     vs_vector_init(&lms,len);
     for (i=0; i<len; i++){
-      LocalMotion lm = restoreLocalmotion(f,BINARY_SERIALIZATION_MODE);
+      LocalMotion lm;
+      if(!restoreLocalmotionBinary(f,&lm)){
+        /* report only once instead of flooding the log for every record */
+        logBinaryReadError(f, "localmotion");
+        break;
+      }
       vs_vector_append_dup(&lms,&lm,sizeof(LocalMotion));
     }
   }
   if(len != vs_vector_size(&lms)){
-    vs_log_error(modname, "Cannot parse the given number of localmotions!\n");
+    vs_log_error(modname, "Cannot parse the given number of localmotions "
+                 "(got %i of %i)!\n", vs_vector_size(&lms), len);
   }
   return lms;
 }
@@ -434,7 +471,11 @@ int vsReadFromFileText(FILE* f, LocalMotions* lms){
     char l[1024];
     if(fgets(l, sizeof(l), f)==0) return VS_ERROR;
     return vsReadFromFile(f,lms,ASCII_SERIALIZATION_MODE);
-  } else if(c=='\n' || c==' ') {
+  } else if(c=='\n' || c=='\r' || c==' ' || c=='\t') {
+    /* tolerate CR (and tabs): an ascii transform file written through a
+       text-mode handle on Windows has CRLF line endings, and it must remain
+       readable through a binary-mode handle (which is required for the binary
+       format, see serialize.h) */
     return vsReadFromFile(f,lms,ASCII_SERIALIZATION_MODE);
   } else if(c==EOF) {
     return VS_ERROR;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -32,6 +32,27 @@
 #include "transform.h"
 #include "vidstab_api.h"
 
+/*
+ * IMPORTANT - contract for all FILE* passed to the functions below:
+ *
+ * The stream MUST be opened in BINARY mode, i.e. fopen(path, "wb") for
+ * writing and fopen(path, "rb") for reading.
+ *
+ * The default (BINARY_SERIALIZATION_MODE) transform file format contains
+ * arbitrary binary data (int16/int32/double). On platforms that distinguish
+ * text and binary streams (Windows/MSVCRT, but also OS/2, DOS, ...) a stream
+ * opened in text mode mangles that data:
+ *   - reading stops at the first 0x1A (Ctrl-Z) byte, which is interpreted as
+ *     end-of-file. Such a byte occurs in practically every transform file
+ *     (~0.15% of all bytes, mostly inside the double mantissas), so the file
+ *     is silently truncated after a few frames and parsing fails with
+ *     "Cannot parse localmotion!" - see issue #104.
+ *   - 0x0A bytes are expanded to 0x0D 0x0A on writing, so the file is not
+ *     portable to a reader that (correctly) uses a binary stream.
+ * Note that on POSIX systems text and binary mode are identical, which is why
+ * a caller that forgets the "b" only breaks on Windows.
+ */
+
 /// Vector of LocalMotions
 typedef VSVector VSManyLocalMotions;
 /// helper macro to access a localmotions vector in the VSVector of all Frames

--- a/tests/test_serialize_robust.c
+++ b/tests/test_serialize_robust.c
@@ -1,0 +1,173 @@
+/*
+ * test_serialize_robust.c
+ *
+ * Regression tests for issue #104: a binary transform file that got truncated
+ * (which is what MSVCRT does to a binary stream opened in text mode: reading
+ * stops at the first 0x1A / Ctrl-Z byte) must fail gracefully instead of
+ * inventing null localmotions and flooding the log, and an ascii transform
+ * file with CRLF line endings must still be readable from a binary handle.
+ */
+
+#define SR_NLM 20
+#define SR_NFRAMES 3
+
+static LocalMotions sr_make_lms(int withCtrlZ){
+  /* a contrast value that contains a 0x1A byte - completely ordinary data,
+     ~0.15% of all bytes of a real transform file are 0x1A */
+  static const unsigned char ctrlz_double[8] =
+    {0x1a,0x2b,0x3c,0x4d,0x5e,0x6f,0xd1,0x3f};
+  LocalMotions lms;
+  int i;
+  vs_vector_init(&lms, SR_NLM);
+  for(i=0; i<SR_NLM; i++){
+    LocalMotion lm;
+    memset(&lm,0,sizeof(lm));
+    lm.v.x     = i - 10;
+    lm.v.y     = 10 - i;
+    lm.f.x     = 20 + (i%5)*128;
+    lm.f.y     = 20 + (i/5)*64;
+    lm.f.size  = 32;
+    lm.contrast = 0.5;
+    lm.match    = 0.25;
+    if(withCtrlZ && i==SR_NLM/2)
+      memcpy(&lm.contrast, ctrlz_double, 8);
+    vs_vector_append_dup(&lms,&lm,sizeof(LocalMotion));
+  }
+  return lms;
+}
+
+static void sr_write_file(const char* name, int serializationMode, int withCtrlZ){
+  VSMotionDetect md;
+  int fr;
+  FILE* f = fopen(name,"wb");
+  memset(&md,0,sizeof(md));
+  md.serializationMode = serializationMode;
+  md.conf.accuracy = 15;
+  md.conf.shakiness = 10;
+  md.conf.stepSize = 6;
+  md.conf.contrastThreshold = 0.25;
+  vsPrepareFile(&md,f);
+  for(fr=1; fr<=SR_NFRAMES; fr++){
+    LocalMotions lms = sr_make_lms(withCtrlZ);
+    md.frameNum = fr;
+    vsWriteToFile(&md,f,&lms);
+    vs_vector_del(&lms);
+  }
+  fclose(f);
+}
+
+static unsigned char* sr_slurp(const char* name, long* len){
+  unsigned char* buf;
+  FILE* f = fopen(name,"rb");
+  if(!f) return 0;
+  fseek(f,0,SEEK_END); *len = ftell(f); fseek(f,0,SEEK_SET);
+  buf = vs_malloc(*len);
+  if(fread(buf,1,*len,f) != (size_t)*len){ fclose(f); vs_free(buf); return 0; }
+  fclose(f);
+  return buf;
+}
+
+static void sr_spit(const char* name, const unsigned char* buf, long len){
+  FILE* f = fopen(name,"wb");
+  fwrite(buf,1,len,f);
+  fclose(f);
+}
+
+static void sr_free_mlms(VSManyLocalMotions* mlms){
+  int i;
+  for(i=0; i<vs_vector_size(mlms); i++)
+    if(VSMLMGet(mlms,i)) vs_vector_del(VSMLMGet(mlms,i));
+  vs_vector_del(mlms);
+}
+
+int test_serialize_robust(){
+  long len, i, first1a = -1;
+  unsigned char* buf;
+  FILE* f;
+  VSManyLocalMotions mlms;
+
+  /* ---- 1. binary file round trips ---- */
+  sr_write_file("srtest_bin.trf", BINARY_SERIALIZATION_MODE, 1);
+  buf = sr_slurp("srtest_bin.trf",&len);
+  test_bool(buf!=0);
+  f = fopen("srtest_bin.trf","rb");
+  test_bool(f!=0);
+  test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
+  test_bool(vs_vector_size(&mlms)==SR_NFRAMES);
+  for(i=0; i<vs_vector_size(&mlms); i++)
+    test_bool(vs_vector_size(VSMLMGet(&mlms,i))==SR_NLM);
+  sr_free_mlms(&mlms);
+  fclose(f);
+  fprintf(stderr,"** binary file round trip OKAY\n");
+
+  /* ---- 2. truncation at the first 0x1A (Ctrl-Z), as an MSVCRT text-mode
+       handle would do: must not produce bogus (null) localmotions ---- */
+  for(i=0; i<len; i++) if(buf[i]==0x1a){ first1a = i; break; }
+  test_bool(first1a > 0);
+  sr_spit("srtest_trunc.trf", buf, first1a);
+  fprintf(stderr,"** truncating transform file at first 0x1A: %li of %li bytes\n",
+          first1a, len);
+  f = fopen("srtest_trunc.trf","rb");
+  test_bool(f!=0);
+  test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
+  for(i=0; i<vs_vector_size(&mlms); i++){
+    LocalMotions* lms = VSMLMGet(&mlms,i);
+    int j;
+    if(!lms) continue;
+    for(j=0; j<vs_vector_size(lms); j++){
+      /* every restored localmotion must be one that was really in the file,
+         i.e. no null_localmotion() placeholders for unreadable records */
+      test_bool(LMGet(lms,j)->f.size == 32);
+    }
+  }
+  sr_free_mlms(&mlms);
+  fclose(f);
+  fprintf(stderr,"** truncated binary file handled gracefully OKAY\n");
+
+  /* ---- 3. a corrupt (implausibly large) list length must be rejected
+       instead of being allocated and parsed record by record ---- */
+  {
+    int32_t bogus = 100000000;
+    unsigned char* copy = vs_malloc(len);
+    memcpy(copy,buf,len);
+    memcpy(copy+24+4,&bogus,4);  /* header(24) + frameNum(4) -> list length */
+    sr_spit("srtest_biglen.trf", copy, len);
+    vs_free(copy);
+    f = fopen("srtest_biglen.trf","rb");
+    test_bool(f!=0);
+    test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
+    test_bool(vs_vector_size(&mlms)>=1);
+    test_bool(VSMLMGet(&mlms,0)==0 || vs_vector_size(VSMLMGet(&mlms,0))==0);
+    sr_free_mlms(&mlms);
+    fclose(f);
+    fprintf(stderr,"** corrupt list length rejected OKAY\n");
+  }
+  vs_free(buf);
+
+  /* ---- 4. ascii file with CRLF line endings read from a binary handle ---- */
+  sr_write_file("srtest_ascii.trf", ASCII_SERIALIZATION_MODE, 0);
+  buf = sr_slurp("srtest_ascii.trf",&len);
+  test_bool(buf!=0);
+  {
+    unsigned char* crlf = vs_malloc(2*len);
+    long k = 0;
+    for(i=0; i<len; i++){
+      if(buf[i]=='\n') crlf[k++] = '\r';
+      crlf[k++] = buf[i];
+    }
+    sr_spit("srtest_ascii_crlf.trf", crlf, k);
+    vs_free(crlf);
+  }
+  vs_free(buf);
+  f = fopen("srtest_ascii_crlf.trf","rb");
+  test_bool(f!=0);
+  test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
+  test_bool(vs_vector_size(&mlms)==SR_NFRAMES);
+  for(i=0; i<vs_vector_size(&mlms); i++)
+    test_bool(vs_vector_size(VSMLMGet(&mlms,i))==SR_NLM);
+  sr_free_mlms(&mlms);
+  fclose(f);
+  fprintf(stderr,"** ascii file with CRLF line endings OKAY\n\n");
+
+  return 1;
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -34,6 +34,7 @@
 #include "test_compareimg.c"
 #include "test_motiondetect.c"
 #include "test_store_restore.c"
+#include "test_serialize_robust.c"
 #include "test_contrast.c"
 #include "test_boxblur.c"
 #include "test_omp.c"
@@ -123,6 +124,10 @@ int main(int argc, char** argv){
     UNIT(test_store_restore(&testdata, ASCII_SERIALIZATION_MODE));
     UNIT(test_store_restore(&testdata, BINARY_SERIALIZATION_MODE));
     UNIT(test_store_restore(&testdata, 0)); // test default binary selection
+  }
+
+  if(all || contains(argv,argc,"--testSRO", "serialization robustness")){
+    UNIT(test_serialize_robust());
   }
 
   if(all || contains(argv,argc,"--testCT", "contrastImg")){


### PR DESCRIPTION
Relates to #104. **Library hardening + regression tests only** — the actual #104 bug turned out to be already fixed upstream in FFmpeg (details below).

## What #104 was
Historically, FFmpeg gave vid.stab the **binary** `.trf` format but opened the file in **text mode** (`fopen(path, "w")` / `"r"`). On Windows a text-mode read treats **0x1A (Ctrl-Z) as end-of-file**, and the binary format stores `contrast`/`match` as doubles whose mantissa bytes hit 0x1A constantly. Measured on a 300-frame file (782,424 bytes): **1167 occurrences, 0.149% of all bytes, first at offset 2524** — inside the *second* frame. So the read was truncated almost immediately, which is why output equalled input.

Truncating a real `.trf` at its first 0x1A reproduces the reported symptom exactly, including the detail that `Cannot parse localmotion!` repeats a few times **and then goes silent** returning `VS_OK`.

Worth recording: **CRLF translation is not involved.** Text-mode write turns `\n` into `\r\n` and text-mode read turns it back — an exact involution. Emulating the full write+read path produced a file byte-identical to plain truncation.

## Current upstream FFmpeg already fixes this
`vf_vidstabdetect.c` now has a `fileformat` option (ascii/binary), sets `md->serializationMode` before `vsMotionDetectInit`, and picks the file mode accordingly:

```c
    md->serializationMode = s->fileformat;
    if (s->fileformat == BINARY_SERIALIZATION_MODE)
        file_mode = "wb";
    ...
    s->f = avpriv_fopen_utf8(s->result, file_mode);
```

and `vf_vidstabtransform.c` reads with `avpriv_fopen_utf8(tc->input, "rb")`. So users on a current FFmpeg are not affected, and `avpriv_fopen_utf8` fixes non-ASCII paths too.

## So why merge this?
Nothing here is required to fix #104, but all of it is independently useful:

- `src/serialize.h` **documents the binary-mode contract** — the library only receives a `FILE*` and cannot fix its mode, so this is the only place the requirement can live. It is what a future host needs to read.
- The reader now distinguishes **truncation** ("unexpected end of file ... open in binary mode") from a malformed record, and logs **once per frame instead of once per record**. One pathological input went from 16.6M log lines to one.
- It no longer feeds `null_localmotion()` placeholders into stabilisation on parse failure — previously a partially-read file silently produced garbage motions instead of an error.
- Implausible list lengths are rejected instead of growing a vector to millions of entries (a memory-exhaustion hazard on a corrupt or mismatched file).
- The ASCII reader tolerates `\r`/`\t`, so a CRLF ASCII `.trf` written by an older text-mode build still parses.

Still relevant to: anyone on an older FFmpeg, other hosts (transcode, direct embedders), and any caller that passes a text-mode handle.

## Tests
New `--testSRO`: round trip, truncation-at-first-0x1A invents no localmotions, corrupt length rejected, ASCII+CRLF parses. Suite 14/14 -> 15/15.

`ISSUE-104-ANALYSIS.md` records the full investigation and the trade-offs of changing the binary default (recommendation: don't).

## Caveat
No Windows host available — the mechanism is proven by faithful emulation of documented MSVCRT semantics, not on Windows.
