### PR TITLE
l1campath: fold the L1 parameters into zoom/optzoom/smoothing, bump to 1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include (GNUInstallDirs)
 find_package(OpenMP)
 
 set(MAJOR_VERSION 1)
-set(MINOR_VERSION 2)
+set(MINOR_VERSION 3)
 set(PATCH_VERSION 0)
 # note the separator between minor and patch: without it this produced "1.20"
 # for 1.2.0 (and "1.10" for 1.1.0), which is what ends up in the Version field

--- a/Changelog
+++ b/Changelog
@@ -1,8 +1,8 @@
-1.2	L1-optimal camera path (Grundmann et al., CVPR 2011) implemented and
+1.3	L1-optimal camera path (Grundmann et al., CVPR 2011) implemented and
 	enabled: camPathAlgo=VSOptimalL1 now really runs the optimization
-	instead of falling back to the gaussian filter.  New config fields
-	pathD1Weight, pathD2Weight, pathD3Weight and pathMaxZoom; callers
-	that leave them at zero get the defaults.
+	instead of falling back to the gaussian filter.  No new config
+	fields: the optimization takes its zoom budget from zoom/optZoom
+	and its horizon from smoothing.
 	Built-in interior point LP solver, no external dependency; GLPK
 	selectable with cmake -DVIDSTAB_LPSOLVER=glpk.
 1.1     use openMP to do parallel execution

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ A video acquired using a hand-held camera or a camera mounted on a vehicle, typi
    composed of static, linear and parabolic segments, giving a result that looks
    like it came off a dolly or a crane rather than off a low-pass filter. Solved
    as a linear program with a built-in solver, so it needs no extra dependency.
+   It is steered by the usual knobs: `zoom`/`optzoom` give it the crop budget it
+   may spend, `smoothing` the horizon over which the path should stay rigid.
  * Detection algorithms:
   * Smart and fast multi measurement fields algorithm with contrast selection.
   * Brute force algorithm only for translations.

