### PR TITLE
tests: make the SSE2-vs-C equivalence checks actually able to fail

### DIFF
--- a/tests/test_compareimg.c
+++ b/tests/test_compareimg.c
@@ -1,13 +1,23 @@
 #define NUMCMP 2000
 
+/* Compares the (possibly SIMD) compareSubImg against the plain C reference
+   compareSubImg_thr and asserts that they agree exactly.
+   field.size MUST be a multiple of 16: the SSE2 implementation advances 16
+   bytes per inner iteration ("k += 16"), so any other size makes it read
+   beyond the field and the results legitimately differ. Production code never
+   does that because vsMotionDetectInit() rounds fieldSize up to a multiple of
+   16 when SSE2 is enabled (see src/motiondetect.c:
+   "fieldSize = (fieldSize / 16 + 1) * 16").
+   The threshold is INT_MAX here, so neither implementation can exit early and
+   strict equality is the correct assertion. */
 int checkCompareImg(VSMotionDetect* md, const VSFrame* frame){
   int i;
-  int error;
+  unsigned int error, errorRef;
   uint8_t *Y_c;
   Field field;
   field.x=400;
   field.y=400;
-  field.size=12;
+  field.size=64; /* multiple of 16, see comment above */
 
   Y_c = frame->data[0];
   int linesize = frame->linesize[0];
@@ -17,8 +27,15 @@ int checkCompareImg(VSMotionDetect* md, const VSFrame* frame){
     error = compareSubImg(Y_c, Y_c, &field,
                           linesize, linesize, md->fi.height,
                           1, i, 0, INT_MAX);
-    fprintf(stderr,"mismatch %i: %i\n", i, error);
+    errorRef = compareSubImg_thr(Y_c, Y_c, &field,
+                                 linesize, linesize, md->fi.height,
+                                 1, i, 0, INT_MAX);
+    fprintf(stderr,"mismatch %i: opt %u, C %u\n", i, error, errorRef);
+    test_bool(error == errorRef);
   }
+  /* a shift of 0 against the identical image must give a difference of 0 */
+  test_bool(compareSubImg(Y_c, Y_c, &field, linesize, linesize, md->fi.height,
+                          1, 0, 0, INT_MAX) == 0);
   return 1;
 }
 
@@ -52,13 +69,17 @@ int runcompare( cmpSubImgFunc cmpsubfunc,
                         2, i%200, i/200, INT_MAX);
   }
   int end = timeOfDayinMS();
-  if(diffsRef)
+  if(diffsRef){
+    int reported = 0;
     for(i=0; i<numruns; i++){
-      if(diffs[i]!=diffsRef[i]){
-        fprintf(stderr, "ERROR! Ref difference %i, Opt difference %i\n",
-                diffsRef[i], diffs[i]);
+      if(diffs[i]!=diffsRef[i] && reported++ < 10){
+        fprintf(stderr, "ERROR! run %i: Ref difference %i, Opt difference %i\n",
+                i, diffsRef[i], diffs[i]);
       }
+      /* threshold is INT_MAX above, so no early exit: must be exactly equal */
+      test_bool(diffs[i]==diffsRef[i]);
     }
+  }
   return end-start;
 }
 

--- a/tests/test_contrast.c
+++ b/tests/test_contrast.c
@@ -42,5 +42,41 @@ void test_contrastImg(const TestData* testdata){
     }
     test_bool(contrastC[i]==contrastOpt[i]);
   }
