### PR TITLE
Warn instead of silently downgrading VSOptimalL1 to Gaussian

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -66,7 +66,10 @@ VSTransformConfig vsTransformGetDefaultConfig(const char* modName){
   conf.simpleMotionCalculation = 0;
   conf.storeTransforms    = 0;
   conf.smoothZoom         = 0;
-  conf.camPathAlgo        = VSOptimalL1;
+  /* VSOptimalL1 (==0) is not implemented, so the default is Gaussian.
+     Note: a caller that zero-initializes the config still ends up requesting
+     VSOptimalL1 and will get the "not implemented" warning below. */
+  conf.camPathAlgo        = VSGaussian;
   return conf;
 }
 
@@ -104,8 +107,15 @@ int vsTransformDataInit(VSTransformData* td, const VSTransformConfig* conf,
 
   td->conf.interpolType = VS_MAX(VS_MIN(td->conf.interpolType,VS_BiCubic),VS_Zero);
 
-  // not yet implemented
-  if(td->conf.camPathAlgo==VSOptimalL1) td->conf.camPathAlgo=VSGaussian;
+  /* The L1-optimal camera path algorithm is not implemented. Tell the user
+     instead of silently doing something else than what was requested. */
+  if(td->conf.camPathAlgo==VSOptimalL1){
+    vs_log_warn(td->conf.modName,
+                "camera path algorithm 'optimal L1' (optalgo=%i) is not implemented, "
+                "using 'gaussian' (optalgo=%i) instead\n",
+                (int)VSOptimalL1, (int)VSGaussian);
+    td->conf.camPathAlgo=VSGaussian;
+  }
 
   switch(td->conf.interpolType){
    case VS_Zero:     td->interpolate = &interpolateZero; break;
@@ -224,9 +234,10 @@ void vsTransformationsCleanup(VSTransformations* trans){
 int cameraPathOptimization(VSTransformData* td, VSTransformations* trans){
   switch(td->conf.camPathAlgo){
    case VSAvg: return cameraPathAvg(td,trans);
-   case VSOptimalL1: // not yet implenented
+     // VSOptimalL1 is not implemented; vsTransformDataInit already replaced it
+     // by VSGaussian (and warned about it). Handled here only for completeness.
+   case VSOptimalL1:
    case VSGaussian: return cameraPathGaussian(td,trans);
-//   case VSOptimalL1: return cameraPathOptimalL1(td,trans);
   }
   return VS_ERROR;
 }

--- a/src/transform.h
+++ b/src/transform.h
@@ -60,6 +60,12 @@ typedef enum { VS_Zero, VS_Linear, VS_BiLinear, VS_BiCubic, VS_NBInterPolTypes} 
 VS_API const char* getInterpolationTypeName(VSInterpolType type);
 
 typedef enum { VSKeepBorder = 0, VSCropBorder } VSBorderType;
+/** algorithm used to optimize (smooth) the camera path.
+ *  Attention: the numeric values are part of the API/ABI (e.g. ffmpeg's
+ *  'optalgo' option passes these integers), so they must not be renumbered.
+ *  VSOptimalL1 is *not implemented*: requesting it logs a warning and
+ *  VSGaussian is used instead (see issue #71).
+ */
 typedef enum { VSOptimalL1 = 0, VSGaussian, VSAvg } VSCamPathAlgo;
 
 /**
@@ -102,7 +108,10 @@ typedef struct VS_API _VSTransformConfig {
     int            simpleMotionCalculation;
     int            storeTransforms; // stores calculated transforms to file
     int            smoothZoom;   // if 1 the zooming is also smoothed. Typically not recommended.
-    VSCamPathAlgo  camPathAlgo;  // algorithm to use for camera path optimization
+    /* algorithm to use for camera path optimization.
+       Note: VSOptimalL1 is not implemented; it is treated as VSGaussian
+       (with a warning). Default is VSGaussian. */
+    VSCamPathAlgo  camPathAlgo;
 } VSTransformConfig;
 
 typedef struct VS_API _VSTransformData {
@@ -153,6 +162,10 @@ static const char vs_transform_help[] = ""
     "    'interpol'  type of interpolation: 0: no interpolation, \n"
     "                1: linear (horizontal), 2: bi-linear (def), \n"
     "                3: bi-cubic\n"
+    "    'optalgo'   camera path optimization algorithm:\n"
+    "                0: optimal L1 (NOT IMPLEMENTED, falls back to 1),\n"
+    "                1: gaussian kernel low-pass filter (def),\n"
+    "                2: sliding average\n"
     "    'sharpen'   amount of sharpening: 0: no sharpening (def: 0.8)\n"
     "                uses filter unsharp with 5x5 matrix\n"
     "    'tripod'    virtual tripod mode (=relative=0:smoothing=0)\n"

--- a/src/transform_internal.h
+++ b/src/transform_internal.h
@@ -41,7 +41,8 @@ VS_API int cameraPathOptimization(VSTransformData* td, VSTransformations* trans)
 
 VS_API int cameraPathAvg(VSTransformData* td, VSTransformations* trans);
 VS_API int cameraPathGaussian(VSTransformData* td, VSTransformations* trans);
-VS_API int cameraPathOptimalL1(VSTransformData* td, VSTransformations* trans);
+/* Note: there is no cameraPathOptimalL1(). The L1-optimal camera path
+   (VSOptimalL1) is not implemented, see issue #71. */
 
 #endif
 


### PR DESCRIPTION
Relates to #71.

## The problem
`VSCamPathAlgo` declares `{ VSOptimalL1 = 0, VSGaussian, VSAvg }`, but `VSOptimalL1` is **not implemented** — `cameraPathOptimalL1()` was declared in `transform_internal.h` with no definition anywhere. `vsTransformDataInit` silently rewrote it:
```c
// not yet implemented
if(td->conf.camPathAlgo==VSOptimalL1) td->conf.camPathAlgo=VSGaussian;
```
FFmpeg exposes this as the `optalgo` option, so a user who explicitly selects the L1-optimal algorithm got Gaussian with no indication whatsoever.

This does **not** implement L1-optimal stabilisation — that stays open as #71. It just stops the library lying about it.

## The subtlety, and the design choice
Because `VSOptimalL1 == 0`, it is also what a zero-initialised config reads as, and it was the value returned by `vsTransformGetDefaultConfig`. Warning unconditionally would spam every normal user who never asked for L1.

So: `vsTransformGetDefaultConfig` now returns `VSGaussian` **explicitly**, and the warning fires only when `VSOptimalL1` actually reaches `vsTransformDataInit`.

**This is ABI-safe.** No enumerator value changes, so FFmpeg's `optalgo` keeps meaning 0=L1, 1=gaussian, 2=avg and any caller storing the integer keeps its meaning. Only the library's suggested default changes, and it changes from "L1, silently rewritten to Gaussian" to "Gaussian" — identical observable behaviour, minus the lie. The warning lives in `vsTransformDataInit`, which runs once per instance, so it is naturally once-per-use with no static state.

Residual case, documented in both files: a caller that zero-initialises `VSTransformConfig` rather than calling `vsTransformGetDefaultConfig` still requests 0 and will see the warning. Fixing that would require renumbering the enum, which is not worth breaking ABI over.

## Also
- Removed the declaration of the never-defined `cameraPathOptimalL1()` — a declaration with no definition is a trap that only fails at link time.
- Corrected the misleading `// not yet implenented` fallthrough comment and dropped the dead commented-out call. The `case VSOptimalL1:` label stays (the switch has no `default:`, so removing it would produce `-Wswitch`), now documented as defensive.
- `VSCamPathAlgo` doc block now states that the numeric values are ABI and must not be renumbered; `vs_transform_help` marks `optalgo=0` as NOT IMPLEMENTED.

## Verified
A driver linked against the built library shows a default config emits **no** warning and resolves to Gaussian, while explicitly setting `VSOptimalL1` emits the warning **exactly once** and still resolves to Gaussian. Warning-free build, suite 14/14.