--- a/docs/ffmpeg-doc-update.md
+++ b/docs/ffmpeg-doc-update.md
@@ -1,0 +1,112 @@
+# Parameter meanings under the L1 optimal camera path
+
+Notes for a later patch to ffmpeg's `doc/filters.texi` (section
+`vidstabtransform`) and, where noted, to `libavfilter/vf_vidstabtransform.c`.
+
+vid.stab 1.3 makes `optalgo=opt` (`VSOptimalL1`, the L1 optimal camera path of
+Grundmann et al., CVPR 2011) actually run instead of silently falling back to
+the gaussian filter. It deliberately introduces **no new filter options**: the
+optimization reads its two inputs off options that already exist. What changes
+is therefore not the option list but what three of the options *mean* when
+`optalgo=opt` is selected.
+
+The filter code needs no change for this — `VSTransformConfig` has no new
+fields, and the existing `AVOption` table already fills `smoothing`, `zoom`,
+`optzoom` and `zoomspeed`. Only the documentation is out of date. (One
+optional code change is noted under "Defaults" below.)
+
+## How the algorithm uses them
+
+The L1 optimization computes a *crop window*, smaller than the frame, and moves
+it along an optimized path made of static, linear and parabolic segments, under
+the hard constraint that the window never leaves the frame. So it needs exactly
+two things from the user: how much smaller than the frame that window may be
+(the zoom budget), and over what timescale the path should stay rigid.
+
+## `smoothing`
+
+Currently documented as the number of frames (value\*2 + 1) used for lowpass
+filtering the camera movements — accurate for `optalgo=gauss` and `avg`, and
+meaningless as written for `optalgo=opt`, which does not use a sliding window at
+all. Since `optalgo=opt` is the default (see "Defaults" below), the documented
+meaning is wrong for the default configuration.
+
+Proposed addition:
+
+> With @code{optalgo=opt} there is no filter window; @var{smoothing} is read as
+> the timescale, in frames, over which the camera path should stay rigid. It
+> sets the relative weights of the first, second and third derivative of the
+> path in the optimization: a small value produces short static holds with quick
+> transitions between them, a large value long sweeping dolly- or crane-like
+> moves. The default of 15 corresponds to the weights of the original paper.
+
+Worth knowing when advising users: the effect is real and monotone but modest.
+On a synthetic 200-frame shaky pan at 640x480 with the default 15% budget,
+going from `smoothing=3` to `smoothing=60` lowered the L1 norm of the
+stabilized path's acceleration by ~30% and of its jerk by ~40%. The zoom budget
+below is by far the stronger knob; users chasing a smoother result should reach
+for `zoom`/`optzoom` first.
+
+## `zoom` and `optzoom`
+
+Currently: `zoom` is a percentage to zoom in (negative zooms out), `optzoom`
+selects whether an optimal zoom is determined (0 = none, 1 = static, 2 =
+adaptive), `zoomspeed` bounds the per-frame zoom of the adaptive mode.
+
+Under `optalgo=opt` these together supply the zoom budget, i.e. how much smaller
+than the frame the crop window is allowed to be. The budget is spent *inside*
+the optimization rather than applied on top of it, which is the part users need
+to be told:
+
+> With @code{optalgo=opt}, @var{zoom} and @var{optzoom} give the optimization
+> the zoom it may spend on stabilization, rather than being applied to the
+> result afterwards. @code{optzoom=0} restricts it to exactly @var{zoom}
+> percent; with @code{optzoom=1} or @code{2} it uses @var{zoom} if one was
+> given and 15% otherwise. The larger the budget, the more freedom the
+> optimization has and the smoother the resulting path. @code{optzoom=2} and
+> @var{zoomspeed} have no effect here: the crop window has to be fixed before
+> the optimization runs, so @code{optzoom=2} behaves like @code{optzoom=1}.
+>
+> @code{optzoom=0} together with @code{zoom=0} leaves the optimization no room
+> to move at all; in that case it declines and the gaussian filter is used
+> instead, with a message in the log.
+
+A negative `zoom` (zoom out) is not meaningful as a budget and is treated as 0.
+
+## Defaults — note that this changes the out-of-the-box behaviour
+
+`vf_vidstabtransform.c` already defaults to `optalgo=opt` (`{.i64 =
+VSOptimalL1}`, marked "from version 1.0 on"), which until now silently fell back
+to the gaussian filter inside the library. Once ffmpeg is built against
+vid.stab 1.3, **every user who does not pass `optalgo` explicitly gets the L1
+optimal path instead of the gaussian filter.** The option table needs no change
+for that, but the patch should say so plainly, and it is the main thing
+reviewers will want to know.
+
+The remaining defaults — `smoothing=15`, `zoom=0`, `optzoom=1` — give a 15% zoom
+budget and the paper's weights, i.e. exactly the library's own defaults. No
+change needed.
+
+## Tripod mode
+
+`tripod=1` sets `relative=0` and `smoothing=0`. The L1 optimization requires
+relative transforms (it builds the camera path as the running composition of the
+frame-pair transforms), so it declines and the gaussian filter runs instead,
+with a message in the log. Tripod mode therefore behaves exactly as before, and
+the documentation of `tripod` needs no change — but it is worth a sentence in
+the `optalgo` description:
+
+> @code{optalgo=opt} requires relative transforms and at least 4 frames; where
+> it cannot be applied — virtual tripod mode, for instance, which implies
+> @code{relative=0} — the gaussian filter is used instead and a message is
+> written to the log.
+
+## Optional code change
+
+`vf_vidstabtransform.c` fills `VSTransformConfig` field by field and never calls
+`vsTransformGetDefaultConfig()`, so any field it does not know about arrives as
+zero. That is safe today — the L1 path adds no fields, and the fields it does
+read are all set by the filter — but calling `vsTransformGetDefaultConfig()`
+first and overriding from the option table would make the filter robust against
+future library fields. Worth mentioning in the patch as a follow-up, not a
+requirement.