+
+  /* Sweep several field sizes and positions, not just one.
+     Sizes must be multiples of 16: contrastSubImg1_SSE loads 16 bytes per
+     inner iteration ("k += 16"), any other size reads past the field.
+     vsMotionDetectInit() guarantees that in production
+     (see src/motiondetect.c: "fieldSize = (fieldSize / 16 + 1) * 16").
+     Exact equality is required, not an epsilon: both functions reduce the
+     field to an 8 bit min and max and then evaluate the identical expression
+     (maxi-mini)/(maxi+mini+0.1); with identical integer inputs and no
+     reassociation of float ops the doubles are bit-identical. */
+  {
+    static const int sizes[] = {16, 32, 48, 64, 80};
+    static const int pos[][2] = { {400,300}, {200,200}, {900,500}, {640,360} };
+    int s, p, fr;
+    fprintf(stderr,"********** Contrast C vs SSE2 over sizes/positions:\n");
+    for(fr=0; fr<2; fr++){
+      for(s=0; s<(int)(sizeof(sizes)/sizeof(sizes[0])); s++){
+        for(p=0; p<(int)(sizeof(pos)/sizeof(pos[0])); p++){
+          Field ff;
+          ff.size = sizes[s];
+          ff.x = pos[p][0];
+          ff.y = pos[p][1];
+          double cC = contrastSubImg(testdata->frames[fr].data[0], &ff,
+                                     testdata->frames[fr].linesize[0],
+                                     testdata->fi.height, 1);
+          double cO = contrastSubImg1_SSE(testdata->frames[fr].data[0], &ff,
+                                          testdata->frames[fr].linesize[0],
+                                          testdata->fi.height);
+          if(cC != cO)
+            fprintf(stderr,"  CONTRAST MISMATCH frame=%i size=%i pos=(%i,%i): "
+                    "C=%.17g SSE2=%.17g\n", fr, ff.size, ff.x, ff.y, cC, cO);
+          test_bool(cC == cO);
+        }
+      }
+    }
+  }
 #endif
 }

