### PR TITLE
Build-system hygiene, including a CMake 4 hard failure in tests/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,11 @@ cmake_install.cmake
 install_manifest.txt
 
 # Don't include the build directory and compiled Mac dynamic libraries.
-build 
+build
 *.dylib
+
+# Outputs and binaries produced by the test suite
+*.pgm
+/tests/tests
+/tests/lmtest
+/tests/lmstest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,6 @@ if(NOT WIN32)
   add_definitions(-fPIC)
 endif()
 
-if(NOT WIN32)
-  add_definitions(-fPIC)
-endif()
-
 if(APPLE AND NOT CMAKE_OSX_ARCHITECTURES AND NOT SSE2_FOUND)
   add_definitions(-march=armv8-a+fp+simd+crypto+crc)
 endif()

--- a/src/libvidstab.h
+++ b/src/libvidstab.h
@@ -25,7 +25,8 @@
 #ifndef LIBVIDSTAB_H
 #define LIBVIDSTAB_H
 
-#define LIBVIDSTAB_VERSION "v1.1 (2015-05-16)"
+/* Keep in sync with MAJOR/MINOR/PATCH_VERSION in the top-level CMakeLists.txt */
+#define LIBVIDSTAB_VERSION "v1.2.0"
 
 #include "frameinfo.h"
 #include "motiondetect.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 #  very fast: faster than orc code at imgcompare without any options.
 #  library needs libimf.so (link statically?)
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.14)
 project (vid.stab)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../CMakeModules/")

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -134,9 +134,10 @@ int main(int argc, char** argv){
   }
 
   // free
+  /* testdata was zeroed above, so unallocated frames have NULL planes and
+     vsFrameFree() handles those safely; no NULL check on the address needed. */
   for(int i=0; i<FRAMENUM; i++){
-    if(&testdata.frames[i])
-      vsFrameFree(&testdata.frames[i]);
+    vsFrameFree(&testdata.frames[i]);
   }
 
   return unittest_summary();

--- a/transcode/CMakeLists.txt
+++ b/transcode/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.14)
 project (vid.stab.transcode)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../CMakeModules/")


### PR DESCRIPTION
Five independent small fixes.

## 1. CMake 4 breaks the test build (the important one)
Commit 7cef79c ("Fix build with CMake 4") raised only the **root** `CMakeLists.txt` to 3.14. `tests/CMakeLists.txt:5` and `transcode/CMakeLists.txt:1` still said `cmake_minimum_required (VERSION 2.6)`, which on cmake 3.28 emits *"Compatibility with CMake < 3.5 will be removed from a future version"* and on **CMake 4 is a hard error** — so the test suite could not be configured at all. Both raised to 3.14; the deprecation warning is gone.

## 2. Duplicated block
The root `CMakeLists.txt` contained `if(NOT WIN32) add_definitions(-fPIC) endif()` twice. Removed the duplicate.

## 3. Version string out of sync
`src/libvidstab.h` still said `"v1.1 (2015-05-16)"` while cmake declared 1.2.0. Now `"v1.2.0"`, with a comment pointing at the cmake variables. Checked first that nothing parses it — it is only used as `MOD_VERSION` for display in the transcode plugins.

## 4. .gitignore
The suite writes `.pgm` outputs and binaries into `tests/`, which showed up as untracked junk. Added pattern-based entries. No existing files were deleted, only ignored.

## 5. -Waddress warning
`tests/tests.c` had `if(&testdata.frames[i])`, which gcc flags as always-true. The guard was meaningless: `testdata` is `memset` to 0 and `vsFrameFree` only frees non-NULL planes, so unallocated frames were already safe. Guard dropped, with a comment recording why.

## Not done
`src/Makefile` and `CMakeModules/FindGLPK.cmake~` (the remaining `USE_ORC` litter mentioned in #95) are **not tracked in git** — they only exist in some working copies, so there is nothing for the repo to delete. `grep -rn USE_ORC` over the tree gives zero hits.

Library and test builds are warning-free; suite 14/14 unchanged. `transcode/` bump is verified by inspection only, since it needs external transcode headers.
