### PR TITLE
tests: verify detection -> L1 camera path integration on synthetic frames

### DIFF
--- a/tests/generate_synthetic.c
+++ b/tests/generate_synthetic.c
@@ -129,6 +129,50 @@ void generateCircleSquareFrames(VSFrame* frames, VSFrameInfo* fi, VSPixelFormat 
   }
 }
 
+/* A longer, bounded-amplitude "shake" path: sway plus jitter, no net drift.
+   getTestFrameTransform() (used above) grows without bound frame over frame,
+   which is fine for the short 6-frame sequences elsewhere but would carry the
+   content off-canvas well before frame 30 -- this instead orbits around the
+   identity so the synthetic scene stays trackable for the whole sequence,
+   which is what a real detection -> L1-camera-path smoothing test needs. */
+#define SYN_L1_NUM_FRAMES 30
+
+static VSTransform synL1ShakeTransform(int i){
+  double s = (double)i;
+  VSTransform t = null_transform();
+  t.x = 15.0 * sin(s * 0.35) + 4.0 * sin(s * 1.3);
+  t.y = 10.0 * sin(s * 0.27 + 1.0) + 3.0 * sin(s * 1.7);
+  t.alpha = (2.0 * sin(s * 0.19) + 0.5 * sin(s * 2.1)) * M_PI / 180.0;
+  t.zoom = 0;
+  return t;
+}
+
+/* Same base scene and warp mechanism as generateCircleFrames(), but driven by
+   synL1ShakeTransform() instead of getTestFrameTransform(). */
+void generateL1ShakeFrames(VSFrame* frames, VSFrameInfo* fi, VSPixelFormat pf,
+                           int width, int height, int numFrames){
+  int i;
+  VSTransformConfig conf;
+  VSTransformData td;
+
+  test_bool(vsFrameInfoInit(fi, width, height, pf) != 0);
+  for(i=0; i<numFrames; i++)
+    vsFrameAllocate(&frames[i], fi);
+
+  paintSynBase(&frames[0], fi);
+
+  conf = vsTransformGetDefaultConfig("gen_syn_l1shake");
+  conf.interpolType = VS_Zero;
+  test_bool(vsTransformDataInit(&td, &conf, fi, fi) == VS_OK);
+  for(i=1; i<numFrames; i++){
+    VSTransform t = synL1ShakeTransform(i);
+    test_bool(vsTransformPrepare(&td, &frames[i-1], &frames[i]) == VS_OK);
+    test_bool(vsDoTransform(&td, t) == VS_OK);
+    test_bool(vsTransformFinish(&td) == VS_OK);
+  }
+  vsTransformDataCleanup(&td);
+}
+
 void dumpFramesAsPPM(const VSFrame* frames, const VSFrameInfo* fi, int numFrames,
                      const char* prefix){
   int i;

--- a/tests/test_campathopt.c
+++ b/tests/test_campathopt.c
@@ -334,3 +334,133 @@ void test_l1_campath_transforms(TestData* testdata){
   vsTransformationsCleanup(&trans);
   vsTransformDataCleanup(&td);
 }
+
+/* ------------------------------------------- detection -> L1 integration */
+
+/** Everything above exercises the L1 optimizer against purely synthetic,
+    mathematically-defined transform sequences. This closes the remaining
+    gap: run real vsMotionDetection on the synthetic circle frames from
+    generate_synthetic.c (see tests/test_synthetic.c) to get a *detected*
+    path -- not a known ground truth -- then feed that through the real
+    library entry point (vsPreprocessTransforms with camPathAlgo ==
+    VSOptimalL1) and check the same two properties test_l1_run() and
+    test_l1_campath_transforms() check separately: the stabilized path is
+    genuinely smoother, and the crop window never leaves the frame. */
+static void test_l1_synthetic_detection_format(VSPixelFormat pf){
+  const int N = SYN_L1_NUM_FRAMES;
+  VSFrameInfo fi;
+  VSFrame frames[SYN_L1_NUM_FRAMES];
+  VSTransform* raw;
+  VSTransformLS *F, *C, *B, *P;
+  VSMotionDetectConfig mdconf;
+  VSMotionDetect md;
+  VSTransformConfig tdconf;
+  VSTransformData td;
+  VSTransformations trans;
+  double before2, after2, before3, after3;
+  double sx, sy, dx, dy, worst;
+  int i;
+
+  fprintf(stderr, "--- detection -> L1 campath, %s ---\n", synFormatName(pf));
+
+  generateL1ShakeFrames(frames, &fi, pf, SYN_WIDTH, SYN_HEIGHT, N);
+
+  /* detect the raw path from the real synthetic frames, frame by frame,
+     exactly as test_synthetic.c's checkRecoveredMotion() does -- except here
+     the detected transform itself (not a known injected one) is what feeds
+     the optimizer below. */
+  mdconf = vsMotionDetectGetDefaultConfig("test_l1_syn_md");
+  test_bool(vsMotionDetectInit(&md, &mdconf, &fi) == VS_OK);
+  md.conf.numThreads = 1;
+
+  raw = (VSTransform*)vs_malloc(sizeof(VSTransform) * N);
+  for(i=0; i<N; i++){
+    LocalMotions lms;
+    test_bool(vsMotionDetection(&md, &lms, &frames[i]) == VS_OK);
+    raw[i] = vsSimpleMotionsToTransform(fi, "test_l1_syn_md", &lms);
+    vs_vector_del(&lms);
+    vsFrameFree(&frames[i]);
+  }
+  vsMotionDetectionCleanup(&md);
+
+  /* the real library entry point: vsPreprocessTransforms() dispatches to
+     cameraPathOptimalL1() when camPathAlgo == VSOptimalL1, exactly as
+     ffmpeg's vidstabtransform filter calls it */
+  tdconf = vsTransformGetDefaultConfig("test_l1_syn_trans");
+  tdconf.camPathAlgo = VSOptimalL1;
+  test_bool(vsTransformDataInit(&td, &tdconf, &fi, &fi) == VS_OK);
+
+  vsTransformationsInit(&trans);
+  trans.ts = (VSTransform*)vs_malloc(sizeof(VSTransform) * N);
+  trans.len = N;
+  for(i=0; i<N; i++) trans.ts[i] = raw[i];
+
+  test_bool(vsPreprocessTransforms(&td, &trans) == VS_OK);
+
+  /* trans.ts is now the *render* transform updateToRenderTransform(B_t, ...)
+     -- negated and folded together with the crop-window zoom, not B_t itself
+     (see l1campathoptimization.c) -- which is exactly right for the
+     border-inclusion check below, but not something to reverse-engineer B_t
+     from. For the smoothness check we instead call the LS-level solver
+     directly (vsCameraPathOptimalL1LS(), the same function
+     cameraPathOptimalL1() calls internally, and the same one test_l1_run()
+     uses) on the identical F[] built from the raw detected path, to get the
+     true update transforms B_t and build the stabilized path P_t = C_t B_t. */
+  F = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  C = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  B = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  P = (VSTransformLS*)vs_malloc(sizeof(VSTransformLS) * N);
+  F[0] = id_transformLS();
+  C[0] = id_transformLS();
+  for(i=1; i<N; i++){
+    F[i] = transformAZtoLS(&raw[i]);
+    C[i] = concat_transformLS(&C[i-1], &F[i]);
+  }
+  {
+    VSL1Config lsConf = vsL1ConfigFromTransformConfig(&td);
+    double objective = -1.0;
+    test_bool(vsCameraPathOptimalL1LS(F, N, B, &lsConf, &objective) == VS_OK);
+  }
+  for(i=0; i<N; i++)
+    P[i] = concat_transformLS(&C[i], &B[i]);
+
+  before2 = campath_diffnorm(C, N, 2);
+  after2  = campath_diffnorm(P, N, 2);
+  before3 = campath_diffnorm(C, N, 3);
+  after3  = campath_diffnorm(P, N, 3);
+  fprintf(stderr, "  |D2|: %8.2f -> %8.2f   |D3|: %8.2f -> %8.2f\n",
+          before2, after2, before3, after3);
+  test_bool(after2 < before2);
+  test_bool(after3 < before3);
+
+  /* crop-window inclusion, ported from test_l1_campath_transforms() */
+  sx = td.fiSrc.width / 2.0;  sy = td.fiSrc.height / 2.0;
+  dx = td.fiDest.width / 2.0; dy = td.fiDest.height / 2.0;
+  worst = -1e30;
+  for(i=0; i<N; i++){
+    double z = 1.0 - trans.ts[i].zoom / 100.0;
+    double zcos = z * cos(-trans.ts[i].alpha);
+    double zsin = z * sin(-trans.ts[i].alpha);
+    const double cx[4] = { -dx,  dx, dx, -dx };
+    const double cy[4] = { -dy, -dy, dy,  dy };
+    int k;
+    for(k=0; k<4; k++){
+      double px =  zcos * cx[k] + zsin * cy[k] - trans.ts[i].x;
+      double py = -zsin * cx[k] + zcos * cy[k] - trans.ts[i].y;
+      worst = VS_MAX(worst, fabs(px) - sx);
+      worst = VS_MAX(worst, fabs(py) - sy);
+    }
+  }
+  fprintf(stderr, "  worst border overshoot after warping: %.4f px\n", worst);
+  test_bool(worst <= 1e-6);
+
+  vs_free(F); vs_free(C); vs_free(B); vs_free(P);
+  vs_free(raw);
+  vsTransformationsCleanup(&trans);
+  vsTransformDataCleanup(&td);
+}
+
+void test_l1_synthetic_detection(void){
+  test_l1_synthetic_detection_format(PF_YUV420P);
+  test_l1_synthetic_detection_format(PF_RGBA);
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -46,10 +46,10 @@
 #include "test_localmotion2transform.c"
 #include "test_determinism.c"
 #include "test_packed.c"
+#include "test_synthetic.c"
 #ifdef VS_HAVE_LPSOLVER
 #include "test_campathopt.c"
 #endif
-#include "test_synthetic.c"
 
 #define FRAMENUM 5
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -212,6 +212,7 @@ int main(int argc, char** argv){
     UNIT(test_l1_campath());
     UNIT(test_l1_reference());
     UNIT(test_l1_campath_transforms(&testdata));
+    UNIT(test_l1_synthetic_detection());
   }
 #endif
 


### PR DESCRIPTION
## Summary
- Adds a bounded-amplitude "shake" synthetic sequence (`generateL1ShakeFrames`, 30 frames of sway+jitter with no net drift, so content stays trackable throughout) and a new `test_l1_synthetic_detection()`, wired into `--testL1`.
- The existing L1 tests (`test_l1_run`, `test_l1_campath_transforms`, from #158) only exercise the L1 optimizer against purely synthetic, mathematically-defined transform sequences. This closes the remaining gap: runs real `vsMotionDetection` (using the synthetic frame generator from #157) to get an actual *detected* path, then feeds that through the real `cameraPathOptimalL1` entry point and checks the same two properties — meaningfully smoother stabilized path (2nd/3rd derivative L1 norm), and the crop window staying inside the frame — against a real detected path, across two representative pixel formats (`PF_YUV420P`, `PF_RGBA`).
- Also fixes an include-order bug that only appears once both #157 and #158 are merged together: each PR independently added its own `#include` line after `test_packed.c`, and the automatic merge left `test_campathopt.c` included before `test_synthetic.c` — but the new integration test in `test_campathopt.c` needs `test_synthetic.c`'s `synFormatName()` to already be declared. Swapped the order back.

## Test plan
- [x] `./tests --all` passes (28/28 units) on the default SSE2 build
- [x] `./tests --all` passes (28/28 units) on a `-DSSE2_FOUND=OFF` (plain-C) build

🤖 Generated with [Claude Code](https://claude.com/claude-code)