--- a/tests/test_simd_equivalence.c
+++ b/tests/test_simd_equivalence.c
@@ -1,0 +1,228 @@
+/* test_simd_equivalence.c
+ *
+ * Real (failable) equivalence tests between the optimized SIMD routines and
+ * the plain C reference implementations:
+ *   compareSubImg_thr        (src/motiondetect.c)      <-> compareSubImg_thr_sse2 (src/motiondetect_opt.c)
+ *   contrastSubImg           (src/motiondetect.c)      <-> contrastSubImg1_SSE    (src/motiondetect_opt.c)
+ *
+ * IMPORTANT -- only field sizes that are a multiple of 16 are legal input for
+ * the SSE2 routines: their inner loops advance 16 bytes per iteration
+ * ("k += 16"), so a size that is not a multiple of 16 makes them read past the
+ * end of the field and the two implementations then legitimately disagree.
+ * Production code can never do this: vsMotionDetectInit() rounds both
+ * fieldSize and fieldSizeFine up to a multiple of 16 when USE_SSE2 /
+ * USE_SSE2_ASM is enabled (src/motiondetect.c, "fieldSize = (fieldSize / 16 + 1) * 16").
+ * Therefore the tests below only use sizes 16, 32, 48, 64, 80.
+ *
+ * IMPORTANT -- the "threshold" parameter: both implementations abort early once
+ * the running sum exceeds threshold, and the value returned by an early-exited
+ * call is NOT required to equal the full sum -- the only guarantee is that it
+ * is greater than threshold.  (The SSE2 version even drops the not yet
+ * horizontally-added partial sums when it breaks out.)  Consequently:
+ *   - with threshold == UINT_MAX neither can exit early, so the returned values
+ *     MUST be exactly equal  -> strict equality is asserted.
+ *   - with a finite threshold we must not compare the numbers.  We assert the
+ *     two properties the only caller (calcFieldTransPlanar, which uses the
+ *     result exclusively as "if (error < minerror)") actually depends on:
+ *       (a) both agree on whether the result is <= threshold,
+ *       (b) a full argmin scan driven by either implementation selects the
+ *           very same (tx,ty) and the same final minerror.
+ */
+
+#ifdef USE_SSE2
+
+/* only multiples of 16 are valid, see file header */
+static const int simd_field_sizes[]  = { 16, 32, 48, 64, 80 };
+#define SIMD_NUM_FIELD_SIZES ((int)(sizeof(simd_field_sizes)/sizeof(simd_field_sizes[0])))
+
+/* several field positions, all far enough from the border for size 80 + shift 24 */
+static const int simd_field_pos[][2] = { {400,300}, {200,200}, {900,500}, {640,360} };
+#define SIMD_NUM_FIELD_POS ((int)(sizeof(simd_field_pos)/sizeof(simd_field_pos[0])))
+
+/* mimics the search of calcFieldTransPlanar (non-spiral variant):
+   start at (0,0), then scan with a tightening minerror that is handed to the
+   compare function as threshold. Returns the selected shift and the minerror. */
+static void simd_argmin_scan(cmpSubImgFunc cmpsubfunc,
+                             unsigned char* I1, unsigned char* I2,
+                             const Field* field, int width1, int width2, int height,
+                             int maxShift, int stepSize,
+                             int* tx_out, int* ty_out, unsigned int* minerror_out){
+  int i, j;
+  int tx = 0, ty = 0;
+  unsigned int minerror = cmpsubfunc(I1, I2, field, width1, width2, height,
+                                    1, 0, 0, UINT_MAX);
+  for (i = -maxShift; i <= maxShift; i += stepSize) {
+    for (j = -maxShift; j <= maxShift; j += stepSize) {
+      if (i == 0 && j == 0)
+        continue; /* already done */
+      unsigned int error = cmpsubfunc(I1, I2, field, width1, width2, height,
+                                      1, i, j, minerror);
+      if (error < minerror) {
+        minerror = error;
+        tx = i;
+        ty = j;
+      }
+    }
+  }
+  *tx_out = tx;
+  *ty_out = ty;
+  *minerror_out = minerror;
+}
+
+/* threshold == UINT_MAX: no early exit possible on either side,
+   so the returned sums must be bit-for-bit equal. */
+static void simd_test_compare_strict(const TestData* testdata){
+  int s, p, dx, dy;
+  int mismatches = 0;
+  unsigned char* I1 = testdata->frames[0].data[0];
+  unsigned char* I2 = testdata->frames[1].data[0];
+  int w1 = testdata->frames[0].linesize[0];
+  int w2 = testdata->frames[1].linesize[0];
+  int h  = testdata->fi.height;
+
+  fprintf(stderr,"*** compareSubImg: strict equality (threshold=UINT_MAX)\n");
+  for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
+    for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
+      Field f;
+      f.size = simd_field_sizes[s];
+      f.x    = simd_field_pos[p][0];
+      f.y    = simd_field_pos[p][1];
+      for (dy = -16; dy <= 16; dy += 8) {       /* includes 0 */
+        for (dx = -16; dx <= 16; dx += 8) {     /* includes 0 */
+          unsigned int refval = compareSubImg_thr(I1, I2, &f, w1, w2, h,
+                                                 1, dx, dy, UINT_MAX);
+          unsigned int optval = compareSubImg_thr_sse2(I1, I2, &f, w1, w2, h,
+                                                       1, dx, dy, UINT_MAX);
+          if (refval != optval && mismatches++ < 10)
+            fprintf(stderr,"  MISMATCH size=%i pos=(%i,%i) d=(%i,%i): C=%u SSE2=%u\n",
+                    f.size, f.x, f.y, dx, dy, refval, optval);
+          test_bool(refval == optval);
+        }
+      }
+    }
+  }
+}
+
+/* finite threshold: the returned numbers may legally differ (early exit).
+   Assert only what the caller relies on: both must agree on whether the
+   result is <= threshold. */
+static void simd_test_compare_threshold(const TestData* testdata){
+  int s, p, t, dx, dy;
+  unsigned char* I1 = testdata->frames[0].data[0];
+  unsigned char* I2 = testdata->frames[1].data[0];
+  int w1 = testdata->frames[0].linesize[0];
+  int w2 = testdata->frames[1].linesize[0];
+  int h  = testdata->fi.height;
+
+  fprintf(stderr,"*** compareSubImg: finite threshold, <=threshold decision must agree\n");
+  for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
+    for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
+      Field f;
+      f.size = simd_field_sizes[s];
+      f.x    = simd_field_pos[p][0];
+      f.y    = simd_field_pos[p][1];
+      /* a representative full sum to derive thresholds from */
+      unsigned int full = compareSubImg_thr(I1, I2, &f, w1, w2, h, 1, 0, 0, UINT_MAX);
+      unsigned int thresholds[4];
+      thresholds[0] = 0;
+      thresholds[1] = full / 4;
+      thresholds[2] = full;
+      thresholds[3] = full * 2 + 1;
+      for (t = 0; t < 4; t++) {
+        unsigned int thr = thresholds[t];
+        for (dy = -8; dy <= 8; dy += 8) {
+          for (dx = -8; dx <= 8; dx += 8) {
+            unsigned int refval = compareSubImg_thr(I1, I2, &f, w1, w2, h,
+                                                    1, dx, dy, thr);
+            unsigned int optval = compareSubImg_thr_sse2(I1, I2, &f, w1, w2, h,
+                                                         1, dx, dy, thr);
+            /* the guarantee: an early-exited result is > threshold */
+            test_bool((refval <= thr) == (optval <= thr));
+          }
+        }
+      }
+    }
+  }
+}
+
+/* the property that really matters: the search in calcFieldTransPlanar must
+   pick the same shift and end with the same minerror, whichever
+   implementation drives it. */
+static void simd_test_compare_argmin(const TestData* testdata){
+  int s, p;
+  unsigned char* I1 = testdata->frames[0].data[0];
+  unsigned char* I2 = testdata->frames[1].data[0];
+  int w1 = testdata->frames[0].linesize[0];
+  int w2 = testdata->frames[1].linesize[0];
+  int h  = testdata->fi.height;
+
+  fprintf(stderr,"*** compareSubImg: argmin of a calcFieldTransPlanar-like scan must match\n");
+  for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
+    for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
+      Field f;
+      int txC, tyC, txO, tyO;
+      unsigned int minC, minO;
+      f.size = simd_field_sizes[s];
+      f.x    = simd_field_pos[p][0];
+      f.y    = simd_field_pos[p][1];
+      simd_argmin_scan(compareSubImg_thr,      I1, I2, &f, w1, w2, h, 12, 2,
+                       &txC, &tyC, &minC);
+      simd_argmin_scan(compareSubImg_thr_sse2, I1, I2, &f, w1, w2, h, 12, 2,
+                       &txO, &tyO, &minO);
+      if (txC != txO || tyC != tyO || minC != minO)
+        fprintf(stderr,"  ARGMIN MISMATCH size=%i pos=(%i,%i): "
+                "C=(%i,%i,%u) SSE2=(%i,%i,%u)\n",
+                f.size, f.x, f.y, txC, tyC, minC, txO, tyO, minO);
+      test_bool(txC == txO);
+      test_bool(tyC == tyO);
+      test_bool(minC == minO);
+    }
+  }
+}
+
+/* contrastSubImg (C, bytesPerPixel=1) vs contrastSubImg1_SSE.
+   Both reduce the field to an 8 bit minimum and maximum and then evaluate the
+   very same expression (maxi-mini)/(maxi+mini+0.1) in double precision.  If
+   the two reductions agree, the doubles are computed by identical operations
+   on identical integer inputs and are therefore bit-identical -- there is no
+   reordering of floating point arithmetic anywhere.  Hence we assert exact
+   equality rather than an epsilon: any nonzero difference means the SIMD
+   min/max reduction is wrong, which is exactly what we want to catch. */
+static void simd_test_contrast(const TestData* testdata){
+  int s, p, fr;
+  fprintf(stderr,"*** contrastSubImg: strict equality C vs SSE2\n");
+  for (fr = 0; fr < 2; fr++) {
+    unsigned char* I = testdata->frames[fr].data[0];
+    int w = testdata->frames[fr].linesize[0];
+    int h = testdata->fi.height;
+    for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
+      for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
+        Field f;
+        f.size = simd_field_sizes[s];
+        f.x    = simd_field_pos[p][0];
+        f.y    = simd_field_pos[p][1];
+        double cC = contrastSubImg(I, &f, w, h, 1);
+        double cO = contrastSubImg1_SSE(I, &f, w, h);
+        if (cC != cO)
+          fprintf(stderr,"  CONTRAST MISMATCH frame=%i size=%i pos=(%i,%i): "
+                  "C=%.17g SSE2=%.17g\n", fr, f.size, f.x, f.y, cC, cO);
+        test_bool(cC == cO);
+      }
+    }
+  }
+}
+
+#endif /* USE_SSE2 */
+
+void test_simd_equivalence(const TestData* testdata){
+#ifdef USE_SSE2
+  fprintf(stderr,"********** SSE2 vs C equivalence:\n");
+  simd_test_compare_strict(testdata);
+  simd_test_compare_threshold(testdata);
+  simd_test_compare_argmin(testdata);
+  simd_test_contrast(testdata);
+#else
+  (void)testdata;
+  fprintf(stderr,"********** SSE2 vs C equivalence: SSE2 not enabled, nothing to compare\n");
+#endif
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -32,6 +32,7 @@
 
 #include "test_transform.c"
 #include "test_compareimg.c"
+#include "test_simd_equivalence.c"
 #include "test_motiondetect.c"
 #include "test_store_restore.c"
 #include "test_contrast.c"
@@ -109,6 +110,10 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testCIP", "compareImg_performance")){
     UNIT(test_compareImg_performance(&testdata));
+  }
+
+  if(all || contains(argv,argc,"--testSIMD", "SSE2 vs C equivalence")){
+    UNIT(test_simd_equivalence(&testdata));
   }
 
   if(all || contains(argv,argc,"--testMD", "motionDetect")){


### PR DESCRIPTION
No library changes — tests only.

## The problem
The suite looked like it verified the SIMD paths against the scalar reference. It did not:

- **`checkCompareImg` (`--testCCI`) could never fail.** It called only the `compareSubImg` macro (i.e. the SSE2 variant), printed the numbers, and ended with an unconditional `return 1;`. It never compared against `compareSubImg_thr` at all.
- **`runcompare` (`--testCIP`)** detected mismatches against its reference array but only did `fprintf(stderr, "ERROR! ...")` — no `test_bool`, so it could not fail either.
- `checkCompareImg` used `field.size = 12`. The SSE2 inner loop advances 16 bytes at a time, so a non-multiple-of-16 size reads past the field and the SSE and C results legitimately disagree. Production never hits this because `vsMotionDetectInit` rounds `fieldSize` up to a multiple of 16, but the test did — which is why its printed numbers looked wrong.

So a change to the hottest function in the library could not be validated by "all tests pass".

## What this adds
- `--testCCI` now asserts `error == errorRef` against the scalar reference, with `field.size = 64` and a comment explaining why only multiples of 16 are legal input.
- `runcompare` mismatches now fail via `test_bool`.
- New `--testSIMD`, sweeping sizes {16,32,48,64,80} × 4 field positions:
  - strict equality at `threshold = UINT_MAX` (500 assertions);
  - for **finite** thresholds, *not* value equality — an early-exited return is only required to exceed the threshold — but `(ref<=thr) == (opt<=thr)`, plus an **argmin scan** mimicking `calcFieldTransPlanar` (start at (0,0), tightening `minerror`) requiring identical `tx`/`ty`/`minerror`. This is the property the caller actually relies on;
  - `contrastSubImg` vs `contrastSubImg1_SSE` strict equality.
- `--testCT` already asserted, but covered exactly one field; extended to a size/position sweep.

Contrast is compared with `==`, deliberately: both reduce the field to `unsigned char` min/max then evaluate the identical double expression, so any difference *is* the bug. An epsilon would only hide it.

## Proof the assertions can fail
Deliberate bugs injected into the SSE2 code, then reverted (not committed):

| Injection | Caught by |
|---|---|
| `k += 16` → `k += 8` | all 500 strict-equality asserts, 162 threshold asserts, 17/15/20 argmin asserts |
| `sum > threshold` → `sum > threshold/2` (premature early exit) | **only the new finite-threshold and argmin asserts** — strict equality, `--testCCI` and `--testCIP` all correctly still pass. This is precisely the case the old suite structurally could not see. |
| contrast: perturb one `_mm_min_epu8` operand | `--testCT` 0/2040 and all 40 contrast asserts, e.g. `C=0.79957916885849556 SSE2=0.79016221873364734` |

Worth noting: *removing* the early-exit `break` entirely is correctly **not** flagged — the function then returns the full sum, which still exceeds the threshold, so every property still holds.

Verified `-DUSE_SSE2`/`-msse2` are actually in the generated flags. 15/15 in both Debug and Release; also compiles clean without SSE2. No equivalence assertion fails on unmodified master.
