### PR TITLE
FindSSE: only probe for SSE when the target is x86 (#109)

### DIFF
--- a/CMakeModules/FindSSE.cmake
+++ b/CMakeModules/FindSSE.cmake
@@ -1,6 +1,43 @@
 include(CheckCCompilerFlag)
 
-if (MSVC)
+# SSE is an x86-only feature set, so detection must be done for the TARGET
+# architecture, never for the build host.  When cross-compiling (e.g. from an
+# x86_64 host to riscv64 or arm) any host-based or host-compiler-based probe
+# yields a false positive and "-msse2" ends up on a compiler that rejects it.
+# See https://github.com/georgmartius/vid.stab/issues/109
+set(_SSE_TARGET_IS_X86 FALSE)
+if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+      # Explicit (possibly universal) architecture list: only enable SSE if every
+      # requested architecture is x86.
+      set(_SSE_TARGET_IS_X86 TRUE)
+      foreach(_sse_arch IN LISTS CMAKE_OSX_ARCHITECTURES)
+            if(NOT _sse_arch MATCHES "^(x86_64h?|i[3-6]86)$")
+                  set(_SSE_TARGET_IS_X86 FALSE)
+            endif()
+      endforeach()
+      unset(_sse_arch)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^([xX]86(_64)?|[iI][3-6]86|AMD64|amd64|[eE][mM]64[tT])$")
+      set(_SSE_TARGET_IS_X86 TRUE)
+endif()
+
+if(NOT _SSE_TARGET_IS_X86)
+      if(CMAKE_CROSSCOMPILING)
+            message(STATUS "Cross-compiling for non-x86 target "
+                    "'${CMAKE_SYSTEM_PROCESSOR}': skipping SSE detection")
+      else()
+            message(STATUS "Non-x86 target '${CMAKE_SYSTEM_PROCESSOR}': "
+                    "skipping SSE detection")
+      endif()
+
+      # Define the variables (as false) rather than leaving them unset, so that
+      # if(SSE2_FOUND) in the callers behaves sanely.  No FORCE: an explicit
+      # -DSSE2_FOUND=... from the user is preserved.
+      set(SSE2_FOUND   FALSE CACHE BOOL "SSE2 available on target")
+      set(SSE3_FOUND   FALSE CACHE BOOL "SSE3 available on target")
+      set(SSSE3_FOUND  FALSE CACHE BOOL "SSSE3 available on target")
+      set(SSE4_1_FOUND FALSE CACHE BOOL "SSE4.1 available on target")
+
+elseif (MSVC)
       message(STATUS "MSVC detected, enabling default SSE2+ support")
 
       set(SSE2_FOUND TRUE CACHE BOOL "SSE2 available on target" FORCE)
@@ -77,3 +114,5 @@ if(NOT SSE4_1_FOUND)
 endif()
 
 mark_as_advanced(SSE2_FOUND SSE3_FOUND SSSE3_FOUND SSE4_1_FOUND)
+
+unset(_SSE_TARGET_IS_X86)


### PR DESCRIPTION
Closes #109.

## The problem
`CMakeModules/FindSSE.cmake` ran its feature probes unconditionally, regardless of the target architecture. Cross-builds then got `-msse2` for a non-x86 target and failed. Distro packagers work around it today by passing `-DSSE2_FOUND=False` by hand (reported from Alpine, cross-compiling to riscv64).

Small correction to the issue text: the current file does **not** read `/proc/cpuinfo` — that was an older revision. It probes with `check_c_compiler_flag(-msse2 …)` + `try_compile`. The defect is that those probes were not gated on the target.

## The fix
An up-front target-architecture gate: true only when `CMAKE_SYSTEM_PROCESSOR` matches an x86 family (`x86`, `x86_64`, `i386`–`i686`, `AMD64`, …). On Apple, if `CMAKE_OSX_ARCHITECTURES` is set it is true only when *every* listed arch is x86, so a universal `x86_64;arm64` build correctly stays false. `SSE2_FOUND`/`SSE3_FOUND`/`SSSE3_FOUND`/`SSE4_1_FOUND` are set as `CACHE BOOL` **without FORCE**, so they are defined-but-false and an explicit `-DSSE2_FOUND=...` from the user still wins.

## Verification
- **Native x86_64 — no regression.** Probes still succeed; `flags.make` still has `-DUSE_SSE2` and `-msse2`. This was the critical check.
- **Simulated riscv64 cross** (`-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=riscv64`): `skipping SSE detection`, and neither `-msse2` nor `-DUSE_SSE2` appears. Configure-only — it would not link without a real toolchain. Confirmed `-DSSE2_FOUND=True` still forces it back on.
- **aarch64 target**: same result. (Note `-DCMAKE_SYSTEM_PROCESSOR=aarch64` *alone* is silently ignored by CMake — without `CMAKE_SYSTEM_NAME` it gets overwritten with the host value. That is CMake semantics, not the gate.) Regex unit-checked in isolation: aarch64/arm64/riscv64/ppc64le/empty → FALSE; x86_64/i686/AMD64 → TRUE.
- Suite 14/14 on the native build, including `SSE2 contrast 0.84, C contrast 0.84`.

## Apple Silicon
Unaffected, and now deterministic. Without `CMAKE_OSX_ARCHITECTURES`, `CMAKE_SYSTEM_PROCESSOR` is `arm64` → gate false → `SSE2_FOUND` defined FALSE, so `if(APPLE AND NOT CMAKE_OSX_ARCHITECTURES AND NOT SSE2_FOUND)` still fires and adds the NEON flags. Previously that relied on the `-msse2` compiler probe happening to fail.
