### PR TITLE
Fix malformed version in the generated pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,10 @@ find_package(OpenMP)
 set(MAJOR_VERSION 1)
 set(MINOR_VERSION 2)
 set(PATCH_VERSION 0)
-set(VIDSTAB_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}${PATCH_VERSION})
+# note the separator between minor and patch: without it this produced "1.20"
+# for 1.2.0 (and "1.10" for 1.1.0), which is what ends up in the Version field
+# of the generated vidstab.pc
+set(VIDSTAB_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
 
 # Default to release builds if no explicit build type specified.
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
`VIDSTAB_VERSION` concatenated `MINOR_VERSION` and `PATCH_VERSION` without a separator, so `vidstab.pc` advertised **`Version: 1.20`** instead of `1.2.0` (and `1.10` for the 1.1.0 release).

```diff
-set(VIDSTAB_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}${PATCH_VERSION})
+set(VIDSTAB_VERSION ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION})
```

Verified: the generated `.pc` now reads `Version: 1.2.0`, and it agrees with `LIBVIDSTAB_VERSION` in `src/libvidstab.h`.

**This is not the cause of #113.** FFmpeg's configure only requires `vidstab >= 0.98`, and pkg-config compares components numerically, so `1.20` already satisfied it. The string was simply wrong.

**SOVERSION is unaffected** — it is built from `MAJOR_VERSION.MINOR_VERSION` directly, so the soname stays `libvidstab.so.1.2`. No ABI change.

**Caveat for packagers:** anyone who pinned `vidstab >= 1.10` believing that was the 1.1.0 string will no longer match, since `1.2.0` compares as 2 < 10. Unlikely, but worth a release note.
