### PR TITLE
Implement the L1 optimal camera path (Grundmann et al. 2011)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static libraries"
        ON)
 
 option(USE_OMP "use parallelization use OMP" ON)
+option(USE_GLPK "use GLPK as the LP solver for the L1 optimal camera path" ON)
 
 set(CMAKE_C_STANDARD 99)
 
@@ -63,6 +64,20 @@ set(SOURCES src/frameinfo.c src/transformtype.c src/libvidstab.c
   src/motiondetect_opt.c src/serialize.c src/localmotion2transform.c
   src/boxblur.c src/vsvector.c)
 
+# The L1 optimal camera path (Grundmann et al. 2011) needs a linear program
+# solver.  Without one the VSOptimalL1 setting silently falls back to the
+# gaussian filter, so the solver stays entirely optional.
+if(USE_GLPK)
+  find_package(GLPK)
+endif()
+if(GLPK_FOUND)
+  list(APPEND SOURCES src/l1campathoptimization.c src/lpsolver_glpk.c)
+  add_definitions(-DUSE_GLPK -DVS_HAVE_LPSOLVER)
+  message(STATUS "L1 optimal camera path enabled (GLPK ${GLPK_VERSION})")
+else()
+  message(STATUS "L1 optimal camera path disabled (no LP solver found)")
+endif()
+
 set(HEADERS src/frameinfo.h src/transformtype.h src/libvidstab.h
   src/transform.h src/motiondetect.h src/serialize.h
   src/localmotion2transform.h src/boxblur.h src/vsvector.h )
@@ -85,6 +100,10 @@ if (NOT MSVC)
   target_link_libraries(vidstab m)
 endif ()
 set(PKG_EXTRA_LIBS -lm)
+if(GLPK_FOUND)
+  target_link_libraries(vidstab GLPK::GLPK)
+  set(PKG_EXTRA_LIBS "${PKG_EXTRA_LIBS} -lglpk")
+endif()
 if(USE_OMP AND OPENMP_FOUND)
 if(TARGET OpenMP::OpenMP_C)
 target_link_libraries(vidstab OpenMP::OpenMP_C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static libraries"
        ON)
 
 option(USE_OMP "use parallelization use OMP" ON)
-option(USE_GLPK "use GLPK as the LP solver for the L1 optimal camera path" ON)
 
 set(CMAKE_C_STANDARD 99)
 
@@ -64,19 +63,29 @@ set(SOURCES src/frameinfo.c src/transformtype.c src/libvidstab.c
   src/motiondetect_opt.c src/serialize.c src/localmotion2transform.c
   src/boxblur.c src/vsvector.c)
 
-# The L1 optimal camera path (Grundmann et al. 2011) needs a linear program
-# solver.  Without one the VSOptimalL1 setting silently falls back to the
-# gaussian filter, so the solver stays entirely optional.
-if(USE_GLPK)
+# --- LP solver backend for the L1 optimal camera path -------------------------
+# The built-in interior point solver keeps vid.stab dependency free; GLPK can be
+# selected instead and serves as the cross-check in the test suite.
+set(VIDSTAB_LPSOLVER "builtin" CACHE STRING
+    "LP solver for the L1 optimal camera path: builtin or glpk")
+set_property(CACHE VIDSTAB_LPSOLVER PROPERTY STRINGS builtin glpk)
+
+set(LP_SOURCES src/l1campathoptimization.c src/lpsolver_ipm.c)
+set(LP_DEFS -DUSE_IPM -DVS_HAVE_LPSOLVER)
+set(LP_BACKEND "built-in interior point")
+if(VIDSTAB_LPSOLVER STREQUAL "glpk")
   find_package(GLPK)
+  if(GLPK_FOUND)
+    set(LP_SOURCES src/l1campathoptimization.c src/lpsolver_glpk.c)
+    set(LP_DEFS -DUSE_GLPK -DVS_HAVE_LPSOLVER)
+    set(LP_BACKEND "GLPK ${GLPK_VERSION}")
+  else()
+    message(WARNING "VIDSTAB_LPSOLVER=glpk but GLPK was not found, using the built-in solver")
+  endif()
 endif()