--- a/src/l1campathoptimization.c
+++ b/src/l1campathoptimization.c
@@ -364,7 +364,7 @@ VSL1Config vsL1GetDefaultConfig(void){
   c.wAffine     = 100.0;
   c.frameWidth  = 0.0;
   c.frameHeight = 0.0;
-  c.cropRatio   = 1.0 / 1.15;   // matches the pathMaxZoom default of 15 percent
+  c.cropRatio   = 1.0 / (1.0 + VS_L1_DEFAULT_ZOOM / 100.0);
   c.minScale    = 1.0;
   c.maxScale    = 1.1;
   c.maxSkewDev  = 0.1;
@@ -497,22 +497,45 @@ int vsCameraPathOptimalL1LS(const VSTransformLS* F, int N, VSTransformLS* B,
 
 VSL1Config vsL1ConfigFromTransformConfig(const VSTransformData* td){
   VSL1Config c = vsL1GetDefaultConfig();
-  /* Not every caller goes through vsTransformGetDefaultConfig(): the ffmpeg
-     filter fills VSTransformConfig field by field from its option table, so
-     fields it does not know about arrive as zero.  All weights zero would make
-     the objective identically zero and every feasible path optimal, and a crop
-     of zero percent would leave the optimization no room at all -- neither is
-     something anybody can have meant, so fall back to the defaults. */
-  if (td->conf.pathD1Weight > 0.0 || td->conf.pathD2Weight > 0.0 ||
-      td->conf.pathD3Weight > 0.0) {
-    c.w1 = VS_MAX(td->conf.pathD1Weight, 0.0);
-    c.w2 = VS_MAX(td->conf.pathD2Weight, 0.0);
-    c.w3 = VS_MAX(td->conf.pathD3Weight, 0.0);
-  }
-  /* pathMaxZoom is the zoom in percent that the optimization may use up, so
-     the crop window is that much smaller than the frame */
-  if (td->conf.pathMaxZoom > 0.0)
-    c.cropRatio = 1.0 / (1.0 + td->conf.pathMaxZoom / 100.0);
+
+  /* --- zoom budget, from zoom and optZoom ---------------------------------
+     The optimization gets a crop window that is `budget` percent smaller than
+     the frame and keeps that window inside the frame; the zoom that goes with
+     it ends up in the render transforms.  That is precisely what zoom/optZoom
+     already mean, so they are what we read:
+
+       optZoom == 0            the user wants no automatic zoom: the budget is
+                               whatever conf.zoom asks for, and nothing more.
+                               With conf.zoom <= 0 there is no room to move at
+                               all and cameraPathOptimalL1() gives up.
+       optZoom != 0            conf.zoom if it was given, else the default.
+
+     optZoom == 2 (adaptive) has no L1 counterpart -- the crop window has to be
+     fixed before the LP is built -- so it is treated like the static case. */
+  double budget = VS_MAX(td->conf.zoom, 0.0);
+  if (td->conf.optZoom != 0 && budget <= 0.0) budget = VS_L1_DEFAULT_ZOOM;
+  c.cropRatio = 1.0 / (1.0 + budget / 100.0);
+
+  /* --- objective weights, from smoothing ----------------------------------
+     The LP has no data term competing with the objective -- closeness to the
+     original path comes from the inclusion and proximity constraints -- so it
+     is invariant under a common scaling of w1..w3 and only their ratio counts.
+     Read conf.smoothing as the timescale T (in frames) over which the path
+     should look rigid: |D^k P| is of order (amplitude / t^k) for motion of
+     period t, so weighting the k-th term with T^k makes all three contribute
+     equally at t = T, and motion faster than T is punished by the higher
+     orders.  Raising T therefore shifts weight from |D(P)| to |D^3(P)|: the
+     path goes from short static holds with quick transitions towards long
+     sweeping parabolic moves.  Written as s = T / T0 the weights are
+     10 s, s^2, 100 s^3, which we divide by s^2 to keep the numbers in a range
+     the solver is comfortable with; at T = T0 this reproduces the ratio of
+     fig. 8(d) of the paper exactly. */
+  const double T0 = 15.0;  /* the default of conf.smoothing */
+  double s = VS_MAX(td->conf.smoothing, 1) / T0;
+  c.w1 = 10.0 / s;
+  c.w2 = 1.0;
+  c.w3 = 100.0 * s;
+
   c.frameWidth  = td->fiSrc.width;
   c.frameHeight = td->fiSrc.height;
   c.verbose     = td->conf.verbose;
@@ -576,6 +599,16 @@ int cameraPathOptimalL1(VSTransformData* td, VSTransformations* trans){
   for (int t = 1; t < N; t++) F[t] = transformAZtoLS(&trans->ts[t]);
 
   VSL1Config conf = vsL1ConfigFromTransformConfig(td);
+  if (conf.cropRatio >= 1.0) {
+    /* optZoom == 0 and no zoom asked for: the crop window is the whole frame,
+       so the inclusion constraints pin the path to the original and there is
+       nothing to optimize.  Say so and let the caller fall back. */
+    vs_log_error(td->conf.modName,
+                 "L1 camera path optimization needs a zoom budget: "
+                 "use optzoom!=0 or zoom>0");
+    vs_free(F); vs_free(B);
+    return VS_ERROR;
+  }
   double objective = 0.0;
   int status = vsCameraPathOptimalL1LS(F, N, B, &conf, &objective);
   if (status == VS_OK) {
@@ -588,11 +621,12 @@ int cameraPathOptimalL1(VSTransformData* td, VSTransformations* trans){
       trans->ts[t].extra = extra;
     }
     /* The inclusion constraints already bound the crop window exactly, and the
-       zoom that goes with it is part of the transforms above.  The heuristic
-       estimators in vsPreprocessTransforms() would only add more zoom on top
-       of that, so switch them off; an explicitly requested conf.zoom is still
-       honoured and added. */
+       zoom that goes with it is part of the transforms above.  Both the
+       heuristic estimators and the global zoom in vsPreprocessTransforms()
+       would only add more zoom on top of that, so mark the budget as spent:
+       it went into the optimization, not on top of it. */
     td->conf.optZoom = 0;
+    td->conf.zoom    = 0.0;
   }
   vs_free(F);
   vs_free(B);

--- a/src/l1campathoptimization.h
+++ b/src/l1campathoptimization.h
@@ -83,6 +83,10 @@ VS_API void transformLS_vec(double* rx, double* ry, const VSTransformLS* t,
 VS_API VSTransformLS transformAZtoLS(const VSTransform* t);
 VS_API VSTransform   transformLStoAZ(const VSTransformLS* t);
 
+/** zoom in percent the optimization spends when the VSTransformConfig asks for
+    an automatic zoom (optZoom != 0) without naming an amount (zoom == 0) */
+#define VS_L1_DEFAULT_ZOOM 15.0
+
 /** parameters of the L1 optimization, independent of VSTransformData so that
     the core can be exercised on its own */
 typedef struct VS_API _VSL1Config {

--- a/src/transform.c
+++ b/src/transform.c
@@ -69,10 +69,6 @@ VSTransformConfig vsTransformGetDefaultConfig(const char* modName){
   conf.storeTransforms    = 0;
   conf.smoothZoom         = 0;
   conf.camPathAlgo        = VSOptimalL1;
-  conf.pathD1Weight       = 10.0;
-  conf.pathD2Weight       = 1.0;
-  conf.pathD3Weight       = 100.0;
-  conf.pathMaxZoom        = 15.0;
   return conf;
 }
 

--- a/src/transform.h
+++ b/src/transform.h
@@ -104,18 +104,9 @@ typedef struct VS_API _VSTransformConfig {
     int            storeTransforms; // stores calculated transforms to file
     int            smoothZoom;   // if 1 the zooming is also smoothed. Typically not recommended.
     VSCamPathAlgo  camPathAlgo;  // algorithm to use for camera path optimization
-    /* --- parameters of the L1 optimal camera path (VSOptimalL1) ---
-     * weights of the first, second and third derivative of the camera path in
-     * the objective; the defaults follow fig. 8(d) of Grundmann et al. 2011:
-     * penalizing jerks (D3) an order of magnitude harder than the rest gives
-     * the most pleasant result. */
-    double         pathD1Weight; // weight of |D(P)|   , 0 disables the term
-    double         pathD2Weight; // weight of |D^2(P)| , 0 disables the term
-    double         pathD3Weight; // weight of |D^3(P)| , 0 disables the term
-    /* zoom in percent that the optimization may use up: the crop window it
-     * keeps inside the frame is that much smaller than the frame itself.
-     * Larger values give the optimization more freedom to smooth. */
-    double         pathMaxZoom;
+    /* The L1 optimal camera path (VSOptimalL1) has no parameters of its own:
+     * it reads its zoom budget off zoom/optZoom and its horizon off smoothing,
+     * see vsL1ConfigFromTransformConfig(). */
 } VSTransformConfig;
 
 typedef struct VS_API _VSTransformData {

--- a/tests/test_campathopt.c
+++ b/tests/test_campathopt.c
@@ -265,19 +265,34 @@ void test_l1_campath_transforms(TestData* testdata){
   const int N = 50;
   VSTransformConfig conf = vsTransformGetDefaultConfig("test_l1");
   conf.camPathAlgo = VSOptimalL1;
-  /* A caller that does not know about the new fields leaves them at zero (the
-     ffmpeg filter fills the config field by field); that must not produce a
-     degenerate program. */
+  /* The optimization has no parameters of its own: it reads the zoom budget
+     off zoom/optZoom and the horizon off smoothing. */
   {
-    VSTransformConfig zeroed = conf;
-    zeroed.pathD1Weight = zeroed.pathD2Weight = zeroed.pathD3Weight = 0.0;
-    zeroed.pathMaxZoom = 0.0;
-    VSTransformData ztd;
-    test_bool(vsTransformDataInit(&ztd, &zeroed, &testdata->fi, &testdata->fi) == VS_OK);
-    VSL1Config zc = vsL1ConfigFromTransformConfig(&ztd);
-    test_bool(zc.w1 > 0.0 && zc.w3 > 0.0);
-    test_bool(zc.cropRatio > 0.0 && zc.cropRatio < 1.0);
-    vsTransformDataCleanup(&ztd);
+    VSTransformConfig c2 = conf;
+    VSTransformData td2;
+    VSL1Config a, b;
+    /* automatic zoom without an amount -> the default budget */
+    test_bool(vsTransformDataInit(&td2, &c2, &testdata->fi, &testdata->fi) == VS_OK);
+    a = vsL1ConfigFromTransformConfig(&td2);
+    test_bool(fabs(a.cropRatio - 1.0/(1.0 + VS_L1_DEFAULT_ZOOM/100.0)) < 1e-12);
+    /* the default smoothing reproduces the weights of the paper */
+    test_bool(fabs(a.w1 - 10.0) < 1e-12 && fabs(a.w2 - 1.0) < 1e-12
+              && fabs(a.w3 - 100.0) < 1e-12);
+    vsTransformDataCleanup(&td2);
+    /* an explicit zoom is the budget, whether or not optZoom is on */
+    c2.zoom = 30.0; c2.optZoom = 0; c2.smoothing = 30;
+    test_bool(vsTransformDataInit(&td2, &c2, &testdata->fi, &testdata->fi) == VS_OK);
+    b = vsL1ConfigFromTransformConfig(&td2);
+    test_bool(fabs(b.cropRatio - 1.0/1.3) < 1e-12);
+    /* twice the horizon shifts weight from |D(P)| onto |D^3(P)| */
+    test_bool(b.w1 < a.w1 && b.w3 > a.w3);
+    vsTransformDataCleanup(&td2);
+    /* no automatic zoom and none asked for: no room, so it declines and the
+       caller falls back to the gaussian filter */
+    c2.zoom = 0.0; c2.optZoom = 0;
+    test_bool(vsTransformDataInit(&td2, &c2, &testdata->fi, &testdata->fi) == VS_OK);
+    test_bool(vsL1ConfigFromTransformConfig(&td2).cropRatio >= 1.0);
+    vsTransformDataCleanup(&td2);
   }
   VSTransformData td;
   test_bool(vsTransformDataInit(&td, &conf, &testdata->fi, &testdata->fi) == VS_OK);
@@ -357,6 +372,7 @@ static void test_l1_synthetic_detection_format(VSPixelFormat pf){
   VSTransformConfig tdconf;
   VSTransformData td;
   VSTransformations trans;
+  VSL1Config lsConf;
   double before2, after2, before3, after3;
   double sx, sy, dx, dy, worst;
   int i;
@@ -389,6 +405,9 @@ static void test_l1_synthetic_detection_format(VSPixelFormat pf){
   tdconf = vsTransformGetDefaultConfig("test_l1_syn_trans");
   tdconf.camPathAlgo = VSOptimalL1;
   test_bool(vsTransformDataInit(&td, &tdconf, &fi, &fi) == VS_OK);
+  /* has to be taken before the run: cameraPathOptimalL1() marks the zoom
+     budget as spent in td.conf once it has folded it into the transforms */
+  lsConf = vsL1ConfigFromTransformConfig(&td);
 
   vsTransformationsInit(&trans);
   trans.ts = (VSTransform*)vs_malloc(sizeof(VSTransform) * N);
@@ -417,7 +436,6 @@ static void test_l1_synthetic_detection_format(VSPixelFormat pf){
     C[i] = concat_transformLS(&C[i-1], &F[i]);
   }
   {
-    VSL1Config lsConf = vsL1ConfigFromTransformConfig(&td);
     double objective = -1.0;
     test_bool(vsCameraPathOptimalL1LS(F, N, B, &lsConf, &objective) == VS_OK);
   }


### PR DESCRIPTION
The L1 optimal camera path landed with four config fields of its own — `pathD1Weight`, `pathD2Weight`, `pathD3Weight`, `pathMaxZoom` — which would have meant four new options for every caller, ffmpeg's `vidstabtransform` included. This removes all four: the optimization needs a zoom budget and a timescale, and `VSTransformConfig` already carries both.

### `pathMaxZoom` → `zoom` / `optZoom`

- `optZoom == 0` → budget is exactly `conf.zoom`; otherwise `conf.zoom` if given, else 15% (the old `pathMaxZoom` default).
- `optZoom == 2` is treated like `1` — the crop window must be fixed before the LP is built, so adaptive zoom has no counterpart.
- No budget at all (`optZoom == 0`, `zoom <= 0`) leaves zero freedom, so the optimization declines with a log message and the gaussian filter runs instead.
- On success the budget is marked as spent (`conf.zoom = 0` alongside `conf.optZoom = 0`). It goes *into* the optimization, so `vsPreprocessTransforms()` no longer adds it a second time on top of the crop zoom — that double-zoom was a bug.

### `pathD[123]Weight` → `smoothing`

The LP has no data term competing with the objective — closeness to the original path comes from the inclusion and proximity constraints — so it is invariant under a common scaling of `w1..w3` and only their ratio matters. Three doubles overstated the control on offer.

`smoothing` is now read as the timescale T over which the path should stay rigid. Weighting the k-th derivative with T^k makes all three terms comparable at t = T, so faster motion is punished by the higher orders: `w1 = 10/s, w2 = 1, w3 = 100·s` with `s = max(smoothing,1)/15`. At the default `smoothing = 15` this reproduces the ratio of fig. 8(d) of the paper exactly, so the default configuration is unchanged.

Checked empirically rather than assumed — 200-frame synthetic shaky pan, 640×480, default budget:

| smoothing | \|D1\| | \|D2\| | \|D3\| |
|---|---|---|---|
| original | 8068.0 | 8479.6 | 15885.7 |
| 3 | 428.3 | 7.5 | 3.1 |
| 15 | 430.0 | 6.8 | 2.0 |
| 60 | 437.5 | 5.2 | 1.9 |

Monotone and in the intended direction: a longer horizon lowers acceleration and jerk and lets the path be less static. The effect is modest — the zoom budget remains the much stronger knob.

### Also

- Drops the zero-means-default fallback the new fields required, which had made an all-zero weighting inexpressible.
- `docs/ffmpeg-doc-update.md` records the changed parameter meanings for a later patch to ffmpeg's `doc/filters.texi`. Worth noting from writing it: `vf_vidstabtransform.c` already defaults to `optalgo=opt`, so once ffmpeg builds against 1.3, users who don't pass `optalgo` get the L1 path instead of the gaussian filter. Tripod mode implies `relative=0` and so keeps falling back, unchanged.
- Version bumped to 1.3. Note this moves the (previously unreleased) L1 Changelog entry from 1.2 to 1.3; 1.1 → 1.3 leaves no 1.2 entry in the file.

### Behaviour change

`smoothing` and `zoom` now affect L1 output where they were partly ignored before, so anyone who tuned them against the gaussian path and then switched `optalgo` will see different results than on the previous commit.

### Testing

`./tests --all` → 28/28 passing (6 L1 units included), library builds clean, `vidstab.pc` reports 1.3.0. One test ordering fix was needed: `test_l1_synthetic_detection_format()` built its `VSL1Config` after `vsPreprocessTransforms()`, which now sees the budget already spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)