-if(GLPK_FOUND)
-  list(APPEND SOURCES src/l1campathoptimization.c src/lpsolver_glpk.c)
-  add_definitions(-DUSE_GLPK -DVS_HAVE_LPSOLVER)
-  message(STATUS "L1 optimal camera path enabled (GLPK ${GLPK_VERSION})")
-else()
-  message(STATUS "L1 optimal camera path disabled (no LP solver found)")
-endif()
+add_definitions(${LP_DEFS})
+message(STATUS "L1 optimal camera path LP solver: ${LP_BACKEND}")
+list(APPEND SOURCES ${LP_SOURCES})
 
 set(HEADERS src/frameinfo.h src/transformtype.h src/libvidstab.h
   src/transform.h src/motiondetect.h src/serialize.h
@@ -100,7 +109,7 @@ if (NOT MSVC)
   target_link_libraries(vidstab m)
 endif ()
 set(PKG_EXTRA_LIBS -lm)
-if(GLPK_FOUND)
+if(GLPK_FOUND AND VIDSTAB_LPSOLVER STREQUAL "glpk")
   target_link_libraries(vidstab GLPK::GLPK)
   set(PKG_EXTRA_LIBS "${PKG_EXTRA_LIBS} -lglpk")
 endif()

--- a/CMakeModules/FindGLPK.cmake
+++ b/CMakeModules/FindGLPK.cmake
@@ -1,0 +1,57 @@
+# find GLPK (GNU Linear Programming Kit)
+#
+# defines
+#   GLPK_FOUND
+#   GLPK_INCLUDE_DIRS
+#   GLPK_LIBRARIES
+# and the imported target GLPK::GLPK
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_GLPK QUIET glpk)
+endif()
+
+find_path(GLPK_INCLUDE_DIR
+  NAMES glpk.h
+  HINTS ${PC_GLPK_INCLUDEDIR} ${PC_GLPK_INCLUDE_DIRS} $ENV{GLPK_DIR}/include
+  PATH_SUFFIXES glpk
+  DOC "Directory containing glpk.h")
+
+find_library(GLPK_LIBRARY
+  NAMES glpk
+  HINTS ${PC_GLPK_LIBDIR} ${PC_GLPK_LIBRARY_DIRS} $ENV{GLPK_DIR}/lib
+  DOC "Path to the GLPK library")
+
+if(PC_GLPK_VERSION)
+  set(GLPK_VERSION ${PC_GLPK_VERSION})
+elseif(GLPK_INCLUDE_DIR AND EXISTS "${GLPK_INCLUDE_DIR}/glpk.h")
+  file(STRINGS "${GLPK_INCLUDE_DIR}/glpk.h" _glpk_major
+       REGEX "^#define[ \t]+GLP_MAJOR_VERSION[ \t]+[0-9]+")
+  file(STRINGS "${GLPK_INCLUDE_DIR}/glpk.h" _glpk_minor
+       REGEX "^#define[ \t]+GLP_MINOR_VERSION[ \t]+[0-9]+")
+  string(REGEX REPLACE ".*[ \t]([0-9]+).*" "\\1" _glpk_major "${_glpk_major}")
+  string(REGEX REPLACE ".*[ \t]([0-9]+).*" "\\1" _glpk_minor "${_glpk_minor}")
+  # note the MATCHES rather than a plain truth test: GLP_MINOR_VERSION is 0 for
+  # GLPK 5.0, and "0" is false in CMake
+  if(_glpk_major MATCHES "^[0-9]+$" AND _glpk_minor MATCHES "^[0-9]+$")
+    set(GLPK_VERSION "${_glpk_major}.${_glpk_minor}")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GLPK
+  REQUIRED_VARS GLPK_LIBRARY GLPK_INCLUDE_DIR
+  VERSION_VAR GLPK_VERSION)
+
+if(GLPK_FOUND)
+  set(GLPK_LIBRARIES ${GLPK_LIBRARY})
+  set(GLPK_INCLUDE_DIRS ${GLPK_INCLUDE_DIR})
+  if(NOT TARGET GLPK::GLPK)
+    add_library(GLPK::GLPK UNKNOWN IMPORTED)
+    set_target_properties(GLPK::GLPK PROPERTIES
+      IMPORTED_LOCATION "${GLPK_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${GLPK_INCLUDE_DIR}")
+  endif()
+endif()
+
+mark_as_advanced(GLPK_INCLUDE_DIR GLPK_LIBRARY)

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+1.2	L1-optimal camera path (Grundmann et al., CVPR 2011) implemented and
+	enabled: camPathAlgo=VSOptimalL1 now really runs the optimization
+	instead of falling back to the gaussian filter.  New config fields
+	pathD1Weight, pathD2Weight, pathD3Weight and pathMaxZoom; callers
+	that leave them at zero get the defaults.
+	Built-in interior point LP solver, no external dependency; GLPK
+	selectable with cmake -DVIDSTAB_LPSOLVER=glpk.
 1.1     use openMP to do parallel execution
 1.0 = 0.98 (just because of API changes the version number was bumped
 0.98...

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A video acquired using a hand-held camera or a camera mounted on a vehicle, typi
 
  * Fast detection of subsequent transformations e.g. translation and rotations up to a given extent.
  * Low pass filtered smoothing with adjustable horizon.
+ * L1-optimal camera path (Grundmann et al., CVPR 2011): the stabilized path is
+   composed of static, linear and parabolic segments, giving a result that looks
+   like it came off a dolly or a crane rather than off a low-pass filter. Solved
+   as a linear program with a built-in solver, so it needs no extra dependency.
  * Detection algorithms:
   * Smart and fast multi measurement fields algorithm with contrast selection.
   * Brute force algorithm only for translations.
@@ -30,6 +34,11 @@ A video acquired using a hand-held camera or a camera mounted on a vehicle, typi
  * A Linux-based system
  * ffmpeg source code
  * Cmake
+
+The L1-optimal camera path is solved with a built-in interior point solver and
+needs nothing else. GLPK can be used instead with `cmake -DVIDSTAB_LPSOLVER=glpk`;
+the test suite runs against either and cross-checks both against the reference
+implementation in `docs/l1campath-reference.py`.
 
 ## Installation Instructions
 

--- a/docs/l1campath-reference.py
+++ b/docs/l1campath-reference.py
@@ -194,6 +194,28 @@ def frame_pairs(N):
     return np.array(F)
 
 
+def true_objective(F, upd, **kw):
+    """Objective evaluated directly from the update transforms, the same way
+    objectiveOf() in l1campathoptimization.c does it.  The value linprog
+    reports also contains the slack variables, which a solver that stops just
+    short of optimality has not pushed all the way down, so it is not
+    comparable across solvers; this is."""
+    conf = dict(DEFAULTS); conf.update(kw)
+    N = len(F)
+    lay = Layout(N)
+    flat = np.asarray(upd).reshape(-1)
+    weights = (conf["w1"], conf["w2"], conf["w3"])
+    total = 0.0
+    for order in (1, 2, 3):
+        for t in range(N - order):
+            r = residual(order, F, t, lay)
+            for p in (X, Y, A, B):
+                lin, konst = r[p]
+                val = konst + sum(c * flat[j] for j, c in lin.items())
+                total += weights[order-1] * (conf["w_affine"] if p in (A, B) else 1.0) * abs(val)
+    return total
+
+
 def diffnorm(P, order):
     d = P * np.array([1.0, 1.0, 100.0, 100.0])
     for _ in range(order):
@@ -204,12 +226,17 @@ def diffnorm(P, order):
 if __name__ == "__main__":
     W, H = 640.0, 480.0
 
-    N = 24
-    F = frame_pairs(N)
-    upd, obj = solve(F, W, H)
-    print(f"N = {N}, reference objective = {obj:.10g}")
+    for N in (24, 200):
+        F = frame_pairs(N)
+        upd, obj = solve(F, W, H)
+        print(f"N = {N:3d}: linprog reported {obj:.10g}, true objective "
+              f"{true_objective(F, upd):.12g}")
     print()
-    print("  #define L1_REFERENCE_OBJECTIVE %.12g" % obj)
+    print("  /* tests/test_campathopt.c */")
+    for N, name in ((24, "L1_REFERENCE_OBJECTIVE_24"), (200, "L1_REFERENCE_OBJECTIVE_200")):
+        F = frame_pairs(N)
+        upd, _ = solve(F, W, H)
+        print("  #define %s %.12g" % (name, true_objective(F, upd)))
     print()
 
     for N in (60, 200):

--- a/docs/l1campath-reference.py
+++ b/docs/l1campath-reference.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Independent reference implementation of the L1 optimal camera path LP.
+
+This mirrors src/l1campathoptimization.c exactly -- same parametrisation, same
+residuals, same constraints -- but builds the problem with numpy and solves it
+with scipy/HiGHS instead of the vendored solver.  It exists so that the model
+in the C code can be cross-checked against something that was written from the
+paper independently of it:
+
+  Grundmann, Kwatra, Essa: "Auto-Directed Video Stabilization with Robust L1
+  Optimal Camera Paths", CVPR 2011.
+
+Run it to obtain the value that tests/test_campathopt.c compares against:
+
+    python3 docs/l1campath-reference.py
+
+Requires numpy and scipy; neither is needed to build or test vid.stab.
+"""
+
+import math
+import numpy as np
+from scipy.optimize import linprog
+
+X, Y, A, B = 0, 1, 2, 3
+
+
+# ------------------------------------------------------- similarity transforms
+#
+#     [ a  b  x ]
+#     [-b  a  y ]   stored as (x, y, a, b), acting on centre-relative coords
+#     [ 0  0  1 ]
+
+def ident():
+    return np.array([0.0, 0.0, 1.0, 0.0])
+
+
+def concat(t1, t2):
+    """matrix product t1 * t2, i.e. t2 applied first"""
+    x1, y1, a1, b1 = t1
+    x2, y2, a2, b2 = t2
+    return np.array([a1 * x2 + b1 * y2 + x1,
+                     -b1 * x2 + a1 * y2 + y1,
+                     a1 * a2 - b1 * b2,
+                     a1 * b2 + b1 * a2])
+
+
+def invert(t):
+    x, y, a, b = t
+    z = a * a + b * b
+    ra, rb = a / z, -b / z
+    return np.array([-(ra * x + rb * y), -(-rb * x + ra * y), ra, rb])
+
+
+def apply_pt(t, px, py):
+    x, y, a, b = t
+    return a * px + b * py + x, -b * px + a * py + y
+
+
+# ------------------------------------------------------------ the LP, verbatim
+
+class Layout:
+    """same numbering as vs_l1_col / vs_l1_row in the C code"""
+
+    def __init__(self, N):
+        self.N = N
+
+    def col(self, group, t, param):
+        return 4 * (group * self.N - (group * (group - 1)) // 2) + 4 * t + param
+
+    def numcols(self):
+        return self.col(3, self.N - 3, 0)
+
+
+def mul_FB(r, F, t, s, lay):
+    """accumulate s * (F B_t) into the four component expressions r"""
+    fx, fy, fa, fb = F
+    r[X][0][lay.col(0, t, X)] = r[X][0].get(lay.col(0, t, X), 0.0) + s * fa
+    r[X][0][lay.col(0, t, Y)] = r[X][0].get(lay.col(0, t, Y), 0.0) + s * fb
+    r[X][1] += s * fx
+    r[Y][0][lay.col(0, t, X)] = r[Y][0].get(lay.col(0, t, X), 0.0) - s * fb
+    r[Y][0][lay.col(0, t, Y)] = r[Y][0].get(lay.col(0, t, Y), 0.0) + s * fa
+    r[Y][1] += s * fy
+    r[A][0][lay.col(0, t, A)] = r[A][0].get(lay.col(0, t, A), 0.0) + s * fa
+    r[A][0][lay.col(0, t, B)] = r[A][0].get(lay.col(0, t, B), 0.0) - s * fb
+    r[B][0][lay.col(0, t, A)] = r[B][0].get(lay.col(0, t, A), 0.0) + s * fb
+    r[B][0][lay.col(0, t, B)] = r[B][0].get(lay.col(0, t, B), 0.0) + s * fa
+
+
+def add_B(r, t, s, lay):
+    for p in (X, Y, A, B):
+        r[p][0][lay.col(0, t, p)] = r[p][0].get(lay.col(0, t, p), 0.0) + s
+
+
+def residual(order, F, t, lay):
+    """eqs. (4)-(6) with R_t = F_{t+1} B_{t+1} - B_t"""
+    r = [[{}, 0.0] for _ in range(4)]
+    if order == 1:
+        mul_FB(r, F[t + 1], t + 1, +1.0, lay)
+        add_B(r, t, -1.0, lay)
+    elif order == 2:
+        mul_FB(r, F[t + 2], t + 2, +1.0, lay)
+        add_B(r, t + 1, -1.0, lay)
+        mul_FB(r, F[t + 1], t + 1, -1.0, lay)
+        add_B(r, t, +1.0, lay)
+    elif order == 3:
+        mul_FB(r, F[t + 3], t + 3, +1.0, lay)
+        add_B(r, t + 2, -1.0, lay)
+        mul_FB(r, F[t + 2], t + 2, -2.0, lay)
+        add_B(r, t + 1, +2.0, lay)
+        mul_FB(r, F[t + 1], t + 1, +1.0, lay)
+        add_B(r, t, -1.0, lay)
+    return r
+
+
+DEFAULTS = dict(w1=10.0, w2=1.0, w3=100.0, w_affine=100.0,
+                crop_ratio=1.0 / 1.15, min_scale=1.0, max_scale=1.1,
+                max_skew=0.1)
+
+
+def solve(F, width, height, **kw):
+    conf = dict(DEFAULTS)
+    conf.update(kw)
+    N = len(F)
+    lay = Layout(N)
+    ncols = lay.numcols()
+
+    c = np.zeros(ncols)
+    A_ub, b_ub = [], []
+
+    def add_row(coeffs, rhs):
+        row = np.zeros(ncols)
+        for j, v in coeffs.items():
+            row[j] += v
+        A_ub.append(row)
+        b_ub.append(rhs)
+
+    weights = (conf["w1"], conf["w2"], conf["w3"])
+    for order in (1, 2, 3):
+        for t in range(N - order):
+            r = residual(order, F, t, lay)
+            for p in (X, Y, A, B):
+                lin, konst = r[p]
+                ecol = lay.col(order, t, p)
+                c[ecol] = weights[order - 1] * (conf["w_affine"]
+                                                if p in (A, B) else 1.0)
+                # -e <= lin + konst <= e
+                add_row({**lin, ecol: -1.0}, -konst)
+                add_row({**{k: -v for k, v in lin.items()}, ecol: -1.0}, konst)
+
+    # inclusion: the four crop corners, transformed by B_t, stay in the frame
+    x2, y2 = width / 2.0, height / 2.0
+    cw, ch = x2 * conf["crop_ratio"], y2 * conf["crop_ratio"]
+    for t in range(N):
+        for (cx, cy) in [(-cw, -ch), (cw, -ch), (cw, ch), (-cw, ch)]:
+            row = {lay.col(0, t, X): 1.0, lay.col(0, t, A): cx,
+                   lay.col(0, t, B): cy}
+            add_row(row, x2)
+            add_row({k: -v for k, v in row.items()}, x2)
+            row = {lay.col(0, t, Y): 1.0, lay.col(0, t, B): -cx,
+                   lay.col(0, t, A): cy}
+            add_row(row, y2)
+            add_row({k: -v for k, v in row.items()}, y2)
+
+    # proximity on B, non-negativity on the slacks
+    bounds = []
+    for _ in range(N):
+        bounds += [(None, None), (None, None),
+                   (conf["min_scale"], conf["max_scale"]),
+                   (-conf["max_skew"], conf["max_skew"])]
+    bounds += [(0.0, None)] * (ncols - 4 * N)
+
+    res = linprog(c, A_ub=np.array(A_ub), b_ub=np.array(b_ub), bounds=bounds,
+                  method="highs")
+    if not res.success:
+        raise RuntimeError(res.message)
+    return res.x[:4 * N].reshape(N, 4), res.fun
+
+
+# ------------------------------------- the synthetic path used by the C tests
+
+def ground_truth(t):
+    """must stay identical to campath_ground_truth() in tests/test_campathopt.c"""
+    s = float(t)
+    ang = 0.02 * math.sin(s * 0.11) + 0.01 * math.sin(s * 1.9)
+    return np.array([12.0 * s + 5.0 * math.sin(s * 1.7),
+                     20.0 * math.sin(s * 0.05) + 3.0 * math.cos(s * 2.3),
+                     math.cos(ang), math.sin(ang)])
+
+
+def frame_pairs(N):
+    F = [ident()]
+    for t in range(1, N):
+        F.append(concat(invert(ground_truth(t - 1)), ground_truth(t)))
+    return np.array(F)
+
+
+def diffnorm(P, order):
+    d = P * np.array([1.0, 1.0, 100.0, 100.0])
+    for _ in range(order):
+        d = np.diff(d, axis=0)
+    return float(np.abs(d).sum())
+
+
+if __name__ == "__main__":
+    W, H = 640.0, 480.0
+
+    N = 24
+    F = frame_pairs(N)
+    upd, obj = solve(F, W, H)
+    print(f"N = {N}, reference objective = {obj:.10g}")
+    print()
+    print("  #define L1_REFERENCE_OBJECTIVE %.12g" % obj)
+    print()
+
+    for N in (60, 200):
+        F = frame_pairs(N)
+        C = np.array([ground_truth(t) for t in range(N)])
+        upd, obj = solve(F, W, H)
+        P = np.array([concat(C[t], upd[t]) for t in range(N)])
+        print(f"N = {N}: objective {obj:12.4f}", end="")
+        for o in (1, 2, 3):
+            print(f"   |D^{o}| {diffnorm(C, o):9.2f} -> {diffnorm(P, o):8.2f}",
+                  end="")
+        print()

--- a/src/l1campathoptimization.c
+++ b/src/l1campathoptimization.c
@@ -102,11 +102,19 @@ VSTransform transformLStoAZ(const VSTransformLS* t){
  *   group 2:  e^2_t,     t = 0 .. N-3   slack bounding |D^2(P)|
  *   group 3:  e^3_t,     t = 0 .. N-4   slack bounding |D^3(P)|
  *
- * Rows (8 per order and time step: 4 parameters x lower/upper):
- *   order 1:  t = 0 .. N-2
- *   order 2:  t = 0 .. N-3
- *   order 3:  t = 0 .. N-4
- *   then 8 inclusion rows per t = 0 .. N-1 (4 crop corners x 2 coordinates)
+ * Rows are grouped by time step, 8 inclusion rows (4 crop corners x 2
+ * coordinates) followed by 8 rows for every derivative order that is still
+ * defined at t (4 parameters x lower/upper bound):
+ *
+ *   t = 0 .. N-4 : inclusion, order 1, order 2, order 3   (32 rows)
+ *   t = N-3      : inclusion, order 1, order 2            (24 rows)
+ *   t = N-2      : inclusion, order 1                     (16 rows)
+ *   t = N-1      : inclusion                              ( 8 rows)
+ *
+ * Grouping by time rather than by order is what keeps the constraint matrix
+ * banded: a row at time t only touches B_t .. B_{t+3}, so two rows share a
+ * column only if their time steps are at most 3 apart.  The interior point
+ * backend relies on that to factorize the normal equations in O(N).
  * ************************************************************************** */
 
 enum { PX = 0, PY = 1, PA = 2, PB = 3 };
@@ -118,20 +126,32 @@ int vs_l1_col(int group, int t, int param, int N){
   return 4 * (group * N - (group * (group - 1)) / 2) + 4 * t + param;
 }
 
-/** row of the smoothness constraint of the given order (1..3).
-    upperorlower is 0 for the lower and 1 for the upper bound.
-    Passing order 4 with t = param = 0 yields the first inclusion row. */
-int vs_l1_row(int order, int t, int param, int upperorlower, int N){
-  return 8 * ((order - 1) * N - (order * (order - 1)) / 2)
-         + 8 * t + 2 * param + upperorlower;
+/** number of rows belonging to time step t */
+static int vs_l1_rowsAt(int t, int N){
+  return 8 + (t < N - 1 ? 8 : 0) + (t < N - 2 ? 8 : 0) + (t < N - 3 ? 8 : 0);
+}
+
+/** index of the first row of time step t */
+int vs_l1_rowBase(int t, int N){
+  /* every time step before N-3 contributes the full 32 rows */
+  int full = (t < N - 3) ? t : (N - 3);
+  int base = 32 * full;
+  for (int k = N - 3; k < t; k++) base += vs_l1_rowsAt(k, N);
+  return base;
 }
 
 /** inclusion row k = 0..7 of time step t */
-static int vs_l1_rowCorner(int t, int k, int N){
-  return vs_l1_row(4, 0, 0, 0, N) + 8 * t + k;
+int vs_l1_rowCorner(int t, int k, int N){
+  return vs_l1_rowBase(t, N) + k;
 }
 
-int vs_l1_numrows(int N){ return vs_l1_row(4, 0, 0, 0, N) + 8 * N; }
+/** row of the smoothness constraint of the given order (1..3).
+    upperorlower is 0 for the lower and 1 for the upper bound. */
+int vs_l1_row(int order, int t, int param, int upperorlower, int N){
+  return vs_l1_rowBase(t, N) + 8 * order + 2 * param + upperorlower;
+}
+
+int vs_l1_numrows(int N){ return vs_l1_rowBase(N - 1, N) + 8; }
 int vs_l1_numcols(int N){ return vs_l1_col(3, N - 3, 0, N); }
 
 /** upper bound on the number of nonzero matrix entries:
@@ -247,6 +267,91 @@ static void emitPair(VSLinProg* lp, int rowlo, int rowup, int ecol,
   vs_lp_set_row_bounds(lp, rowup, -VS_LP_INF, -e->konst);
 }
 
+/** value of a residual at a given point */
+static double exprEval(const L1Expr* e, const double* x){
+  double s = e->konst;
+  for (int i = 0; i < e->n; i++) s += e->val[i] * x[e->col[i]];
+  return s;
+}
+
+/** Objective of a candidate solution, evaluated directly from B rather than
+    taken from the solver.
+
+    The slack variables of the program are only pushed down to |residual| by the
+    objective, so a solver that stops slightly short of optimality reports a
+    value that is not the objective of the B it returns -- it can even be below
+    the true optimum.  Recomputing here makes the number exact and comparable
+    across backends. */
+static double objectiveOf(const VSTransformLS* F, int N, const VSL1Config* conf,
+                          const double* Bflat){
+  const double weight[3] = { conf->w1, conf->w2, conf->w3 };
+  double total = 0.0;
+  L1Expr r[4];
+  for (int order = 1; order <= 3; order++) {
+    for (int t = 0; t < N - order; t++) {
+      buildResidual(r, order, F, t, N);
+      for (int p = PX; p <= PB; p++) {
+        double w = weight[order - 1] * ((p == PA || p == PB) ? conf->wAffine : 1.0);
+        total += w * fabs(exprEval(&r[p], Bflat));
+      }
+    }
+  }
+  return total;
+}
+
+/** Removes any residual constraint violation.
+
+    The inclusion and proximity constraints are only satisfied up to whatever
+    accuracy the solver reached.  Both describe a convex set that contains the
+    identity transform, so shrinking B_t towards the identity restores
+    feasibility exactly, and because the violation is tiny the shrink factor is
+    1 or a hair below it.  This is what turns "the LP said so" into an actual
+    guarantee that the crop window never leaves the frame. */
+static void enforceFeasibility(VSTransformLS* B, int N, const VSL1Config* conf){
+  const double x2 = conf->frameWidth  / 2.0;
+  const double y2 = conf->frameHeight / 2.0;
+  const double cw = x2 * conf->cropRatio;
+  const double ch = y2 * conf->cropRatio;
+  const double cornerx[4] = { -cw,  cw, cw, -cw };
+  const double cornery[4] = { -ch, -ch, ch,  ch };
+
+  for (int t = 0; t < N; t++) {
+    double lambda = 1.0;
+    /* value at the identity, and the difference to the candidate, for every
+       constraint; feasibility is affine in lambda */
+    double idv[12], curv[12], lo[12], up[12];
+    int n = 0;
+    for (int i = 0; i < 4; i++) {
+      double ix, iy, bx, by;
+      VSTransformLS id = id_transformLS();
+      transformLS_vec(&ix, &iy, &id,   cornerx[i], cornery[i]);
+      transformLS_vec(&bx, &by, &B[t], cornerx[i], cornery[i]);
+      idv[n] = ix; curv[n] = bx; lo[n] = -x2; up[n] = x2; n++;
+      idv[n] = iy; curv[n] = by; lo[n] = -y2; up[n] = y2; n++;
+    }
+    idv[n] = 1.0; curv[n] = B[t].a; lo[n] = conf->minScale; up[n] = conf->maxScale; n++;
+    idv[n] = 0.0; curv[n] = B[t].b; lo[n] = -conf->maxSkewDev; up[n] = conf->maxSkewDev; n++;
+
+    for (int i = 0; i < n; i++) {
+      double d = curv[i] - idv[i];
+      if (d > 0.0 && curv[i] > up[i]) {
+        double l = (up[i] - idv[i]) / d;
+        if (l < lambda) lambda = l;
+      } else if (d < 0.0 && curv[i] < lo[i]) {
+        double l = (lo[i] - idv[i]) / d;
+        if (l < lambda) lambda = l;
+      }
+    }
+    if (lambda < 0.0) lambda = 0.0;
+    if (lambda < 1.0) {
+      B[t].x = lambda * B[t].x;
+      B[t].y = lambda * B[t].y;
+      B[t].a = 1.0 + lambda * (B[t].a - 1.0);
+      B[t].b = lambda * B[t].b;
+    }
+  }
+}
+
 /* ************************************************************************* */
 
 VSL1Config vsL1GetDefaultConfig(void){
@@ -286,9 +391,16 @@ int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N, VSTransformLS* B,
 
   /* --- columns: B is free except for the proximity bounds, the slacks are
      non-negative and carry the whole objective --------------------------- */
+  const double x2 = conf->frameWidth  / 2.0;
+  const double y2 = conf->frameHeight / 2.0;
   for (int t = 0; t < N; t++) {
-    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PX, N), -VS_LP_INF, VS_LP_INF);
-    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PY, N), -VS_LP_INF, VS_LP_INF);
+    /* |B.x| <= x2 and |B.y| <= y2 are implied by the inclusion rows below:
+       averaging the two rows of a pair of opposite corners cancels the a and b
+       terms and leaves exactly these bounds.  Stating them explicitly costs
+       nothing, tightens the relaxation, and gives every variable of the
+       program a finite lower bound, which the interior point backend needs. */
+    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PX, N), -x2, x2);
+    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PY, N), -y2, y2);
     /* proximity constraints, section 2.1 of the paper: keep the update
        transform close to the identity so the crop does not distort */
     vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PA, N),
@@ -325,8 +437,6 @@ int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N, VSTransformLS* B,
   /* --- inclusion rows: all four corners of the crop rectangle, transformed
      by B_t, have to stay inside the frame rectangle (eq. 8, in coordinates
      relative to the frame centre) ---------------------------------------- */
-  const double x2 = conf->frameWidth  / 2.0;
-  const double y2 = conf->frameHeight / 2.0;
   const double cw = x2 * conf->cropRatio;
   const double ch = y2 * conf->cropRatio;
   const double cornerx[4] = { -cw,  cw, cw, -cw };
@@ -364,8 +474,22 @@ int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N, VSTransformLS* B,
     B[t].b     = vs_lp_get_col_value(lp, vs_l1_col(0, t, PB, N));
     B[t].extra = 0;
   }
-  if (objective) *objective = vs_lp_get_obj_value(lp);
   vs_lp_free(lp);
+
+  enforceFeasibility(B, N, conf);
+  if (objective) {
+    double* Bflat = (double*)vs_malloc(sizeof(double) * 4 * N);
+    if (Bflat) {
+      for (int t = 0; t < N; t++) {
+        Bflat[vs_l1_col(0, t, PX, N)] = B[t].x;
+        Bflat[vs_l1_col(0, t, PY, N)] = B[t].y;
+        Bflat[vs_l1_col(0, t, PA, N)] = B[t].a;
+        Bflat[vs_l1_col(0, t, PB, N)] = B[t].b;
+      }
+      *objective = objectiveOf(F, N, conf, Bflat);
+      vs_free(Bflat);
+    }
+  }
   return VS_OK;
 }
 

--- a/src/l1campathoptimization.c
+++ b/src/l1campathoptimization.c
@@ -1,0 +1,477 @@
+/*
+ *  l1campathoptimization.c
+ *
+ *  Copyright (C) Georg Martius - January 2014 - 2026
+ *   georg dot martius at web dot de
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+
+#include "l1campathoptimization.h"
+#include "transform_internal.h"
+#include "transformtype_operations.h"
+#include "vidstabdefines.h"
+#include "lpsolver.h"
+
+#include <math.h>
+#include <string.h>
+
+/* ****************************************************************************
+ * operations on VSTransformLS
+ * ************************************************************************** */
+
+VSTransformLS id_transformLS(void){
+  VSTransformLS t = { 0.0, 0.0, 1.0, 0.0, 0 };
+  return t;
+}
+
+/* matrix product t1 * t2, i.e. t2 is applied first.  With
+     [ a  b  x ]           (t1 t2).x = a1 x2 + b1 y2 + x1
+     [-b  a  y ]           (t1 t2).a = a1 a2 - b1 b2
+   this is just the product of the two similarity matrices. */
+VSTransformLS concat_transformLS(const VSTransformLS* t1, const VSTransformLS* t2){
+  VSTransformLS t;
+  t.x     = t1->a * t2->x + t1->b * t2->y + t1->x;
+  t.y     = -t1->b * t2->x + t1->a * t2->y + t1->y;
+  t.a     = t1->a * t2->a - t1->b * t2->b;
+  t.b     = t1->a * t2->b + t1->b * t2->a;
+  t.extra = t1->extra || t2->extra;
+  return t;
+}
+
+VSTransformLS invert_transformLS(const VSTransformLS* t){
+  VSTransformLS r;
+  double z = t->a * t->a + t->b * t->b;
+  if (z == 0.0) return id_transformLS();  // degenerate, should not happen
+  r.a     =  t->a / z;
+  r.b     = -t->b / z;
+  r.x     = -(r.a * t->x + r.b * t->y);
+  r.y     = -(-r.b * t->x + r.a * t->y);
+  r.extra = t->extra;
+  return r;
+}
+
+void transformLS_vec(double* rx, double* ry, const VSTransformLS* t,
+                     double x, double y){
+  *rx =  t->a * x + t->b * y + t->x;
+  *ry = -t->b * x + t->a * y + t->y;
+}
+
+VSTransformLS transformAZtoLS(const VSTransform* t){
+  VSTransformLS r;
+  double z = 1.0 + t->zoom / 100.0;
+  r.x     = t->x;
+  r.y     = t->y;
+  r.a     = z * cos(t->alpha);
+  r.b     = z * sin(t->alpha);
+  r.extra = t->extra;
+  return r;
+}
+
+VSTransform transformLStoAZ(const VSTransformLS* t){
+  VSTransform r = null_transform();
+  r.x     = t->x;
+  r.y     = t->y;
+  r.alpha = atan2(t->b, t->a);
+  r.zoom  = (sqrt(t->a * t->a + t->b * t->b) - 1.0) * 100.0;
+  r.extra = t->extra;
+  return r;
+}
+
+/* ****************************************************************************
+ * layout of the linear program
+ *
+ * Columns (4 per group and time step, in the order x, y, a, b):
+ *   group 0:  B_t,       t = 0 .. N-1   the update transforms
+ *   group 1:  e^1_t,     t = 0 .. N-2   slack bounding |D(P)|
+ *   group 2:  e^2_t,     t = 0 .. N-3   slack bounding |D^2(P)|
+ *   group 3:  e^3_t,     t = 0 .. N-4   slack bounding |D^3(P)|
+ *
+ * Rows (8 per order and time step: 4 parameters x lower/upper):
+ *   order 1:  t = 0 .. N-2
+ *   order 2:  t = 0 .. N-3
+ *   order 3:  t = 0 .. N-4
+ *   then 8 inclusion rows per t = 0 .. N-1 (4 crop corners x 2 coordinates)
+ * ************************************************************************** */
+
+enum { PX = 0, PY = 1, PA = 2, PB = 3 };
+
+/** first column of group `group` (0 = B, 1..3 = slack of that order).
+    Group g starts after the groups before it, which hold N, N-1, N-2 entries
+    of 4 columns each: 4*(g*N - g(g-1)/2). */
+int vs_l1_col(int group, int t, int param, int N){
+  return 4 * (group * N - (group * (group - 1)) / 2) + 4 * t + param;
+}
+
+/** row of the smoothness constraint of the given order (1..3).
+    upperorlower is 0 for the lower and 1 for the upper bound.
+    Passing order 4 with t = param = 0 yields the first inclusion row. */
+int vs_l1_row(int order, int t, int param, int upperorlower, int N){
+  return 8 * ((order - 1) * N - (order * (order - 1)) / 2)
+         + 8 * t + 2 * param + upperorlower;
+}
+
+/** inclusion row k = 0..7 of time step t */
+static int vs_l1_rowCorner(int t, int k, int N){
+  return vs_l1_row(4, 0, 0, 0, N) + 8 * t + k;
+}
+
+int vs_l1_numrows(int N){ return vs_l1_row(4, 0, 0, 0, N) + 8 * N; }
+int vs_l1_numcols(int N){ return vs_l1_col(3, N - 3, 0, N); }
+
+/** upper bound on the number of nonzero matrix entries:
+    order 1 rows have 4, order 2 rows have 6, order 3 rows have 8 and
+    inclusion rows have 3 entries. */
+static int vs_l1_maxentries(int N){
+  return 8 * (N - 1) * 4 + 8 * (N - 2) * 6 + 8 * (N - 3) * 8 + 8 * N * 3;
+}
+
+/* ****************************************************************************
+ * building the residuals
+ *
+ * A residual is held as a sparse linear expression over the B columns plus a
+ * constant, so that
+ *
+ *     residual = sum_i val[i] * x[col[i]] + konst.
+ *
+ * Both the lower and the upper constraint row of a residual are emitted from
+ * that single expression, which is what keeps the two rows of a pair in sync.
+ * ************************************************************************** */
+
+#define L1_MAXTERMS 12
+
+typedef struct {
+  int    col[L1_MAXTERMS];
+  double val[L1_MAXTERMS];
+  int    n;
+  double konst;
+} L1Expr;
+
+static void exprReset(L1Expr* e){ e->n = 0; e->konst = 0.0; }
+
+static void exprAdd(L1Expr* e, int col, double v){
+  if (v == 0.0) return;
+  for (int i = 0; i < e->n; i++) {
+    if (e->col[i] == col) { e->val[i] += v; return; }
+  }
+  if (e->n >= L1_MAXTERMS) return;  // cannot happen, see L1_MAXTERMS
+  e->col[e->n] = col;
+  e->val[e->n] = v;
+  e->n++;
+}
+
+/** accumulates s * (F B_t) into the four component expressions r.
+      (F B).x =  fa Bx + fb By + fx        (F B).a = fa Ba - fb Bb
+      (F B).y = -fb Bx + fa By + fy        (F B).b = fa Bb + fb Ba  */
+static void exprAddFB(L1Expr r[4], const VSTransformLS* F, int t, double s, int N){
+  exprAdd(&r[PX], vs_l1_col(0, t, PX, N),  s * F->a);
+  exprAdd(&r[PX], vs_l1_col(0, t, PY, N),  s * F->b);
+  r[PX].konst += s * F->x;
+  exprAdd(&r[PY], vs_l1_col(0, t, PX, N), -s * F->b);
+  exprAdd(&r[PY], vs_l1_col(0, t, PY, N),  s * F->a);
+  r[PY].konst += s * F->y;
+  exprAdd(&r[PA], vs_l1_col(0, t, PA, N),  s * F->a);
+  exprAdd(&r[PA], vs_l1_col(0, t, PB, N), -s * F->b);
+  exprAdd(&r[PB], vs_l1_col(0, t, PA, N),  s * F->b);
+  exprAdd(&r[PB], vs_l1_col(0, t, PB, N),  s * F->a);
+}
+
+/** accumulates s * B_t into the four component expressions r */
+static void exprAddB(L1Expr r[4], int t, double s, int N){
+  for (int p = PX; p <= PB; p++) exprAdd(&r[p], vs_l1_col(0, t, p, N), s);
+}
+
+/** residual of order 1..3 at time t, following eqs. (4)-(6) of the paper with
+      R_t = F_{t+1} B_{t+1} - B_t
+    Note that the operations are additive, not compositional: the identity I
+    below denotes the identity of the parameter space, not the identity
+    transform composed with B. */
+static void buildResidual(L1Expr r[4], int order, const VSTransformLS* F,
+                          int t, int N){
+  for (int p = PX; p <= PB; p++) exprReset(&r[p]);
+  switch (order) {
+   case 1:  // R_t
+    exprAddFB(r, &F[t + 1], t + 1, +1.0, N);
+    exprAddB (r,             t,    -1.0, N);
+    break;
+   case 2:  // R_{t+1} - R_t = F_{t+2}B_{t+2} - (I + F_{t+1})B_{t+1} + B_t
+    exprAddFB(r, &F[t + 2], t + 2, +1.0, N);
+    exprAddB (r,             t + 1, -1.0, N);
+    exprAddFB(r, &F[t + 1], t + 1, -1.0, N);
+    exprAddB (r,             t,     +1.0, N);
+    break;
+   case 3:  // R_{t+2} - 2R_{t+1} + R_t
+            //   = F_{t+3}B_{t+3} - (I+2F_{t+2})B_{t+2} + (2I+F_{t+1})B_{t+1} - B_t
+    exprAddFB(r, &F[t + 3], t + 3, +1.0, N);
+    exprAddB (r,             t + 2, -1.0, N);
+    exprAddFB(r, &F[t + 2], t + 2, -2.0, N);
+    exprAddB (r,             t + 1, +2.0, N);
+    exprAddFB(r, &F[t + 1], t + 1, +1.0, N);
+    exprAddB (r,             t,     -1.0, N);
+    break;
+   default:
+    break;
+  }
+}
+
+/** emits the constraint pair  -e <= expr <= e  as
+      lower row:  expr_linear + e >= -konst
+      upper row:  expr_linear - e <= -konst
+    Deriving both rows from the same expression is deliberate: in the earlier
+    hand-written version the two rows of one pair had drifted apart, which
+    silently turned an absolute value into an equality. */
+static void emitPair(VSLinProg* lp, int rowlo, int rowup, int ecol,
+                     const L1Expr* e){
+  for (int i = 0; i < e->n; i++) {
+    vs_lp_add_entry(lp, rowlo, e->col[i], e->val[i]);
+    vs_lp_add_entry(lp, rowup, e->col[i], e->val[i]);
+  }
+  vs_lp_add_entry(lp, rowlo, ecol,  1.0);
+  vs_lp_add_entry(lp, rowup, ecol, -1.0);
+  vs_lp_set_row_bounds(lp, rowlo, -e->konst,  VS_LP_INF);
+  vs_lp_set_row_bounds(lp, rowup, -VS_LP_INF, -e->konst);
+}
+
+/* ************************************************************************* */
+
+VSL1Config vsL1GetDefaultConfig(void){
+  VSL1Config c;
+  /* fig. 8(d) of the paper: eliminating jerks matters most, so w3 is an order
+     of magnitude above w1 and w2 */
+  c.w1          = 10.0;
+  c.w2          = 1.0;
+  c.w3          = 100.0;
+  c.wAffine     = 100.0;
+  c.frameWidth  = 0.0;
+  c.frameHeight = 0.0;
+  c.cropRatio   = 0.9;
+  c.minScale    = 1.0;
+  c.maxScale    = 1.1;
+  c.maxSkewDev  = 0.1;
+  c.verbose     = 0;
+  return c;
+}
+
+int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N, VSTransformLS* B,
+                            const VSL1Config* conf, double* objective){
+  if (!F || !B || !conf) return VS_ERROR;
+  /* the third derivative needs frames t .. t+3 */
+  if (N < 4) return VS_ERROR;
+  if (!(conf->frameWidth > 0.0) || !(conf->frameHeight > 0.0)) return VS_ERROR;
+  if (!(conf->cropRatio > 0.0) || conf->cropRatio > 1.0) return VS_ERROR;
+  if (!(conf->minScale > 0.0) || conf->minScale > conf->maxScale) return VS_ERROR;
+
+  const int numrows = vs_l1_numrows(N);
+  const int numcols = vs_l1_numcols(N);
+  VSLinProg* lp = vs_lp_new("vid.stab L1 camera path", numrows, numcols,
+                            vs_l1_maxentries(N));
+  if (!lp) return VS_ERROR;
+
+  const double weight[3] = { conf->w1, conf->w2, conf->w3 };
+
+  /* --- columns: B is free except for the proximity bounds, the slacks are
+     non-negative and carry the whole objective --------------------------- */
+  for (int t = 0; t < N; t++) {
+    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PX, N), -VS_LP_INF, VS_LP_INF);
+    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PY, N), -VS_LP_INF, VS_LP_INF);
+    /* proximity constraints, section 2.1 of the paper: keep the update
+       transform close to the identity so the crop does not distort */
+    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PA, N),
+                         conf->minScale, conf->maxScale);
+    vs_lp_set_col_bounds(lp, vs_l1_col(0, t, PB, N),
+                         -conf->maxSkewDev, conf->maxSkewDev);
+  }
+  for (int order = 1; order <= 3; order++) {
+    for (int t = 0; t < N - order; t++) {
+      for (int p = PX; p <= PB; p++) {
+        int col = vs_l1_col(order, t, p, N);
+        vs_lp_set_col_bounds(lp, col, 0.0, VS_LP_INF);
+        vs_lp_set_obj(lp, col, weight[order - 1]
+                      * ((p == PA || p == PB) ? conf->wAffine : 1.0));
+      }
+    }
+  }
+
+  /* --- smoothness rows -------------------------------------------------- */
+  L1Expr r[4];
+  for (int order = 1; order <= 3; order++) {
+    for (int t = 0; t < N - order; t++) {
+      buildResidual(r, order, F, t, N);
+      for (int p = PX; p <= PB; p++) {
+        emitPair(lp,
+                 vs_l1_row(order, t, p, 0, N),
+                 vs_l1_row(order, t, p, 1, N),
+                 vs_l1_col(order, t, p, N),
+                 &r[p]);
+      }
+    }
+  }
+
+  /* --- inclusion rows: all four corners of the crop rectangle, transformed
+     by B_t, have to stay inside the frame rectangle (eq. 8, in coordinates
+     relative to the frame centre) ---------------------------------------- */
+  const double x2 = conf->frameWidth  / 2.0;
+  const double y2 = conf->frameHeight / 2.0;
+  const double cw = x2 * conf->cropRatio;
+  const double ch = y2 * conf->cropRatio;
+  const double cornerx[4] = { -cw,  cw, cw, -cw };
+  const double cornery[4] = { -ch, -ch, ch,  ch };
+  for (int t = 0; t < N; t++) {
+    for (int i = 0; i < 4; i++) {
+      double cx = cornerx[i], cy = cornery[i];
+      int rowx = vs_l1_rowCorner(t, 2 * i,     N);
+      int rowy = vs_l1_rowCorner(t, 2 * i + 1, N);
+      /* -x2 <= Bx + a cx + b cy <= x2 */
+      vs_lp_add_entry(lp, rowx, vs_l1_col(0, t, PX, N), 1.0);
+      vs_lp_add_entry(lp, rowx, vs_l1_col(0, t, PA, N), cx);
+      vs_lp_add_entry(lp, rowx, vs_l1_col(0, t, PB, N), cy);
+      vs_lp_set_row_bounds(lp, rowx, -x2, x2);
+      /* -y2 <= By - b cx + a cy <= y2 */
+      vs_lp_add_entry(lp, rowy, vs_l1_col(0, t, PY, N), 1.0);
+      vs_lp_add_entry(lp, rowy, vs_l1_col(0, t, PB, N), -cx);
+      vs_lp_add_entry(lp, rowy, vs_l1_col(0, t, PA, N), cy);
+      vs_lp_set_row_bounds(lp, rowy, -y2, y2);
+    }
+  }
+
+  /* --- solve ------------------------------------------------------------ */
+  int status = vs_lp_solve(lp, conf->verbose & VS_DEBUG);
+  if (status != VS_OK) {
+    vs_log_error("vid.stab", "L1 camera path: %s (%s, %i rows, %i cols)",
+                 vs_lp_status_msg(lp), vs_lp_backend_name(), numrows, numcols);
+    vs_lp_free(lp);
+    return VS_ERROR;
+  }
+  for (int t = 0; t < N; t++) {
+    B[t].x     = vs_lp_get_col_value(lp, vs_l1_col(0, t, PX, N));
+    B[t].y     = vs_lp_get_col_value(lp, vs_l1_col(0, t, PY, N));
+    B[t].a     = vs_lp_get_col_value(lp, vs_l1_col(0, t, PA, N));
+    B[t].b     = vs_lp_get_col_value(lp, vs_l1_col(0, t, PB, N));
+    B[t].extra = 0;
+  }
+  if (objective) *objective = vs_lp_get_obj_value(lp);
+  vs_lp_free(lp);
+  return VS_OK;
+}
+
+/* ************************************************************************* */
+
+VSL1Config vsL1ConfigFromTransformConfig(const VSTransformData* td){
+  VSL1Config c = vsL1GetDefaultConfig();
+  c.w1          = td->conf.pathD1Weight;
+  c.w2          = td->conf.pathD2Weight;
+  c.w3          = td->conf.pathD3Weight;
+  c.frameWidth  = td->fiSrc.width;
+  c.frameHeight = td->fiSrc.height;
+  /* pathMaxZoom is the zoom in percent that the optimization may use up, so
+     the crop window is that much smaller than the frame */
+  c.cropRatio   = 1.0 / (1.0 + VS_MAX(td->conf.pathMaxZoom, 0.0) / 100.0);
+  c.verbose     = td->conf.verbose;
+  return c;
+}
+
+/** Converts an update transform B_t into the VSTransform that the warping code
+    has to be fed to realize it.
+
+    transformPlanar() in transformfloat.c maps a destination pixel p_d, taken
+    relative to the frame centre, to the source pixel
+
+        p_s = z R(-alpha) p_d - (x,y),      z = 1 - zoom/100
+
+    while the destination frame corresponds to the crop rectangle, which is
+    cropRatio as large as the frame.  We therefore want
+
+        p_s = B(cropRatio * p_d)
+
+    Comparing the two, with theta and |B| the rotation and the scale of B,
+    gives the exact conversion below.  The zoom needed to see only the crop
+    rectangle is part of it, which is why cameraPathOptimalL1() switches the
+    heuristic zoom estimation off: the optimization already guaranteed that
+    this exact crop stays inside the frame. */
+static VSTransform updateToRenderTransform(const VSTransformLS* B, double cropRatio){
+  VSTransform r = null_transform();
+  r.x     = -B->x;
+  r.y     = -B->y;
+  r.alpha = -atan2(B->b, B->a);
+  r.zoom  = (1.0 - cropRatio * sqrt(B->a * B->a + B->b * B->b)) * 100.0;
+  return r;
+}
+
+int cameraPathOptimalL1(VSTransformData* td, VSTransformations* trans){
+  if (!td || !trans || !trans->ts) return VS_ERROR;
+  const int N = trans->len;
+  if (N < 1) return VS_ERROR;
+  if (!td->conf.relative) {
+    vs_log_error(td->conf.modName,
+                 "L1 camera path optimization requires relative transforms");
+    return VS_ERROR;
+  }
+  if (N < 4) {
+    vs_log_error(td->conf.modName,
+                 "L1 camera path optimization needs at least 4 frames, got %i", N);
+    return VS_ERROR;
+  }
+  if (td->conf.verbose & VS_DEBUG) {
+    vs_log_msg(td->conf.modName, "L1 optimization of camera path (%s)",
+               vs_lp_backend_name());
+  }
+
+  VSTransformLS* F = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  VSTransformLS* B = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  if (!F || !B) { vs_free(F); vs_free(B); return VS_ERROR; }
+  /* The camera path is the running composition of the relative transforms,
+     C_t = C_{t-1} F_t, so the frame-pair transforms are the relative
+     transforms themselves.  F[0] is never read (C_0 drops out of every
+     residual), but is initialised so the array is fully defined. */
+  F[0] = id_transformLS();
+  for (int t = 1; t < N; t++) F[t] = transformAZtoLS(&trans->ts[t]);
+
+  VSL1Config conf = vsL1ConfigFromTransformConfig(td);
+  double objective = 0.0;
+  int status = vsCameraPathOptimalL1LS(F, N, B, &conf, &objective);
+  if (status == VS_OK) {
+    if (td->conf.verbose & VS_DEBUG) {
+      vs_log_msg(td->conf.modName, "L1 camera path objective: %g", objective);
+    }
+    for (int t = 0; t < N; t++) {
+      int extra = trans->ts[t].extra;
+      trans->ts[t] = updateToRenderTransform(&B[t], conf.cropRatio);
+      trans->ts[t].extra = extra;
+    }
+    /* The inclusion constraints already bound the crop window exactly, and the
+       zoom that goes with it is part of the transforms above.  The heuristic
+       estimators in vsPreprocessTransforms() would only add more zoom on top
+       of that, so switch them off; an explicitly requested conf.zoom is still
+       honoured and added. */
+    td->conf.optZoom = 0;
+  }
+  vs_free(F);
+  vs_free(B);
+  return status;
+}
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/l1campathoptimization.c
+++ b/src/l1campathoptimization.c
@@ -364,7 +364,7 @@ VSL1Config vsL1GetDefaultConfig(void){
   c.wAffine     = 100.0;
   c.frameWidth  = 0.0;
   c.frameHeight = 0.0;
-  c.cropRatio   = 0.9;
+  c.cropRatio   = 1.0 / 1.15;   // matches the pathMaxZoom default of 15 percent
   c.minScale    = 1.0;
   c.maxScale    = 1.1;
   c.maxSkewDev  = 0.1;
@@ -497,14 +497,24 @@ int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N, VSTransformLS* B,
 
 VSL1Config vsL1ConfigFromTransformConfig(const VSTransformData* td){
   VSL1Config c = vsL1GetDefaultConfig();
-  c.w1          = td->conf.pathD1Weight;
-  c.w2          = td->conf.pathD2Weight;
-  c.w3          = td->conf.pathD3Weight;
-  c.frameWidth  = td->fiSrc.width;
-  c.frameHeight = td->fiSrc.height;
+  /* Not every caller goes through vsTransformGetDefaultConfig(): the ffmpeg
+     filter fills VSTransformConfig field by field from its option table, so
+     fields it does not know about arrive as zero.  All weights zero would make
+     the objective identically zero and every feasible path optimal, and a crop
+     of zero percent would leave the optimization no room at all -- neither is
+     something anybody can have meant, so fall back to the defaults. */
+  if (td->conf.pathD1Weight > 0.0 || td->conf.pathD2Weight > 0.0 ||
+      td->conf.pathD3Weight > 0.0) {
+    c.w1 = VS_MAX(td->conf.pathD1Weight, 0.0);
+    c.w2 = VS_MAX(td->conf.pathD2Weight, 0.0);
+    c.w3 = VS_MAX(td->conf.pathD3Weight, 0.0);
+  }
   /* pathMaxZoom is the zoom in percent that the optimization may use up, so
      the crop window is that much smaller than the frame */
-  c.cropRatio   = 1.0 / (1.0 + VS_MAX(td->conf.pathMaxZoom, 0.0) / 100.0);
+  if (td->conf.pathMaxZoom > 0.0)
+    c.cropRatio = 1.0 / (1.0 + td->conf.pathMaxZoom / 100.0);
+  c.frameWidth  = td->fiSrc.width;
+  c.frameHeight = td->fiSrc.height;
   c.verbose     = td->conf.verbose;
   return c;
 }

--- a/src/l1campathoptimization.h
+++ b/src/l1campathoptimization.h
@@ -141,6 +141,8 @@ VS_API VSL1Config vsL1ConfigFromTransformConfig(const VSTransformData* td);
 #ifdef TESTING
 /* index helpers, exposed for the unit tests */
 int vs_l1_row(int order, int t, int param, int upperorlower, int N);
+int vs_l1_rowCorner(int t, int k, int N);
+int vs_l1_rowBase(int t, int N);
 int vs_l1_col(int group, int t, int param, int N);
 int vs_l1_numrows(int N);
 int vs_l1_numcols(int N);

--- a/src/l1campathoptimization.h
+++ b/src/l1campathoptimization.h
@@ -1,0 +1,160 @@
+/*
+ *  l1campathoptimization.h
+ *
+ *  Copyright (C) Georg Martius - January 2014 - 2026
+ *   georg dot martius at web dot de
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+#ifndef __L1CAMPATHOPTIMIZATION_H
+#define __L1CAMPATHOPTIMIZATION_H
+
+#include "transform.h"
+
+/** Optimal camera path via L1 minimization, after
+ *
+ *  @INPROCEEDINGS{GrundmannKwatra2011,
+ *   author    = {M. Grundmann and V. Kwatra and I. Essa},
+ *   title     = {Auto-Directed Video Stabilization with Robust L1 Optimal
+ *                Camera Paths},
+ *   booktitle = {IEEE Conference on Computer Vision and Pattern Recognition
+ *                (CVPR)},
+ *   year      = {2011}}
+ *
+ *  The original camera path C_t is given by the frame-pair transforms F_t via
+ *  C_t = C_{t-1} F_t.  We look for update ("crop window") transforms B_t such
+ *  that the stabilized path P_t = C_t B_t is composed of static, linear and
+ *  parabolic segments only.  That is achieved by minimizing the weighted L1
+ *  norm of the first three derivatives of P, which -- after dropping the known
+ *  factor C_t, see eq. (4) of the paper -- becomes a linear program in B.
+ */
+
+/* --------------------------------------------------------------------------
+ * 4-DOF linear similarity transform.
+ *
+ * Corresponds to the matrix
+ *
+ *       [ a   b   x ]
+ *       [-b   a   y ]
+ *       [ 0   0   1 ]
+ *
+ * acting on coordinates relative to the frame centre.  This is the same
+ * transform as VSTransform, only parametrized by (x,y,a,b) instead of
+ * (x,y,alpha,zoom), which turns composition into a bilinear -- and the LP
+ * constraints into a linear -- expression.  The relation to VSTransform is
+ *
+ *      a = (1 + zoom/100) cos(alpha)
+ *      b = (1 + zoom/100) sin(alpha)
+ *
+ * matching prepare_transform() in transformtype.c.
+ * -------------------------------------------------------------------------- */
+typedef struct VS_API _VSTransformLS {
+  double x;
+  double y;
+  double a;
+  double b;
+  int    extra;
+} VSTransformLS;
+
+/// identity transform (x=y=0, a=1, b=0)
+VS_API VSTransformLS id_transformLS(void);
+/// matrix product t1 * t2 (t2 applied first)
+VS_API VSTransformLS concat_transformLS(const VSTransformLS* t1, const VSTransformLS* t2);
+/// matrix inverse
+VS_API VSTransformLS invert_transformLS(const VSTransformLS* t);
+/// applies the transform to a point given relative to the frame centre
+VS_API void transformLS_vec(double* rx, double* ry, const VSTransformLS* t,
+                            double x, double y);
+VS_API VSTransformLS transformAZtoLS(const VSTransform* t);
+VS_API VSTransform   transformLStoAZ(const VSTransformLS* t);
+
+/** parameters of the L1 optimization, independent of VSTransformData so that
+    the core can be exercised on its own */
+typedef struct VS_API _VSL1Config {
+  double w1;          ///< weight of |D(P)|_1   (constant segments)
+  double w2;          ///< weight of |D^2(P)|_1 (linear segments)
+  double w3;          ///< weight of |D^3(P)|_1 (parabolic segments)
+  /** relative weight of the (a,b) part of the residual against the (x,y) part.
+      The paper uses 100, since translations live on a pixel scale while a and
+      b are of order 1. */
+  double wAffine;
+  double frameWidth;  ///< width of the frame in pixels
+  double frameHeight; ///< height of the frame in pixels
+  /** size of the crop window relative to the frame, in (0,1].  The corners of
+      that window, transformed by B_t, are constrained to stay inside the
+      frame; the smaller it is, the more freedom the optimization has.  The
+      paper uses 0.75. */
+  double cropRatio;
+  /** proximity constraints (paper section 2.1: 0.9 <= a <= 1.1, |b| <= 0.1).
+      a below 1 lets the optimization shrink the sampled region to buy extra
+      translation freedom, at the price of magnifying the output further: the
+      total magnification is 1/(cropRatio * minScale).  We therefore default
+      minScale to 1, so that cropRatio alone determines how much is zoomed;
+      lower it to trade sharpness for smoothness. */
+  double minScale;    ///< lower bound on a, default 1.0
+  double maxScale;    ///< upper bound on a, default 1.1
+  double maxSkewDev;  ///< proximity: |b| <= maxSkewDev (paper: 0.1)
+  int    verbose;
+} VSL1Config;
+
+VS_API VSL1Config vsL1GetDefaultConfig(void);
+
+/** Core of the algorithm, free of any VSTransformData dependency.
+
+    @param F     frame-pair transforms, F[t] takes frame t to frame t-1's
+                 coordinate system so that C_t = C_{t-1} F_t.  F[0] is never
+                 read; pass the identity.
+    @param N     number of frames, must be >= 4
+    @param B     output array of N update transforms (caller allocated)
+    @param conf  parameters, must not be NULL
+    @param objective if not NULL, receives the optimal objective value
+    @return VS_OK on success, VS_ERROR if the LP could not be solved
+ */
+VS_API int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N,
+                                   VSTransformLS* B, const VSL1Config* conf,
+                                   double* objective);
+
+/** Camera path optimization for a list of relative vid.stab transforms.
+    trans->ts is replaced in place by the update transforms B_t, in the same
+    sense as cameraPathGaussian(): applying ts[t] to frame t yields the
+    stabilized frame. */
+VS_API int cameraPathOptimalL1(VSTransformData* td, VSTransformations* trans);
+
+/** builds the VSL1Config that cameraPathOptimalL1() would use for td */
+VS_API VSL1Config vsL1ConfigFromTransformConfig(const VSTransformData* td);
+
+#ifdef TESTING
+/* index helpers, exposed for the unit tests */
+int vs_l1_row(int order, int t, int param, int upperorlower, int N);
+int vs_l1_col(int group, int t, int param, int N);
+int vs_l1_numrows(int N);
+int vs_l1_numcols(int N);
+#endif
+
+#endif  /* __L1CAMPATHOPTIMIZATION_H */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/lpsolver.h
+++ b/src/lpsolver.h
@@ -35,7 +35,14 @@
  *
  *  The point of this thin layer is that the construction of the camera path
  *  LP in l1campathoptimization.c is independent of which solver is used,
- *  so a backend can be swapped in without touching the model.
+ *  so a backend can be swapped in without touching the model.  Two exist:
+ *  lpsolver_ipm.c (built in, the default) and lpsolver_glpk.c.
+ *
+ *  A backend may impose extra requirements on the model.  The built-in one
+ *  needs every variable and every row to be bounded on at least one side, and
+ *  it needs the rows ordered so that the matrix is banded -- both of which the
+ *  camera path program satisfies by construction.  It reports an error rather
+ *  than guessing if they do not hold.
  */
 
 /// any bound with |value| >= VS_LP_INF counts as infinite

--- a/src/lpsolver.h
+++ b/src/lpsolver.h
@@ -1,0 +1,92 @@
+/*
+ *  lpsolver.h
+ *
+ *  Copyright (C) Georg Martius - January 2014 - 2026
+ *   georg dot martius at web dot de
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+#ifndef __LPSOLVER_H
+#define __LPSOLVER_H
+
+/** Minimal interface to a linear program of the form
+ *
+ *      minimize    c^T x
+ *      subject to  rowlo_i <= (A x)_i <= rowup_i
+ *                  collo_j <=    x_j  <= colup_j
+ *
+ *  Rows and columns are numbered 0..num-1.  Use +-VS_LP_INF for an
+ *  unbounded side; setting lo == up gives an equality.
+ *
+ *  The point of this thin layer is that the construction of the camera path
+ *  LP in l1campathoptimization.c is independent of which solver is used,
+ *  so a backend can be swapped in without touching the model.
+ */
+
+/// any bound with |value| >= VS_LP_INF counts as infinite
+#define VS_LP_INF 1e30
+
+typedef struct VSLinProg VSLinProg;
+
+/** creates an empty problem.
+    @param numrows    number of constraint rows
+    @param numcols    number of structural variables
+    @param maxentries upper bound on the number of nonzero matrix entries
+    All objective coefficients start at 0, all rows and columns start free.
+    Returns NULL on allocation failure. */
+VSLinProg* vs_lp_new(const char* name, int numrows, int numcols, int maxentries);
+
+void vs_lp_free(VSLinProg* lp);
+
+void vs_lp_set_row_bounds(VSLinProg* lp, int row, double lo, double up);
+void vs_lp_set_col_bounds(VSLinProg* lp, int col, double lo, double up);
+void vs_lp_set_obj(VSLinProg* lp, int col, double coef);
+
+/** adds one nonzero entry A[row][col] = val.  Each (row,col) pair must be
+    added at most once. */
+void vs_lp_add_entry(VSLinProg* lp, int row, int col, double val);
+
+/** solves the problem.  Returns VS_OK when an optimal solution was found and
+    VS_ERROR otherwise (infeasible, unbounded, numerical failure, ...).
+    @param verbose if nonzero the backend may print progress information */
+int vs_lp_solve(VSLinProg* lp, int verbose);
+
+/** objective value of the solution; only valid after vs_lp_solve returned VS_OK */
+double vs_lp_get_obj_value(const VSLinProg* lp);
+
+/** value of variable col; only valid after vs_lp_solve returned VS_OK */
+double vs_lp_get_col_value(const VSLinProg* lp, int col);
+
+/** name of the compiled-in backend, for logging */
+const char* vs_lp_backend_name(void);
+
+/** human readable description of why the last solve failed, or "" */
+const char* vs_lp_status_msg(const VSLinProg* lp);
+
+#endif /* __LPSOLVER_H */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/lpsolver_glpk.c
+++ b/src/lpsolver_glpk.c
@@ -1,0 +1,198 @@
+/*
+ *  lpsolver_glpk.c
+ *
+ *  GLPK backend for the minimal LP interface in lpsolver.h.
+ *
+ *  Copyright (C) Georg Martius - January 2014 - 2026
+ *   georg dot martius at web dot de
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+
+#include "lpsolver.h"
+
+#ifdef USE_GLPK
+
+#include "vidstabdefines.h"
+#include <glpk.h>
+#include <string.h>
+#include <stdio.h>
+
+struct VSLinProg {
+  glp_prob* lp;
+  int    numrows;
+  int    numcols;
+  int    maxentries;
+  int    numentries;   // number of entries stored so far
+  int*   ia;           // 1-based triplet arrays as required by glp_load_matrix
+  int*   ja;
+  double* ar;
+  int    solved;
+  const char* status;
+};
+
+/** translates a (lo,up) pair into GLPK's bound type */
+static int boundtype(double lo, double up){
+  int lofin = lo > -VS_LP_INF;
+  int upfin = up <  VS_LP_INF;
+  if (!lofin && !upfin) return GLP_FR;
+  if (lofin && !upfin)  return GLP_LO;
+  if (!lofin && upfin)  return GLP_UP;
+  return (lo == up) ? GLP_FX : GLP_DB;
+}
+
+VSLinProg* vs_lp_new(const char* name, int numrows, int numcols, int maxentries){
+  if (numrows <= 0 || numcols <= 0 || maxentries <= 0) return 0;
+  VSLinProg* p = (VSLinProg*)vs_zalloc(sizeof(VSLinProg));
+  if (!p) return 0;
+  p->numrows    = numrows;
+  p->numcols    = numcols;
+  p->maxentries = maxentries;
+  p->numentries = 0;
+  p->status     = "";
+  /* +1 because GLPK's triplet arrays are 1-based */
+  p->ia = (int*)   vs_malloc(sizeof(int)    * (maxentries + 1));
+  p->ja = (int*)   vs_malloc(sizeof(int)    * (maxentries + 1));
+  p->ar = (double*)vs_malloc(sizeof(double) * (maxentries + 1));
+  p->lp = glp_create_prob();
+  if (!p->ia || !p->ja || !p->ar || !p->lp) {
+    vs_lp_free(p);
+    return 0;
+  }
+  glp_set_prob_name(p->lp, name ? name : "vid.stab");
+  glp_set_obj_dir(p->lp, GLP_MIN);
+  glp_add_rows(p->lp, numrows);
+  glp_add_cols(p->lp, numcols);
+  /* GLPK's default row type is GLP_FX with bound 0; we want free rows until
+     the model says otherwise, so that a forgotten bound does not silently
+     turn into an equality. */
+  for (int i = 1; i <= numrows; i++) glp_set_row_bnds(p->lp, i, GLP_FR, 0.0, 0.0);
+  return p;
+}
+
+void vs_lp_free(VSLinProg* p){
+  if (!p) return;
+  if (p->lp) glp_delete_prob(p->lp);
+  if (p->ia) vs_free(p->ia);
+  if (p->ja) vs_free(p->ja);
+  if (p->ar) vs_free(p->ar);
+  vs_free(p);
+}
+
+void vs_lp_set_row_bounds(VSLinProg* p, int row, double lo, double up){
+  if (!p || row < 0 || row >= p->numrows) return;
+  glp_set_row_bnds(p->lp, row + 1, boundtype(lo, up), lo, up);
+}
+
+void vs_lp_set_col_bounds(VSLinProg* p, int col, double lo, double up){
+  if (!p || col < 0 || col >= p->numcols) return;
+  glp_set_col_bnds(p->lp, col + 1, boundtype(lo, up), lo, up);
+}
+
+void vs_lp_set_obj(VSLinProg* p, int col, double coef){
+  if (!p || col < 0 || col >= p->numcols) return;
+  glp_set_obj_coef(p->lp, col + 1, coef);
+}
+
+void vs_lp_add_entry(VSLinProg* p, int row, int col, double val){
+  if (!p) return;
+  if (row < 0 || row >= p->numrows || col < 0 || col >= p->numcols) return;
+  if (p->numentries >= p->maxentries) {  // must not happen; guarded for safety
+    p->status = "matrix entry buffer overflow";
+    return;
+  }
+  int k = ++p->numentries;
+  p->ia[k] = row + 1;
+  p->ja[k] = col + 1;
+  p->ar[k] = val;
+}
+
+int vs_lp_solve(VSLinProg* p, int verbose){
+  if (!p) return VS_ERROR;
+  p->solved = 0;
+  /* GLPK writes to the terminal from glp_scale_prob() too, which the message
+     level in glp_smcp does not cover, so silence it globally instead */
+  glp_term_out(verbose ? GLP_ON : GLP_OFF);
+  glp_load_matrix(p->lp, p->numentries, p->ia, p->ja, p->ar);
+  /* Scaling matters here: the translational parameters live on a pixel scale
+     while a and b are around 1, so the columns differ by three orders of
+     magnitude. */
+  glp_scale_prob(p->lp, GLP_SF_AUTO);
+
+  glp_smcp parm;
+  glp_init_smcp(&parm);
+  parm.msg_lev = verbose ? GLP_MSG_ALL : GLP_MSG_ERR;
+  parm.presolve = GLP_ON;
+  /* dual simplex with a primal fallback: the smoothness rows make the primal
+     heavily degenerate, the dual copes far better */
+  parm.meth = GLP_DUALP;
+
+  int ret = glp_simplex(p->lp, &parm);
+  if (ret != 0) {
+    /* presolve can fail on numerically awkward instances; retry without it,
+       which also lets us query a proper solution status afterwards */
+    parm.presolve = GLP_OFF;
+    ret = glp_simplex(p->lp, &parm);
+  }
+  glp_term_out(GLP_ON);
+  if (ret != 0) {
+    p->status = "simplex failed";
+    return VS_ERROR;
+  }
+  switch (glp_get_status(p->lp)) {
+   case GLP_OPT:    p->solved = 1; p->status = ""; return VS_OK;
+   case GLP_FEAS:   p->status = "solution feasible but not proven optimal"; break;
+   case GLP_INFEAS: p->status = "solution infeasible"; break;
+   case GLP_NOFEAS: p->status = "problem has no feasible solution"; break;
+   case GLP_UNBND:  p->status = "problem is unbounded"; break;
+   default:         p->status = "solution status undefined"; break;
+  }
+  return VS_ERROR;
+}
+
+double vs_lp_get_obj_value(const VSLinProg* p){
+  return (p && p->solved) ? glp_get_obj_val(p->lp) : 0.0;
+}
+
+double vs_lp_get_col_value(const VSLinProg* p, int col){
+  if (!p || !p->solved || col < 0 || col >= p->numcols) return 0.0;
+  return glp_get_col_prim(p->lp, col + 1);
+}
+
+const char* vs_lp_status_msg(const VSLinProg* p){
+  return (p && p->status) ? p->status : "";
+}
+
+const char* vs_lp_backend_name(void){
+  static char name[64];
+  snprintf(name, sizeof(name), "GLPK %s", glp_version());
+  return name;
+}
+
+#endif /* USE_GLPK */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/lpsolver_ipm.c
+++ b/src/lpsolver_ipm.c
@@ -1,0 +1,881 @@
+/*
+ *  lpsolver_ipm.c
+ *
+ *  Dependency-free backend for the LP interface in lpsolver.h: a primal-dual
+ *  interior point method (Mehrotra predictor-corrector) whose normal equations
+ *  are factorized with a banded Cholesky.
+ *
+ *  Why this and not a simplex: a simplex needs a sparse LU of the basis with
+ *  pivoting and refactorization, which is a large piece of numerical software.
+ *  An interior point method needs only one kind of factorization, always of the
+ *  same symmetric positive definite matrix
+ *
+ *      A Theta A^T,   Theta > 0 diagonal,
+ *
+ *  and the camera path program is banded: a constraint at time t only involves
+ *  the update transforms of t .. t+3, so with the rows ordered by time (see the
+ *  layout comment in l1campathoptimization.c) the matrix above has a half
+ *  bandwidth of about 130 regardless of the number of frames.  A banded
+ *  Cholesky is then O(N) per iteration and about fifty lines.
+ *
+ *  Copyright (C) Georg Martius - 2026
+ *   georg dot martius at web dot de
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ */
+
+#include "lpsolver.h"
+
+#ifdef USE_IPM
+
+#include "vidstabdefines.h"
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+/* The tuning constants are overridable so that they can be swept from a test
+   harness without editing this file. */
+#define IPM_MAXITER   200
+/* accuracy at which the iteration stops early, having converged */
+#ifndef IPM_TOL
+#define IPM_TOL       1e-9
+#endif
+/* Theta = (Z/V + W/T)^-1 is clamped to this range: it legitimately goes to
+   zero for the variables that end up at a bound and to infinity for the
+   others, and without a clamp the normal equations overflow the exponent
+   range long before the iteration is done */
+#ifndef IPM_MINTHETA
+#define IPM_MINTHETA  1e-14
+#endif
+#ifndef IPM_MAXTHETA
+#define IPM_MAXTHETA  1e+14
+#endif
+/* Accuracy accepted when the iteration can no longer improve.
+   Up to a few hundred frames the method reaches 1e-9 or better.  Beyond that
+   the triangular solves accumulate enough round-off along the band that it
+   plateaus around 1e-5.  Measured against an exact simplex solution at 200 and
+   500 frames, an iterate at that level is strictly inside the inclusion and
+   proximity constraints (by 1e-5 pixels) and its true objective is within 1e-4
+   of the optimum, i.e. an equally smooth camera path.  1e-4 therefore leaves
+   headroom without accepting anything that could be seen. */
+#ifndef IPM_ACCEPT
+#define IPM_ACCEPT    1e-4
+#endif
+/* relative shift on the diagonal of the normal equations, see bandCholesky */
+#ifndef IPM_REG
+#define IPM_REG       1e-11
+#endif
+/* refinement passes on the full Newton system, see ipmDirectionRefined */
+#ifndef IPM_REFINE
+#define IPM_REFINE    2
+#endif
+
+struct VSLinProg {
+  int     numrows;
+  int     numcols;
+  int     maxentries;
+  int     numentries;
+  int*    ent_row;
+  int*    ent_col;
+  double* ent_val;
+  double* rowlo;
+  double* rowup;
+  double* collo;
+  double* colup;
+  double* obj;
+  double* sol;         // primal solution of the structural variables
+  double  objval;
+  int     solved;
+  const char* status;
+  char    statusbuf[96];
+};
+
+static int isinf_lp(double v){ return v >= VS_LP_INF || v <= -VS_LP_INF; }
+
+/* ****************************************************************************
+ * banded Cholesky
+ *
+ * The lower triangle of a symmetric matrix with half bandwidth bw is stored
+ * column by column: band[j*(bw+1) + d] holds the element (j+d, j).
+ * ************************************************************************** */
+
+typedef struct {
+  int     m;
+  int     bw;
+  double* dat;
+} Band;
+
+static double* bandAt(Band* b, int col, int d){ return &b->dat[(size_t)col * (b->bw + 1) + d]; }
+
+/** in place Cholesky, L L^T = M.  The diagonal is scaled by 1 + `releps` as a
+    regularization; a relative shift is essential here because the entries of
+    Theta span many orders of magnitude near the solution, so any absolute
+    shift is either meaningless or destroys the small rows.  If a pivot still
+    comes out non-positive it is replaced by a tiny positive value: the result
+    is then no longer an exact factorization, but iterative refinement on the
+    normal equations recovers the accuracy. */
+static void bandCholesky(Band* b, double releps){
+  const int m = b->m, bw = b->bw;
+  for (int j = 0; j < m; j++) {
+    double d = *bandAt(b, j, 0) * (1.0 + releps);
+    int p0 = j - bw; if (p0 < 0) p0 = 0;
+    for (int p = p0; p < j; p++) {
+      double v = *bandAt(b, p, j - p);
+      d -= v * v;
+    }
+    if (!(d > 1e-300)) d = 1e-300;
+    double piv = sqrt(d);
+    *bandAt(b, j, 0) = piv;
+    int imax = j + bw; if (imax > m - 1) imax = m - 1;
+    for (int i = j + 1; i <= imax; i++) {
+      double s = *bandAt(b, j, i - j);
+      int q0 = i - bw; if (q0 < 0) q0 = 0;
+      for (int p = q0; p < j; p++) {
+        s -= *bandAt(b, p, i - p) * *bandAt(b, p, j - p);
+      }
+      *bandAt(b, j, i - j) = s / piv;
+    }
+  }
+}
+
+/** solves L L^T x = r in place on x (which may alias r) */
+static void bandSolve(Band* b, const double* r, double* x){
+  const int m = b->m, bw = b->bw;
+  for (int i = 0; i < m; i++) {
+    double s = r[i];
+    int p0 = i - bw; if (p0 < 0) p0 = 0;
+    for (int p = p0; p < i; p++) s -= *bandAt(b, p, i - p) * x[p];
+    x[i] = s / *bandAt(b, i, 0);
+  }
+  for (int i = m - 1; i >= 0; i--) {
+    double s = x[i];
+    int pmax = i + bw; if (pmax > m - 1) pmax = m - 1;
+    for (int p = i + 1; p <= pmax; p++) s -= *bandAt(b, i, p - i) * x[p];
+    x[i] = s / *bandAt(b, i, 0);
+  }
+}
+
+static double vecmaxabs_(const double* v, int n){
+  double r = 0.0;
+  for (int i = 0; i < n; i++) { double a = fabs(v[i]); if (a > r) r = a; }
+  return r;
+}
+
+/* ****************************************************************************
+ * problem construction
+ * ************************************************************************** */
+
+VSLinProg* vs_lp_new(const char* name, int numrows, int numcols, int maxentries){
+  (void)name;
+  if (numrows <= 0 || numcols <= 0 || maxentries <= 0) return 0;
+  VSLinProg* p = (VSLinProg*)vs_zalloc(sizeof(VSLinProg));
+  if (!p) return 0;
+  p->numrows    = numrows;
+  p->numcols    = numcols;
+  p->maxentries = maxentries;
+  p->status     = "";
+  p->ent_row = (int*)   vs_malloc(sizeof(int)    * maxentries);
+  p->ent_col = (int*)   vs_malloc(sizeof(int)    * maxentries);
+  p->ent_val = (double*)vs_malloc(sizeof(double) * maxentries);
+  p->rowlo   = (double*)vs_malloc(sizeof(double) * numrows);
+  p->rowup   = (double*)vs_malloc(sizeof(double) * numrows);
+  p->collo   = (double*)vs_malloc(sizeof(double) * numcols);
+  p->colup   = (double*)vs_malloc(sizeof(double) * numcols);
+  p->obj     = (double*)vs_zalloc(sizeof(double) * numcols);
+  p->sol     = (double*)vs_zalloc(sizeof(double) * numcols);
+  if (!p->ent_row || !p->ent_col || !p->ent_val || !p->rowlo || !p->rowup ||
+      !p->collo || !p->colup || !p->obj || !p->sol) {
+    vs_lp_free(p);
+    return 0;
+  }
+  for (int i = 0; i < numrows; i++) { p->rowlo[i] = -VS_LP_INF; p->rowup[i] = VS_LP_INF; }
+  for (int j = 0; j < numcols; j++) { p->collo[j] = -VS_LP_INF; p->colup[j] = VS_LP_INF; }
+  return p;
+}
+
+void vs_lp_free(VSLinProg* p){
+  if (!p) return;
+  vs_free(p->ent_row); vs_free(p->ent_col); vs_free(p->ent_val);
+  vs_free(p->rowlo); vs_free(p->rowup);
+  vs_free(p->collo); vs_free(p->colup);
+  vs_free(p->obj);   vs_free(p->sol);
+  vs_free(p);
+}
+
+void vs_lp_set_row_bounds(VSLinProg* p, int row, double lo, double up){
+  if (!p || row < 0 || row >= p->numrows) return;
+  p->rowlo[row] = lo; p->rowup[row] = up;
+}
+
+void vs_lp_set_col_bounds(VSLinProg* p, int col, double lo, double up){
+  if (!p || col < 0 || col >= p->numcols) return;
+  p->collo[col] = lo; p->colup[col] = up;
+}
+
+void vs_lp_set_obj(VSLinProg* p, int col, double coef){
+  if (!p || col < 0 || col >= p->numcols) return;
+  p->obj[col] = coef;
+}
+
+void vs_lp_add_entry(VSLinProg* p, int row, int col, double val){
+  if (!p) return;
+  if (row < 0 || row >= p->numrows || col < 0 || col >= p->numcols) return;
+  if (p->numentries >= p->maxentries) { p->status = "matrix entry buffer overflow"; return; }
+  int k = p->numentries++;
+  p->ent_row[k] = row; p->ent_col[k] = col; p->ent_val[k] = val;
+}
+
+/* ****************************************************************************
+ * the solver
+ *
+ * After normalization every variable v (the structural ones followed by one
+ * slack per row) has a finite lower bound, so shifting by it puts the program
+ * into
+ *
+ *      min c^T v   s.t.  A v = b,   0 <= v <= h,   h_j possibly infinite.
+ *
+ * The primal-dual system is the textbook one:
+ *
+ *      A v = b,  v + t = h,  A^T y + z - w = c,  V Z e = 0,  T W e = 0
+ *
+ * with z, w >= 0 and w_j = 0 wherever h_j is infinite.  Eliminating everything
+ * but y leaves (A Theta A^T) dy = rhs with Theta = (Z/V + W/T)^-1.
+ * ************************************************************************** */
+
+typedef struct {
+  int      m;          // equality rows
+  int      nv;         // variables: structural + one slack per row
+  int      n;          // structural variables
+  int*     colptr;     // CSC of the structural part of A, size n+1
+  int*     rowidx;
+  double*  val;
+  double*  b;
+  double*  c;
+  double*  lo;         // shift that was applied
+  double*  h;          // upper bound of the shifted variable, VS_LP_INF if none
+  double*  scale;      // equilibration factor: true value = lo + scale * v
+  double   objscale;   // the objective was divided by this
+  signed char* sign;   // -1 if the variable was negated during normalization
+} IpmProb;
+
+static void ipmProbFree(IpmProb* q){
+  vs_free(q->colptr); vs_free(q->rowidx); vs_free(q->val);
+  vs_free(q->b); vs_free(q->c); vs_free(q->lo); vs_free(q->h);
+  vs_free(q->scale); vs_free(q->sign);
+  memset(q, 0, sizeof(*q));
+}
+
+/** Equilibrates the program.  The columns of the camera path matrix differ by
+    six orders of magnitude -- a translation is measured in pixels while a and b
+    are of order one -- and the objective coefficients by four.  Without this
+    the normal equations are too ill conditioned to reach optimality on longer
+    sequences.
+
+    Substituting v_j = scale_j * v~_j and multiplying row i by r_i keeps the
+    slack columns equal to -e_i if the slack of row i is scaled by 1/r_i. */
+static void ipmEquilibrate(IpmProb* q){
+  const int n = q->n, m = q->m;
+  double* r = (double*)vs_malloc(sizeof(double) * m);
+  if (!r) return;
+
+  for (int j = 0; j < q->nv; j++) q->scale[j] = 1.0;
+  for (int i = 0; i < m; i++) r[i] = 1.0;
+
+  for (int pass = 0; pass < 3; pass++) {
+    /* columns: largest entry of every structural column becomes 1 */
+    for (int j = 0; j < n; j++) {
+      double mx = 0.0;
+      for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++) {
+        double a = fabs(q->val[k]);
+        if (a > mx) mx = a;
+      }
+      if (mx <= 0.0) continue;
+      double s = 1.0 / mx;
+      for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++) q->val[k] *= s;
+      q->scale[j] *= s;
+      q->c[j] *= s;
+      if (!isinf_lp(q->h[j])) q->h[j] /= s;
+    }
+    /* rows: largest entry of every row becomes 1 */
+    for (int i = 0; i < m; i++) r[i] = 0.0;
+    for (int j = 0; j < n; j++)
+      for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++) {
+        double a = fabs(q->val[k]);
+        if (a > r[q->rowidx[k]]) r[q->rowidx[k]] = a;
+      }
+    for (int i = 0; i < m; i++) r[i] = (r[i] > 0.0) ? 1.0 / r[i] : 1.0;
+    for (int j = 0; j < n; j++)
+      for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++)
+        q->val[k] *= r[q->rowidx[k]];
+    for (int i = 0; i < m; i++) {
+      int j = n + i;
+      q->b[i] *= r[i];
+      q->scale[j] /= r[i];
+      if (!isinf_lp(q->h[j])) q->h[j] *= r[i];
+    }
+  }
+
+  /* finally bring the objective to order one */
+  q->objscale = vecmaxabs_(q->c, q->nv);
+  if (!(q->objscale > 0.0)) q->objscale = 1.0;
+  for (int j = 0; j < q->nv; j++) q->c[j] /= q->objscale;
+  vs_free(r);
+}
+
+/** brings the problem into the form described above.  Returns VS_ERROR if a
+    variable or a row is free on both sides, which this backend does not
+    support (the camera path program never produces one). */
+static int ipmBuild(VSLinProg* p, IpmProb* q){
+  const int m = p->numrows, n = p->numcols;
+  memset(q, 0, sizeof(*q));
+  q->m = m; q->n = n; q->nv = n + m; q->objscale = 1.0;
+
+  q->lo    = (double*)vs_malloc(sizeof(double) * q->nv);
+  q->h     = (double*)vs_malloc(sizeof(double) * q->nv);
+  q->scale = (double*)vs_malloc(sizeof(double) * q->nv);
+  q->c     = (double*)vs_zalloc(sizeof(double) * q->nv);
+  q->b     = (double*)vs_zalloc(sizeof(double) * m);
+  q->sign  = (signed char*)vs_malloc(sizeof(signed char) * q->nv);
+  q->colptr = (int*)vs_zalloc(sizeof(int) * (n + 1));
+  q->rowidx = (int*)vs_malloc(sizeof(int) * (p->numentries > 0 ? p->numentries : 1));
+  q->val    = (double*)vs_malloc(sizeof(double) * (p->numentries > 0 ? p->numentries : 1));
+  if (!q->lo || !q->h || !q->scale || !q->c || !q->b || !q->sign || !q->colptr ||
+      !q->rowidx || !q->val) { ipmProbFree(q); return VS_ERROR; }
+
+  /* structural variables: negate the ones that are bounded from above only */
+  for (int j = 0; j < n; j++) {
+    double l = p->collo[j], u = p->colup[j];
+    if (isinf_lp(l) && isinf_lp(u)) { ipmProbFree(q); return VS_ERROR; }
+    if (isinf_lp(l)) {
+      q->sign[j] = -1;
+      q->lo[j] = -u;
+      q->h[j]  = VS_LP_INF;
+      q->c[j]  = -p->obj[j];
+    } else {
+      q->sign[j] = 1;
+      q->lo[j] = l;
+      q->h[j]  = isinf_lp(u) ? VS_LP_INF : (u - l);
+      q->c[j]  = p->obj[j];
+    }
+  }
+  /* row slacks: A_i x - s_i = 0 with s_i between the row bounds; a row that is
+     bounded from above only is negated, together with its entries */
+  signed char* rowsign = (signed char*)vs_malloc(sizeof(signed char) * m);
+  if (!rowsign) { ipmProbFree(q); return VS_ERROR; }
+  for (int i = 0; i < m; i++) {
+    double l = p->rowlo[i], u = p->rowup[i];
+    if (isinf_lp(l) && isinf_lp(u)) { vs_free(rowsign); ipmProbFree(q); return VS_ERROR; }
+    int j = n + i;
+    q->sign[j] = 1;
+    if (isinf_lp(l)) {
+      rowsign[i] = -1;
+      q->lo[j] = -u;
+      q->h[j]  = VS_LP_INF;
+    } else {
+      rowsign[i] = 1;
+      q->lo[j] = l;
+      q->h[j]  = isinf_lp(u) ? VS_LP_INF : (u - l);
+    }
+  }
+
+  /* CSC of A, with the row and column signs folded in */
+  for (int k = 0; k < p->numentries; k++) q->colptr[p->ent_col[k] + 1]++;
+  for (int j = 0; j < n; j++) q->colptr[j + 1] += q->colptr[j];
+  int* fill = (int*)vs_malloc(sizeof(int) * n);
+  if (!fill) { vs_free(rowsign); ipmProbFree(q); return VS_ERROR; }
+  for (int j = 0; j < n; j++) fill[j] = q->colptr[j];
+  for (int k = 0; k < p->numentries; k++) {
+    int j = p->ent_col[k], i = p->ent_row[k];
+    int pos = fill[j]++;
+    q->rowidx[pos] = i;
+    q->val[pos] = p->ent_val[k] * rowsign[i] * q->sign[j];
+  }
+  vs_free(fill);
+  vs_free(rowsign);
+
+  /* A(v + lo) - (s + lo_s) = 0  =>  A v - s = lo_s - A lo */
+  for (int j = 0; j < n; j++) {
+    for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++)
+      q->b[q->rowidx[k]] -= q->val[k] * q->lo[j];
+  }
+  for (int i = 0; i < m; i++) q->b[i] += q->lo[n + i];
+
+  ipmEquilibrate(q);
+  return VS_OK;
+}
+
+/** res = A_struct * v_struct, the structural block alone */
+static void ipmAxStruct(const IpmProb* q, const double* v, double* res){
+  memset(res, 0, sizeof(double) * q->m);
+  for (int j = 0; j < q->n; j++) {
+    double vj = v[j];
+    if (vj == 0.0) continue;
+    for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++)
+      res[q->rowidx[k]] += q->val[k] * vj;
+  }
+}
+
+/** res = A_struct * v_struct - v_slack  (the full A times v) */
+static void ipmAv(const IpmProb* q, const double* v, double* res){
+  ipmAxStruct(q, v, res);
+  for (int i = 0; i < q->m; i++) res[i] -= v[q->n + i];
+}
+
+/** res = A^T y */
+static void ipmATy(const IpmProb* q, const double* y, double* res){
+  for (int j = 0; j < q->n; j++) {
+    double s = 0.0;
+    for (int k = q->colptr[j]; k < q->colptr[j + 1]; k++)
+      s += q->val[k] * y[q->rowidx[k]];
+    res[j] = s;
+  }
+  for (int i = 0; i < q->m; i++) res[q->n + i] = -y[i];
+}
+
+/** half bandwidth of A Theta A^T, i.e. the largest row span of any column */
+static int ipmBandwidth(const IpmProb* q){
+  int bw = 0;
+  for (int j = 0; j < q->n; j++) {
+    if (q->colptr[j] == q->colptr[j + 1]) continue;
+    int lo = q->rowidx[q->colptr[j]], hi = lo;
+    for (int k = q->colptr[j] + 1; k < q->colptr[j + 1]; k++) {
+      int i = q->rowidx[k];
+      if (i < lo) lo = i;
+      if (i > hi) hi = i;
+    }
+    if (hi - lo > bw) bw = hi - lo;
+  }
+  return bw;
+}
+
+/** assembles A Theta A^T into the band; the slack part contributes only to the
+    diagonal because those columns of A are -e_i */
+static void ipmAssemble(const IpmProb* q, const double* theta, Band* band){
+  memset(band->dat, 0, sizeof(double) * (size_t)band->m * (band->bw + 1));
+  for (int j = 0; j < q->n; j++) {
+    double th = theta[j];
+    if (th == 0.0) continue;
+    for (int k1 = q->colptr[j]; k1 < q->colptr[j + 1]; k1++) {
+      int i1 = q->rowidx[k1];
+      double v1 = th * q->val[k1];
+      for (int k2 = q->colptr[j]; k2 < q->colptr[j + 1]; k2++) {
+        int i2 = q->rowidx[k2];
+        if (i2 < i1) continue;          // lower triangle: store (i2, i1) with i2 >= i1
+        *bandAt(band, i1, i2 - i1) += v1 * q->val[k2];
+      }
+    }
+  }
+  for (int i = 0; i < q->m; i++) *bandAt(band, i, 0) += theta[q->n + i];
+}
+
+/** res = A Theta A^T x.  tmp must have room for nv doubles. */
+static void ipmNormalMul(const IpmProb* q, const double* theta, const double* x,
+                         double* res, double* tmp){
+  ipmATy(q, x, tmp);
+  for (int j = 0; j < q->nv; j++) tmp[j] *= theta[j];
+  ipmAv(q, tmp, res);
+}
+
+/** solves (A Theta A^T) sol = rhs using the banded Cholesky as a
+    preconditioner, with a few steps of iterative refinement.  The normal
+    equations are badly conditioned by construction -- Theta goes to zero for
+    the variables that end up at a bound and to infinity for the others -- so a
+    plain triangular solve stalls at a primal residual around 1e-6, far short of
+    what is needed to declare optimality. */
+static void ipmSolveRefined(Band* band, const IpmProb* q, const double* theta,
+                            const double* rhs, double* sol,
+                            double* work_m, double* work_nv, double* corr_m){
+  const int m = q->m;
+  bandSolve(band, rhs, sol);
+  for (int it = 0; it < 5; it++) {
+    ipmNormalMul(q, theta, sol, work_m, work_nv);
+    double rmax = 0.0, bmax = 0.0;
+    for (int i = 0; i < m; i++) {
+      work_m[i] = rhs[i] - work_m[i];
+      double a = fabs(work_m[i]); if (a > rmax) rmax = a;
+      double c = fabs(rhs[i]);    if (c > bmax) bmax = c;
+    }
+    if (rmax <= 1e-15 * (bmax + 1.0)) break;
+    bandSolve(band, work_m, corr_m);
+    for (int i = 0; i < m; i++) sol[i] += corr_m[i];
+  }
+}
+
+/* ****************************************************************************
+ * one Newton direction
+ *
+ * The system solved here is
+ *
+ *      A dv                        = e1
+ *      dv + dt                     = e2      (only where h is finite)
+ *      A^T dy + dz - dw            = e3
+ *      Z dv + V dz                 = e4
+ *      W dt + T dw                 = e5      (only where h is finite)
+ *
+ * which reduces, with Theta = (Z/V + W/T)^-1, to
+ *
+ *      g  = e3 - e4/v + e5/t - w e2/t
+ *      (A Theta A^T) dy = e1 + A Theta g
+ *      dv = Theta (A^T dy - g)
+ * ************************************************************************** */
+
+typedef struct {
+  const IpmProb* q;
+  Band*          band;
+  const double*  theta;
+  const double*  v;
+  const double*  t;
+  const double*  z;
+  const double*  w;
+  double*        gbuf;   // nv
+  double*        tmpn;   // nv
+  double*        tmpm;   // m
+  double*        wrk1;   // m
+  double*        wrk2;   // m
+  double*        wrk3;   // nv
+} IpmCtx;
+
+static void ipmDirection(IpmCtx* C,
+                         const double* e1, const double* e2, const double* e3,
+                         const double* e4, const double* e5,
+                         double* dv, double* dy, double* dz,
+                         double* dt, double* dw){
+  const IpmProb* q = C->q;
+  const int m = q->m, nv = q->nv;
+  for (int j = 0; j < nv; j++) {
+    double gj = e3[j] - e4[j] / C->v[j];
+    if (!isinf_lp(q->h[j])) gj += (e5[j] - C->w[j] * e2[j]) / C->t[j];
+    C->gbuf[j] = gj;
+    C->tmpn[j] = C->theta[j] * gj;
+  }
+  ipmAv(q, C->tmpn, C->tmpm);
+  for (int i = 0; i < m; i++) C->tmpm[i] += e1[i];
+  ipmSolveRefined(C->band, q, C->theta, C->tmpm, dy, C->wrk1, C->wrk3, C->wrk2);
+  ipmATy(q, dy, C->tmpn);
+  for (int j = 0; j < nv; j++) {
+    dv[j] = C->theta[j] * (C->tmpn[j] - C->gbuf[j]);
+    dz[j] = (e4[j] - C->z[j] * dv[j]) / C->v[j];
+    if (isinf_lp(q->h[j])) { dt[j] = 0.0; dw[j] = 0.0; }
+    else {
+      dt[j] = e2[j] - dv[j];
+      dw[j] = (e5[j] - C->w[j] * dt[j]) / C->t[j];
+    }
+  }
+}
+
+/** Same, followed by iterative refinement on the *full* Newton system.
+
+    Refining only the normal equations is not enough: near the solution Theta
+    spans close to thirty orders of magnitude, and the recovery
+    dv = Theta (A^T dy - g) then loses so much accuracy that the primal residual
+    of the whole system sticks around 1e-6 no matter how exactly dy was
+    computed.  Evaluating the five equations above in their original scaling and
+    solving again for the correction brings it down to round-off, which is what
+    finally lets the method reach a duality gap below 1e-9. */
+typedef struct {
+  double *f1, *f2, *f3, *f4, *f5;
+  double *cv, *cy, *cz, *ct, *cw;
+} IpmRefine;
+
+static void ipmDirectionRefined(IpmCtx* C, IpmRefine* R,
+                                const double* e1, const double* e2, const double* e3,
+                                const double* e4, const double* e5,
+                                double* dv, double* dy, double* dz,
+                                double* dt, double* dw){
+  const IpmProb* q = C->q;
+  const int m = q->m, nv = q->nv;
+  ipmDirection(C, e1, e2, e3, e4, e5, dv, dy, dz, dt, dw);
+  for (int pass = 0; pass < IPM_REFINE; pass++) {
+    ipmAv(q, dv, C->tmpm);
+    for (int i = 0; i < m; i++) R->f1[i] = e1[i] - C->tmpm[i];
+    ipmATy(q, dy, C->tmpn);
+    for (int j = 0; j < nv; j++) {
+      R->f3[j] = e3[j] - C->tmpn[j] - dz[j] + dw[j];
+      R->f4[j] = e4[j] - C->z[j] * dv[j] - C->v[j] * dz[j];
+      if (isinf_lp(q->h[j])) { R->f2[j] = 0.0; R->f5[j] = 0.0; }
+      else {
+        R->f2[j] = e2[j] - dv[j] - dt[j];
+        R->f5[j] = e5[j] - C->w[j] * dt[j] - C->t[j] * dw[j];
+      }
+    }
+    ipmDirection(C, R->f1, R->f2, R->f3, R->f4, R->f5,
+                 R->cv, R->cy, R->cz, R->ct, R->cw);
+    for (int j = 0; j < nv; j++) {
+      dv[j] += R->cv[j]; dz[j] += R->cz[j];
+      dt[j] += R->ct[j]; dw[j] += R->cw[j];
+    }
+    for (int i = 0; i < m; i++) dy[i] += R->cy[i];
+  }
+}
+
+/** largest step that keeps every component non-negative */
+static void ipmStepLengths(const IpmProb* q, const double* v, const double* t,
+                           const double* z, const double* w,
+                           const double* dv, const double* dt,
+                           const double* dz, const double* dw,
+                           double* alpha_p, double* alpha_d){
+  double ap = 1.0, ad = 1.0;
+  for (int j = 0; j < q->nv; j++) {
+    if (dv[j] < 0) { double a = -v[j] / dv[j]; if (a < ap) ap = a; }
+    if (dz[j] < 0) { double a = -z[j] / dz[j]; if (a < ad) ad = a; }
+    if (!isinf_lp(q->h[j])) {
+      if (dt[j] < 0) { double a = -t[j] / dt[j]; if (a < ap) ap = a; }
+      if (dw[j] < 0) { double a = -w[j] / dw[j]; if (a < ad) ad = a; }
+    }
+  }
+  *alpha_p = ap; *alpha_d = ad;
+}
+
+int vs_lp_solve(VSLinProg* p, int verbose){
+  if (!p) return VS_ERROR;
+  p->solved = 0;
+  if (p->status && p->status[0]) return VS_ERROR;   // e.g. entry buffer overflow
+
+  IpmProb q;
+  if (ipmBuild(p, &q) != VS_OK) {
+    p->status = "problem contains a variable or row that is free on both sides";
+    return VS_ERROR;
+  }
+  const int m = q.m, nv = q.nv;
+
+  int bw = ipmBandwidth(&q);
+  /* Guard against a program whose rows are not ordered so that the matrix is
+     banded: the band would degenerate into a dense matrix and exhaust memory. */
+  if ((double)(bw + 1) * m * (double)sizeof(double) > 2e9) {
+    p->status = "constraint matrix is not banded enough for this backend";
+    ipmProbFree(&q);
+    return VS_ERROR;
+  }
+  Band band;
+  band.m = m; band.bw = bw;
+  band.dat = (double*)vs_malloc(sizeof(double) * (size_t)m * (bw + 1));
+
+  /* one block for all working vectors, so the cleanup stays a single free */
+  const int nvecs_nv = 25, nvecs_m = 8;
+  double* pool = (double*)vs_zalloc(sizeof(double) *
+                                    ((size_t)nvecs_nv * nv + (size_t)nvecs_m * m));
+  if (!band.dat || !pool) {
+    p->status = "out of memory";
+    vs_free(band.dat); vs_free(pool); ipmProbFree(&q);
+    return VS_ERROR;
+  }
+  double* pn = pool;
+#define TAKE_NV(name) double* name = pn; pn += nv;
+  TAKE_NV(v)    TAKE_NV(t)    TAKE_NV(z)    TAKE_NV(w)
+  TAKE_NV(theta) TAKE_NV(dv)  TAKE_NV(dt)   TAKE_NV(dz)
+  TAKE_NV(dw)   TAKE_NV(rd)   TAKE_NV(ru)   TAKE_NV(rvz)
+  TAKE_NV(rtw)  TAKE_NV(best) TAKE_NV(gbuf) TAKE_NV(tmpn)
+  TAKE_NV(wrk3) TAKE_NV(f2)   TAKE_NV(f3)   TAKE_NV(f4)
+  TAKE_NV(f5)   TAKE_NV(cv)   TAKE_NV(cz)   TAKE_NV(ct)
+  TAKE_NV(cw)
+#undef TAKE_NV
+  double* pm = pn;
+#define TAKE_M(name) double* name = pm; pm += m;
+  TAKE_M(y)  TAKE_M(dy) TAKE_M(rp)   TAKE_M(tmpm)
+  TAKE_M(wrk1) TAKE_M(wrk2) TAKE_M(f1) TAKE_M(cy)
+#undef TAKE_M
+
+  /* --- starting point ---------------------------------------------------- */
+  for (int j = 0; j < nv; j++) {
+    if (isinf_lp(q.h[j])) {
+      v[j] = 1.0;
+      t[j] = VS_LP_INF;
+      w[j] = 0.0;
+    } else {
+      v[j] = 0.5 * q.h[j];
+      if (v[j] < 1e-6) v[j] = 1e-6;
+      t[j] = q.h[j] - v[j];
+      if (t[j] < 1e-6) t[j] = 1e-6;
+      w[j] = 1.0;
+    }
+    z[j] = 1.0;
+  }
+
+  IpmCtx C;
+  C.q = &q; C.band = &band; C.theta = theta;
+  C.v = v; C.t = t; C.z = z; C.w = w;
+  C.gbuf = gbuf; C.tmpn = tmpn; C.tmpm = tmpm;
+  C.wrk1 = wrk1; C.wrk2 = wrk2; C.wrk3 = wrk3;
+  IpmRefine R;
+  R.f1 = f1; R.f2 = f2; R.f3 = f3; R.f4 = f4; R.f5 = f5;
+  R.cv = cv; R.cy = cy; R.cz = cz; R.ct = ct; R.cw = cw;
+
+  const double cnorm = 1.0 + vecmaxabs_(q.c, nv);
+  const double bnorm = 1.0 + vecmaxabs_(q.b, m);
+  double bestmerit = 1e300;
+  int    bestiter = -1;
+  int    stall = 0;
+
+  int itersdone = 0;
+  for (int iter = 0; iter < IPM_MAXITER; iter++) {
+    itersdone = iter;
+    /* --- residuals and convergence --------------------------------------- */
+    ipmAv(&q, v, tmpm);
+    for (int i = 0; i < m; i++) rp[i] = q.b[i] - tmpm[i];
+    ipmATy(&q, y, tmpn);
+    int npairs = 0;
+    double comp = 0.0, primalobj = 0.0, dualobj = 0.0;
+    for (int j = 0; j < nv; j++) {
+      rd[j] = q.c[j] - tmpn[j] - z[j] + w[j];
+      ru[j] = isinf_lp(q.h[j]) ? 0.0 : (q.h[j] - v[j] - t[j]);
+      comp += v[j] * z[j];
+      npairs++;
+      primalobj += q.c[j] * v[j];
+      if (!isinf_lp(q.h[j])) { comp += t[j] * w[j]; npairs++; dualobj -= q.h[j] * w[j]; }
+    }
+    for (int i = 0; i < m; i++) dualobj += q.b[i] * y[i];
+    double mu = comp / (double)npairs;
+
+    double perr = vecmaxabs_(rp, m)  / bnorm;
+    double uerr = vecmaxabs_(ru, nv) / bnorm;
+    double derr = vecmaxabs_(rd, nv) / cnorm;
+    double gap  = fabs(primalobj - dualobj) / (1.0 + fabs(primalobj));
+    double merit = perr;
+    if (uerr > merit) merit = uerr;
+    if (derr > merit) merit = derr;
+    if (gap  > merit) merit = gap;
+
+    if (verbose) {
+      fprintf(stderr, "  ipm %3i  mu %9.2e  primal %9.2e  dual %9.2e  bnd %9.2e"
+              "  gap %9.2e\n", iter, mu, perr, derr, uerr, gap);
+    }
+    if (merit < bestmerit * (1.0 - 1e-3)) {
+      bestmerit = merit;
+      bestiter  = iter;
+      memcpy(best, v, sizeof(double) * nv);
+      stall = 0;
+    } else {
+      stall++;
+    }
+    if (merit < IPM_TOL) break;
+    /* Once the iterates stop improving there is nothing left to gain: the
+       normal equations have become too ill conditioned for double precision.
+       Continuing reliably ends in a numerical blow-up, so stop and keep the
+       best point seen. */
+    if (stall >= 6 || merit > 1e4 * bestmerit) break;
+
+    /* --- factorization --------------------------------------------------- */
+    for (int j = 0; j < nv; j++) {
+      double d = z[j] / v[j];
+      if (!isinf_lp(q.h[j])) d += w[j] / t[j];
+      double th = 1.0 / d;
+      if (!(th > IPM_MINTHETA)) th = IPM_MINTHETA;
+      if (th > IPM_MAXTHETA)    th = IPM_MAXTHETA;
+      theta[j] = th;
+    }
+    ipmAssemble(&q, theta, &band);
+    bandCholesky(&band, IPM_REG);
+
+    /* --- predictor ------------------------------------------------------- */
+    for (int j = 0; j < nv; j++) {
+      rvz[j] = -v[j] * z[j];
+      rtw[j] = isinf_lp(q.h[j]) ? 0.0 : -t[j] * w[j];
+    }
+    ipmDirectionRefined(&C, &R, rp, ru, rd, rvz, rtw, dv, dy, dz, dt, dw);
+
+    double ap, ad;
+    ipmStepLengths(&q, v, t, z, w, dv, dt, dz, dw, &ap, &ad);
+    double compaff = 0.0;
+    for (int j = 0; j < nv; j++) {
+      compaff += (v[j] + ap * dv[j]) * (z[j] + ad * dz[j]);
+      if (!isinf_lp(q.h[j])) compaff += (t[j] + ap * dt[j]) * (w[j] + ad * dw[j]);
+    }
+    double sigma = (compaff / (double)npairs) / mu;
+    sigma = sigma * sigma * sigma;
+    if (sigma > 1.0)  sigma = 1.0;
+    if (sigma < 1e-9) sigma = 1e-9;
+
+    /* --- corrector, reusing the factorization ---------------------------- */
+    for (int j = 0; j < nv; j++) {
+      rvz[j] = sigma * mu - v[j] * z[j] - dv[j] * dz[j];
+      rtw[j] = isinf_lp(q.h[j]) ? 0.0
+                                : (sigma * mu - t[j] * w[j] - dt[j] * dw[j]);
+    }
+    ipmDirectionRefined(&C, &R, rp, ru, rd, rvz, rtw, dv, dy, dz, dt, dw);
+
+    /* --- step ------------------------------------------------------------ */
+    ipmStepLengths(&q, v, t, z, w, dv, dt, dz, dw, &ap, &ad);
+    const double frac = 0.9995;
+    ap *= frac; ad *= frac;
+    if (ap > 1.0) ap = 1.0;
+    if (ad > 1.0) ad = 1.0;
+    if (ap < 1e-14 || ad < 1e-14) break;   // stuck against the boundary
+
+    for (int j = 0; j < nv; j++) {
+      v[j] += ap * dv[j];
+      z[j] += ad * dz[j];
+      if (!isinf_lp(q.h[j])) { t[j] += ap * dt[j]; w[j] += ad * dw[j]; }
+    }
+    for (int i = 0; i < m; i++) y[i] += ad * dy[i];
+  }
+
+  if (bestmerit <= IPM_ACCEPT) {
+    p->objval = 0.0;
+    for (int j = 0; j < p->numcols; j++) {
+      double val = q.lo[j] + q.scale[j] * best[j];
+      if (q.sign[j] < 0) val = -val;
+      p->sol[j] = val;
+      p->objval += p->obj[j] * val;
+    }
+    p->solved = 1;
+    p->status = "";
+    if (verbose) {
+      fprintf(stderr, "  ipm finished after %i iterations, best iterate %i,"
+              " accuracy %.3e\n", itersdone, bestiter, bestmerit);
+    }
+  } else {
+    snprintf(p->statusbuf, sizeof(p->statusbuf),
+             "interior point method stalled at an accuracy of %.2e", bestmerit);
+    p->status = p->statusbuf;
+  }
+
+  vs_free(band.dat);
+  vs_free(pool);
+  ipmProbFree(&q);
+  return p->solved ? VS_OK : VS_ERROR;
+}
+
+double vs_lp_get_obj_value(const VSLinProg* p){
+  return (p && p->solved) ? p->objval : 0.0;
+}
+
+double vs_lp_get_col_value(const VSLinProg* p, int col){
+  if (!p || !p->solved || col < 0 || col >= p->numcols) return 0.0;
+  return p->sol[col];
+}
+
+const char* vs_lp_status_msg(const VSLinProg* p){
+  return (p && p->status) ? p->status : "";
+}
+
+const char* vs_lp_backend_name(void){
+  return "built-in interior point";
+}
+
+#endif /* USE_IPM */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/transform.c
+++ b/src/transform.c
@@ -26,6 +26,7 @@
 #include "transform.h"
 #include "transform_internal.h"
 #include "transformtype_operations.h"
+#include "l1campathoptimization.h"
 
 #include "transformfixedpoint.h"
 #ifdef TESTING
@@ -68,6 +69,10 @@ VSTransformConfig vsTransformGetDefaultConfig(const char* modName){
   conf.storeTransforms    = 0;
   conf.smoothZoom         = 0;
   conf.camPathAlgo        = VSOptimalL1;
+  conf.pathD1Weight       = 10.0;
+  conf.pathD2Weight       = 1.0;
+  conf.pathD3Weight       = 100.0;
+  conf.pathMaxZoom        = 15.0;
   return conf;
 }
 
@@ -104,9 +109,6 @@ int vsTransformDataInit(VSTransformData* td, const VSTransformConfig* conf,
     td->conf.maxShift = td->fiDest.height/2;
 
   td->conf.interpolType = VS_MAX(VS_MIN(td->conf.interpolType,VS_BiCubic),VS_Zero);
-
-  // not yet implemented
-  if(td->conf.camPathAlgo==VSOptimalL1) td->conf.camPathAlgo=VSGaussian;
 
   switch(td->conf.interpolType){
    case VS_Zero:     td->interpolate = &interpolateZero; break;
@@ -229,9 +231,18 @@ void vsTransformationsCleanup(VSTransformations* trans){
 int cameraPathOptimization(VSTransformData* td, VSTransformations* trans){
   switch(td->conf.camPathAlgo){
    case VSAvg: return cameraPathAvg(td,trans);
-   case VSOptimalL1: // not yet implenented
+   case VSOptimalL1:
+#ifdef VS_HAVE_LPSOLVER
+    /* cameraPathOptimalL1 leaves trans untouched unless it succeeds, so
+       falling back to the gaussian filter is safe.  It fails for absolute
+       transforms, for sequences shorter than 4 frames, and if the LP turns
+       out to be infeasible. */
+    if(cameraPathOptimalL1(td,trans)==VS_OK) return VS_OK;
+    vs_log_msg(td->conf.modName,
+               "L1 camera path optimization unavailable, using gaussian filter");
+#endif // without an LP solver we always use the gaussian filter
+    /* fall through */
    case VSGaussian: return cameraPathGaussian(td,trans);
-//   case VSOptimalL1: return cameraPathOptimalL1(td,trans);
   }
   return VS_ERROR;
 }

--- a/src/transform.h
+++ b/src/transform.h
@@ -104,6 +104,18 @@ typedef struct VS_API _VSTransformConfig {
     int            storeTransforms; // stores calculated transforms to file
     int            smoothZoom;   // if 1 the zooming is also smoothed. Typically not recommended.
     VSCamPathAlgo  camPathAlgo;  // algorithm to use for camera path optimization
+    /* --- parameters of the L1 optimal camera path (VSOptimalL1) ---
+     * weights of the first, second and third derivative of the camera path in
+     * the objective; the defaults follow fig. 8(d) of Grundmann et al. 2011:
+     * penalizing jerks (D3) an order of magnitude harder than the rest gives
+     * the most pleasant result. */
+    double         pathD1Weight; // weight of |D(P)|   , 0 disables the term
+    double         pathD2Weight; // weight of |D^2(P)| , 0 disables the term
+    double         pathD3Weight; // weight of |D^3(P)| , 0 disables the term
+    /* zoom in percent that the optimization may use up: the crop window it
+     * keeps inside the frame is that much smaller than the frame itself.
+     * Larger values give the optimization more freedom to smooth. */
+    double         pathMaxZoom;
 } VSTransformConfig;
 
 typedef struct VS_API _VSTransformData {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,13 +29,26 @@ endif()
 # Make sure the compiler can find include files from transcode
 include_directories (../src)
 
+option(USE_GLPK "use GLPK as the LP solver for the L1 optimal camera path" ON)
+if(USE_GLPK)
+  find_package(GLPK)
+endif()
+if(GLPK_FOUND)
+  set(LP_SOURCES ../src/l1campathoptimization.c ../src/lpsolver_glpk.c)
+  add_definitions(-DUSE_GLPK -DVS_HAVE_LPSOLVER)
+endif()
+
 add_executable (tests tests.c testutils.c testframework.c ../src/vsvector.c
   ../src/transform.c ../src/transformfloat.c ../src/transformfixedpoint.c
   ../src/libvidstab.c ../src/transformtype.c ../src/frameinfo.c
   ../src/serialize.c ../src/localmotion2transform.c
-  ../src/motiondetect.c ../src/motiondetect_opt.c ../src/boxblur.c)
+  ../src/motiondetect.c ../src/motiondetect_opt.c ../src/boxblur.c
+  ${LP_SOURCES})
 
 target_link_libraries(tests m)
+if(GLPK_FOUND)
+target_link_libraries(tests GLPK::GLPK)
+endif()
 if(USE_OMP)
 target_link_libraries(tests gomp)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,14 +29,28 @@ endif()
 # Make sure the compiler can find include files from transcode
 include_directories (../src)
 
-option(USE_GLPK "use GLPK as the LP solver for the L1 optimal camera path" ON)
-if(USE_GLPK)
+# --- LP solver backend for the L1 optimal camera path -------------------------
+# The built-in interior point solver keeps vid.stab dependency free; GLPK can be
+# selected instead and serves as the cross-check in the test suite.
+set(VIDSTAB_LPSOLVER "builtin" CACHE STRING
+    "LP solver for the L1 optimal camera path: builtin or glpk")
+set_property(CACHE VIDSTAB_LPSOLVER PROPERTY STRINGS builtin glpk)
+
+set(LP_SOURCES ../src/l1campathoptimization.c ../src/lpsolver_ipm.c)
+set(LP_DEFS -DUSE_IPM -DVS_HAVE_LPSOLVER)
+set(LP_BACKEND "built-in interior point")
+if(VIDSTAB_LPSOLVER STREQUAL "glpk")
   find_package(GLPK)
+  if(GLPK_FOUND)
+    set(LP_SOURCES ../src/l1campathoptimization.c ../src/lpsolver_glpk.c)
+    set(LP_DEFS -DUSE_GLPK -DVS_HAVE_LPSOLVER)
+    set(LP_BACKEND "GLPK ${GLPK_VERSION}")
+  else()
+    message(WARNING "VIDSTAB_LPSOLVER=glpk but GLPK was not found, using the built-in solver")
+  endif()
 endif()
-if(GLPK_FOUND)
-  set(LP_SOURCES ../src/l1campathoptimization.c ../src/lpsolver_glpk.c)
-  add_definitions(-DUSE_GLPK -DVS_HAVE_LPSOLVER)
-endif()
+add_definitions(${LP_DEFS})
+message(STATUS "L1 optimal camera path LP solver: ${LP_BACKEND}")
 
 add_executable (tests tests.c testutils.c testframework.c ../src/vsvector.c
   ../src/transform.c ../src/transformfloat.c ../src/transformfixedpoint.c
@@ -46,7 +60,7 @@ add_executable (tests tests.c testutils.c testframework.c ../src/vsvector.c
   ${LP_SOURCES})
 
 target_link_libraries(tests m)
-if(GLPK_FOUND)
+if(GLPK_FOUND AND VIDSTAB_LPSOLVER STREQUAL "glpk")
 target_link_libraries(tests GLPK::GLPK)
 endif()
 if(USE_OMP)

--- a/tests/test_campathopt.c
+++ b/tests/test_campathopt.c
@@ -265,6 +265,20 @@ void test_l1_campath_transforms(TestData* testdata){
   const int N = 50;
   VSTransformConfig conf = vsTransformGetDefaultConfig("test_l1");
   conf.camPathAlgo = VSOptimalL1;
+  /* A caller that does not know about the new fields leaves them at zero (the
+     ffmpeg filter fills the config field by field); that must not produce a
+     degenerate program. */
+  {
+    VSTransformConfig zeroed = conf;
+    zeroed.pathD1Weight = zeroed.pathD2Weight = zeroed.pathD3Weight = 0.0;
+    zeroed.pathMaxZoom = 0.0;
+    VSTransformData ztd;
+    test_bool(vsTransformDataInit(&ztd, &zeroed, &testdata->fi, &testdata->fi) == VS_OK);
+    VSL1Config zc = vsL1ConfigFromTransformConfig(&ztd);
+    test_bool(zc.w1 > 0.0 && zc.w3 > 0.0);
+    test_bool(zc.cropRatio > 0.0 && zc.cropRatio < 1.0);
+    vsTransformDataCleanup(&ztd);
+  }
   VSTransformData td;
   test_bool(vsTransformDataInit(&td, &conf, &testdata->fi, &testdata->fi) == VS_OK);
 

--- a/tests/test_campathopt.c
+++ b/tests/test_campathopt.c
@@ -8,9 +8,10 @@
 #include "l1campathoptimization.h"
 #include "lpsolver.h"
 
-/* objective of the N=24 instance below, produced by
+/* optimal objectives of the two instances below, produced by
    docs/l1campath-reference.py (scipy/HiGHS) */
-#define L1_REFERENCE_OBJECTIVE 1981.95228567
+#define L1_REFERENCE_OBJECTIVE_24  1981.95228567
+#define L1_REFERENCE_OBJECTIVE_200 23046.0705989
 
 /* ---------------------------------------------------------------- helpers */
 
@@ -78,14 +79,18 @@ static VSL1Config campath_testconfig(double width, double height){
 void test_l1_indices(void){
   for (int N = 4; N <= 9; N++) {
     int expected = 0;
-    for (int order = 1; order <= 3; order++)
-      for (int t = 0; t < N - order; t++)
+    for (int t = 0; t < N; t++) {
+      test_bool(vs_l1_rowBase(t, N) == expected);
+      for (int k = 0; k < 8; k++)
+        test_bool(vs_l1_rowCorner(t, k, N) == expected++);
+      for (int order = 1; order <= 3; order++) {
+        if (t >= N - order) continue;
         for (int p = 0; p < 4; p++)
           for (int ul = 0; ul < 2; ul++)
             test_bool(vs_l1_row(order, t, p, ul, N) == expected++);
-    /* the inclusion rows follow directly after the smoothness rows */
-    test_bool(vs_l1_row(4, 0, 0, 0, N) == expected);
-    test_bool(vs_l1_numrows(N) == expected + 8 * N);
+      }
+    }
+    test_bool(vs_l1_numrows(N) == expected);
 
     expected = 0;
     for (int group = 0; group <= 3; group++)
@@ -210,7 +215,6 @@ static void test_l1_run(int N, double w1, double w2, double w3, const char* what
 }
 
 void test_l1_campath(void){
-  fprintf(stderr, "  LP backend: %s\n", vs_lp_backend_name());
   test_l1_run(60,  10.0, 1.0, 100.0, "default weights");
   test_l1_run(200, 10.0, 1.0, 100.0, "default weights");
   /* fig. 8 of the paper: each single term on its own */
@@ -221,26 +225,38 @@ void test_l1_campath(void){
   test_l1_run(4,   10.0, 1.0, 100.0, "minimal length");
 }
 
-/** The objective value of a fixed instance, cross-checked against an
-    independent implementation of the same LP (scipy/HiGHS, see
-    docs/l1campath-reference.py).  This catches a drift in the model that the
-    property checks above would still accept. */
-void test_l1_reference(void){
-  const int N = 24;
+/** The objective of two fixed instances, cross-checked against an independent
+    implementation of the same program (scipy/HiGHS, see
+    docs/l1campath-reference.py).  This is what catches a drift in the model
+    that the property checks above would still accept.
+
+    Since the returned update transforms are always feasible, the objective can
+    never fall meaningfully below the optimum; it may sit slightly above it when
+    the solver stops short of full convergence, which the built-in interior
+    point method does on longer sequences. */
+static void test_l1_reference_at(int N, double reference, double tolerance){
   VSTransformLS* F = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
   VSTransformLS* B = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
   campath_frame_pairs(F, N);
   VSL1Config conf = campath_testconfig(640.0, 480.0);
   double objective = -1.0;
-  test_bool(vsCameraPathOptimalL1LS(F, N, B, &conf, &objective) == VS_OK);
-
-  const double reference = L1_REFERENCE_OBJECTIVE;
-  fprintf(stderr, "  objective %.9g, reference %.9g, rel. deviation %.3g\n",
-          objective, reference, fabs(objective - reference) / reference);
-  test_bool(fabs(objective - reference) <= 1e-6 * reference);
-
+  int status = vsCameraPathOptimalL1LS(F, N, B, &conf, &objective);
+  test_bool(status == VS_OK);
+  if (status == VS_OK) {
+    double rel = (objective - reference) / reference;
+    fprintf(stderr, "  N=%3i objective %.10g, optimum %.10g, %+.2e relative\n",
+            N, objective, reference, rel);
+    test_bool(rel > -1e-9);          // a feasible point cannot beat the optimum
+    test_bool(rel < tolerance);
+  }
   vs_free(F);
   vs_free(B);
+}
+
+void test_l1_reference(void){
+  fprintf(stderr, "  LP backend: %s\n", vs_lp_backend_name());
+  test_l1_reference_at(24,  L1_REFERENCE_OBJECTIVE_24,  1e-6);
+  test_l1_reference_at(200, L1_REFERENCE_OBJECTIVE_200, 1e-3);
 }
 
 /** The library level entry point: relative transforms in, update transforms

--- a/tests/test_campathopt.c
+++ b/tests/test_campathopt.c
@@ -1,0 +1,306 @@
+/*
+ * tests for the L1 optimal camera path (l1campathoptimization.c)
+ *
+ * This file is included by tests.c and only compiled when an LP solver
+ * backend is available.
+ */
+
+#include "l1campathoptimization.h"
+#include "lpsolver.h"
+
+/* objective of the N=24 instance below, produced by
+   docs/l1campath-reference.py (scipy/HiGHS) */
+#define L1_REFERENCE_OBJECTIVE 1981.95228567
+
+/* ---------------------------------------------------------------- helpers */
+
+/** A deterministic synthetic camera path: a slow pan and sway with a slow
+    rotation, plus a high frequency shake on top.  No RNG is involved so that
+    the very same path can be reproduced by the reference implementation. */
+static VSTransformLS campath_ground_truth(int t){
+  double s = (double)t;
+  VSTransformLS c;
+  c.x = 12.0 * s + 5.0 * sin(s * 1.7);
+  c.y = 20.0 * sin(s * 0.05) + 3.0 * cos(s * 2.3);
+  double ang = 0.02 * sin(s * 0.11) + 0.01 * sin(s * 1.9);
+  c.a = cos(ang);
+  c.b = sin(ang);
+  c.extra = 0;
+  return c;
+}
+
+/** frame-pair transforms of that path: F_t = C_{t-1}^{-1} C_t */
+static void campath_frame_pairs(VSTransformLS* F, int N){
+  F[0] = id_transformLS();
+  for (int t = 1; t < N; t++) {
+    VSTransformLS prev = campath_ground_truth(t - 1);
+    VSTransformLS cur  = campath_ground_truth(t);
+    VSTransformLS inv  = invert_transformLS(&prev);
+    F[t] = concat_transformLS(&inv, &cur);
+  }
+}
+
+/** L1 norm of the n-th forward difference of a path, with the a/b part scaled
+    up so that it is commensurable with the pixel-valued x/y part */
+static double campath_diffnorm(const VSTransformLS* P, int N, int order){
+  double* d = (double*)vs_malloc(sizeof(double) * N * 4);
+  for (int t = 0; t < N; t++) {
+    d[4*t+0] = P[t].x; d[4*t+1] = P[t].y;
+    d[4*t+2] = P[t].a * 100.0; d[4*t+3] = P[t].b * 100.0;
+  }
+  int len = N;
+  for (int o = 0; o < order; o++) {
+    for (int t = 0; t < len - 1; t++)
+      for (int k = 0; k < 4; k++) d[4*t+k] = d[4*(t+1)+k] - d[4*t+k];
+    len--;
+  }
+  double sum = 0.0;
+  for (int t = 0; t < len; t++)
+    for (int k = 0; k < 4; k++) sum += fabs(d[4*t+k]);
+  vs_free(d);
+  return sum;
+}
+
+static VSL1Config campath_testconfig(double width, double height){
+  VSL1Config c = vsL1GetDefaultConfig();
+  c.frameWidth  = width;
+  c.frameHeight = height;
+  c.cropRatio   = 1.0 / 1.15;
+  return c;
+}
+
+/* ------------------------------------------------- row and column indexing */
+
+/** The row and column numbering must be a bijection onto 0..num-1, in the
+    order the layout comment in l1campathoptimization.c describes.  A gap or an
+    overlap here silently corrupts the whole constraint matrix, which is why
+    this is checked exhaustively rather than spot-checked. */
+void test_l1_indices(void){
+  for (int N = 4; N <= 9; N++) {
+    int expected = 0;
+    for (int order = 1; order <= 3; order++)
+      for (int t = 0; t < N - order; t++)
+        for (int p = 0; p < 4; p++)
+          for (int ul = 0; ul < 2; ul++)
+            test_bool(vs_l1_row(order, t, p, ul, N) == expected++);
+    /* the inclusion rows follow directly after the smoothness rows */
+    test_bool(vs_l1_row(4, 0, 0, 0, N) == expected);
+    test_bool(vs_l1_numrows(N) == expected + 8 * N);
+
+    expected = 0;
+    for (int group = 0; group <= 3; group++)
+      for (int t = 0; t < N - group; t++)
+        for (int p = 0; p < 4; p++)
+          test_bool(vs_l1_col(group, t, p, N) == expected++);
+    test_bool(vs_l1_numcols(N) == expected);
+  }
+}
+
+/* ---------------------------------------------------- the LS transform type */
+
+void test_l1_transformLS(void){
+  VSTransformLS t = { 12.0, -7.0, 0.0, 0.0, 0 };
+  t.a = 1.05 * cos(0.3);
+  t.b = 1.05 * sin(0.3);
+
+  /* t^-1 t == identity */
+  VSTransformLS inv = invert_transformLS(&t);
+  VSTransformLS id  = concat_transformLS(&inv, &t);
+  test_bool(fabs(id.x - 0.0) < 1e-9);
+  test_bool(fabs(id.y - 0.0) < 1e-9);
+  test_bool(fabs(id.a - 1.0) < 1e-9);
+  test_bool(fabs(id.b - 0.0) < 1e-9);
+
+  /* concatenation must agree with applying the transforms one after another */
+  VSTransformLS u = { -3.0, 8.0, 0.98 * cos(-0.1), 0.98 * sin(-0.1), 0 };
+  VSTransformLS tu = concat_transformLS(&t, &u);
+  double x1, y1, x2, y2;
+  transformLS_vec(&x1, &y1, &u, 40.0, -25.0);
+  transformLS_vec(&x1, &y1, &t, x1, y1);
+  transformLS_vec(&x2, &y2, &tu, 40.0, -25.0);
+  test_bool(fabs(x1 - x2) < 1e-9);
+  test_bool(fabs(y1 - y2) < 1e-9);
+
+  /* the (x,y,alpha,zoom) round trip must be lossless ... */
+  VSTransform az = transformLStoAZ(&t);
+  VSTransformLS back = transformAZtoLS(&az);
+  test_bool(fabs(back.x - t.x) < 1e-9);
+  test_bool(fabs(back.y - t.y) < 1e-9);
+  test_bool(fabs(back.a - t.a) < 1e-9);
+  test_bool(fabs(back.b - t.b) < 1e-9);
+
+  /* ... and describe the same mapping as vid.stab's own prepare_transform() */
+  VSFrameInfo fi;
+  vsFrameInfoInit(&fi, 640, 480, PF_GRAY8);
+  PreparedTransform pt = prepare_transform(&az, &fi);
+  Vec v = { 320 + 40, 240 - 25 };
+  double px, py;
+  transform_vec_double(&px, &py, &pt, &v);
+  transformLS_vec(&x1, &y1, &t, 40.0, -25.0);
+  test_bool(fabs((px - 320) - x1) < 1e-6);
+  test_bool(fabs((py - 240) - y1) < 1e-6);
+}
+
+/* --------------------------------------------------------- the optimization */
+
+/** Solves the LP for the synthetic path and checks the three properties that
+    make the result usable: the derivatives of the stabilized path go down, the
+    crop window never leaves the frame, and the update transforms stay within
+    the proximity bounds. */
+static void test_l1_run(int N, double w1, double w2, double w3, const char* what){
+  const double W = 640.0, H = 480.0;
+  VSTransformLS* F = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  VSTransformLS* B = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  VSTransformLS* C = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  VSTransformLS* P = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  campath_frame_pairs(F, N);
+  for (int t = 0; t < N; t++) C[t] = campath_ground_truth(t);
+
+  VSL1Config conf = campath_testconfig(W, H);
+  conf.w1 = w1; conf.w2 = w2; conf.w3 = w3;
+  double objective = -1.0;
+  int status = vsCameraPathOptimalL1LS(F, N, B, &conf, &objective);
+  test_bool(status == VS_OK);
+  if (status != VS_OK) { vs_free(F); vs_free(B); vs_free(C); vs_free(P); return; }
+  test_bool(objective >= 0.0);
+
+  for (int t = 0; t < N; t++) P[t] = concat_transformLS(&C[t], &B[t]);
+
+  double before[3], after[3];
+  for (int o = 1; o <= 3; o++) {
+    before[o-1] = campath_diffnorm(C, N, o);
+    after[o-1]  = campath_diffnorm(P, N, o);
+  }
+  fprintf(stderr, "  %-22s N=%3i  |D|: %8.2f -> %8.2f   |D2|: %8.2f -> %8.2f"
+          "   |D3|: %8.2f -> %8.2f\n", what, N,
+          before[0], after[0], before[1], after[1], before[2], after[2]);
+
+  /* every weighted term must improve, the unweighted ones may not */
+  if (w1 > 0) test_bool(after[0] < before[0]);
+  if (w2 > 0) test_bool(after[1] < before[1]);
+  if (w3 > 0) test_bool(after[2] < before[2]);
+  /* The shake dominates the higher derivatives, so on a sequence long enough
+     for the optimizer to have room they must drop a lot.  For very short
+     sequences there are only a couple of difference terms and the bound is
+     not meaningful. */
+  if (N >= 20) {
+    if (w2 > 0) test_bool(after[1] < 0.2 * before[1]);
+    if (w3 > 0) test_bool(after[2] < 0.2 * before[2]);
+  }
+
+  /* inclusion: all four crop corners stay inside the frame */
+  const double cw = W / 2.0 * conf.cropRatio, ch = H / 2.0 * conf.cropRatio;
+  const double cx[4] = { -cw,  cw, cw, -cw };
+  const double cy[4] = { -ch, -ch, ch,  ch };
+  double worst = -1e30;
+  for (int t = 0; t < N; t++) {
+    for (int i = 0; i < 4; i++) {
+      double px, py;
+      transformLS_vec(&px, &py, &B[t], cx[i], cy[i]);
+      worst = VS_MAX(worst, fabs(px) - W / 2.0);
+      worst = VS_MAX(worst, fabs(py) - H / 2.0);
+    }
+    /* proximity */
+    test_bool(B[t].a >= conf.minScale - 1e-6 && B[t].a <= conf.maxScale + 1e-6);
+    test_bool(fabs(B[t].b) <= conf.maxSkewDev + 1e-6);
+  }
+  test_bool(worst <= 1e-6);
+
+  vs_free(F); vs_free(B); vs_free(C); vs_free(P);
+}
+
+void test_l1_campath(void){
+  fprintf(stderr, "  LP backend: %s\n", vs_lp_backend_name());
+  test_l1_run(60,  10.0, 1.0, 100.0, "default weights");
+  test_l1_run(200, 10.0, 1.0, 100.0, "default weights");
+  /* fig. 8 of the paper: each single term on its own */
+  test_l1_run(60,   1.0, 0.0,   0.0, "only |D|");
+  test_l1_run(60,   0.0, 1.0,   0.0, "only |D^2|");
+  test_l1_run(60,   0.0, 0.0,   1.0, "only |D^3|");
+  /* the shortest sequence the third derivative is defined on */
+  test_l1_run(4,   10.0, 1.0, 100.0, "minimal length");
+}
+
+/** The objective value of a fixed instance, cross-checked against an
+    independent implementation of the same LP (scipy/HiGHS, see
+    docs/l1campath-reference.py).  This catches a drift in the model that the
+    property checks above would still accept. */
+void test_l1_reference(void){
+  const int N = 24;
+  VSTransformLS* F = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  VSTransformLS* B = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  campath_frame_pairs(F, N);
+  VSL1Config conf = campath_testconfig(640.0, 480.0);
+  double objective = -1.0;
+  test_bool(vsCameraPathOptimalL1LS(F, N, B, &conf, &objective) == VS_OK);
+
+  const double reference = L1_REFERENCE_OBJECTIVE;
+  fprintf(stderr, "  objective %.9g, reference %.9g, rel. deviation %.3g\n",
+          objective, reference, fabs(objective - reference) / reference);
+  test_bool(fabs(objective - reference) <= 1e-6 * reference);
+
+  vs_free(F);
+  vs_free(B);
+}
+
+/** The library level entry point: relative transforms in, update transforms
+    out, and a sane refusal for the cases it cannot handle. */
+void test_l1_campath_transforms(TestData* testdata){
+  const int N = 50;
+  VSTransformConfig conf = vsTransformGetDefaultConfig("test_l1");
+  conf.camPathAlgo = VSOptimalL1;
+  VSTransformData td;
+  test_bool(vsTransformDataInit(&td, &conf, &testdata->fi, &testdata->fi) == VS_OK);
+
+  VSTransformations trans;
+  vsTransformationsInit(&trans);
+  trans.ts = (VSTransform*)vs_malloc(sizeof(VSTransform) * N);
+  trans.len = N;
+  /* relative transforms of the synthetic path */
+  VSTransformLS* F = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  campath_frame_pairs(F, N);
+  for (int t = 0; t < N; t++) trans.ts[t] = transformLStoAZ(&F[t]);
+
+  test_bool(vsPreprocessTransforms(&td, &trans) == VS_OK);
+
+  /* The whole point of the inclusion constraints is that the stabilized frame
+     has no undefined border pixels.  Check that end to end by running the
+     corners of the destination frame through exactly the mapping the warping
+     code uses (see transformPlanar in transformfloat.c):
+
+        p_s = z R(-alpha) p_d - (x,y),   z = 1 - zoom/100
+
+     and requiring that they land inside the source frame. */
+  const double sx = td.fiSrc.width / 2.0,  sy = td.fiSrc.height / 2.0;
+  const double dx = td.fiDest.width / 2.0, dy = td.fiDest.height / 2.0;
+  double worst = -1e30;
+  for (int t = 0; t < N; t++) {
+    double z = 1.0 - trans.ts[t].zoom / 100.0;
+    double zcos = z * cos(-trans.ts[t].alpha);
+    double zsin = z * sin(-trans.ts[t].alpha);
+    const double cx[4] = { -dx,  dx, dx, -dx };
+    const double cy[4] = { -dy, -dy, dy,  dy };
+    for (int i = 0; i < 4; i++) {
+      double px =  zcos * cx[i] + zsin * cy[i] - trans.ts[t].x;
+      double py = -zsin * cx[i] + zcos * cy[i] - trans.ts[t].y;
+      worst = VS_MAX(worst, fabs(px) - sx);
+      worst = VS_MAX(worst, fabs(py) - sy);
+    }
+    test_bool(fabs(trans.ts[t].alpha) < 0.2);
+  }
+  fprintf(stderr, "  worst border overshoot after warping: %.4f px\n", worst);
+  test_bool(worst <= 1e-6);
+
+  /* absolute transforms are not supported and must be rejected, not guessed */
+  td.conf.relative = 0;
+  test_bool(cameraPathOptimalL1(&td, &trans) == VS_ERROR);
+  td.conf.relative = 1;
+  /* too short for the third derivative */
+  trans.len = 3;
+  test_bool(cameraPathOptimalL1(&td, &trans) == VS_ERROR);
+  trans.len = N;
+
+  vs_free(F);
+  vsTransformationsCleanup(&trans);
+  vsTransformDataCleanup(&td);
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -45,6 +45,9 @@
 #include "test_localmotion2transform.c"
 #include "test_determinism.c"
 #include "test_packed.c"
+#ifdef VS_HAVE_LPSOLVER
+#include "test_campathopt.c"
+#endif
 
 #define FRAMENUM 5
 
@@ -162,6 +165,16 @@ int main(int argc, char** argv){
   if(all || contains(argv,argc,"--testDET", "deterministic output")){
     UNIT(test_determinism(&testdata));
   }
+
+#ifdef VS_HAVE_LPSOLVER
+  if(all || contains(argv,argc,"--testL1", "L1 optimal camera path")){
+    UNIT(test_l1_indices());
+    UNIT(test_l1_transformLS());
+    UNIT(test_l1_campath());
+    UNIT(test_l1_reference());
+    UNIT(test_l1_campath_transforms(&testdata));
+  }
+#endif
 
   // free
   /* testdata was zeroed above, so unallocated frames have NULL planes and


### PR DESCRIPTION
## Summary
- Implements the L1-optimal camera path from Grundmann, Kwatra & Essa (CVPR 2011): minimizes the weighted L1 norm of the first three derivatives of the stabilized path `P_t = C_t B_t` over update transforms `B_t`, subject to smoothness, proximity, and inclusion (crop-window-stays-in-frame) constraints. Revives and fixes a previously unfinished 2014/2015 implementation — corrected slack-variable sign bug, fixed inclusion constraints to cover all 4 crop corners against the actual crop rectangle, and added the previously-missing proximity constraints.
- Adds a self-contained, dependency-free interior-point LP solver (`src/lpsolver_ipm.c`) as the default backend, so this no longer requires linking GLPK; GLPK remains selectable via `-DVIDSTAB_LPSOLVER=glpk` and is used as a cross-check. The IPM solver exploits the problem's banded time structure for O(N) factorization and is faster and more scalable than GLPK (15.8s vs 59s at 1000 frames).
- Defaults the L1 weights when a caller (e.g. the ffmpeg filter, which fills `VSTransformConfig` field-by-field) leaves the new config fields at zero, so `VSOptimalL1` can't silently degenerate into an unconstrained or zero-room program.
- `tests/test_campathopt.c`: exhaustive row/column-numbering checks, derivative-reduction checks per fig. 8 of the paper, end-to-end crop-containment through the actual warping formula, and agreement with an independent scipy/HiGHS reference implementation (`docs/l1campath-reference.py`).

**Note for reviewers:** this branch was created from a commit that also contains an unrelated docs commit ("Add design spec for synthetic pixel-format stabilizer tests") from a separate, independent PR (#157). Once #157 merges, GitHub will automatically recompute this PR's diff against the new `master` and that file will drop out of the file list here — it is not part of this PR's actual change.

## Test plan
- [x] `tests/test_campathopt.c` covers row/column indexing, the LS transform algebra, the optimizer's derivative-reduction properties, agreement with an independent reference solution, and end-to-end border containment
- [x] `./tests --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)