### PR TITLE
tests: write every output file into a dedicated, gitignored directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,9 @@ install_manifest.txt
 build
 *.dylib
 
-# Outputs and binaries produced by the test suite
-*.pgm
+# Outputs and binaries produced by the test suite.
+# Everything the tests write goes into their output directory, see
+# TEST_OUTPUT_DIR / testOut() in tests/testutils.h.
+testout/
 /tests/tests
-/tests/lmtest
-/tests/lmstest
 tests/build/
-tests/testdata/

--- a/tests/test_boxblur.c
+++ b/tests/test_boxblur.c
@@ -22,8 +22,8 @@ void test_boxblur(const TestData* testdata){
   fprintf(stderr,"********** boxblur speedtest:\n");
   time = runboxblur(testdata->frames[4], dest, testdata->fi, numruns);
   fprintf(stderr,"***C    time for %i runs: %i ms\n", numruns, time);
-  storePGMImage("boxblured.pgm", dest.data[0], testdata->fi);
-  storePGMImage("orig4.pgm", testdata->frames[4].data[0], testdata->fi);
+  storePGMImage(testOut("boxblured.pgm"), dest.data[0], testdata->fi);
+  storePGMImage(testOut("orig4.pgm"), testdata->frames[4].data[0], testdata->fi);
   // timeref=time;
   /* omp_set_dynamic( 0 ); */
   /* omp_set_num_threads( 2); */

--- a/tests/test_serialize_robust.c
+++ b/tests/test_serialize_robust.c
@@ -87,10 +87,10 @@ int test_serialize_robust(){
   VSManyLocalMotions mlms;
 
   /* ---- 1. binary file round trips ---- */
-  sr_write_file("srtest_bin.trf", BINARY_SERIALIZATION_MODE, 1);
-  buf = sr_slurp("srtest_bin.trf",&len);
+  sr_write_file(testOut("srtest_bin.trf"), BINARY_SERIALIZATION_MODE, 1);
+  buf = sr_slurp(testOut("srtest_bin.trf"),&len);
   test_bool(buf!=0);
-  f = fopen("srtest_bin.trf","rb");
+  f = fopen(testOut("srtest_bin.trf"),"rb");
   test_bool(f!=0);
   test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
   test_bool(vs_vector_size(&mlms)==SR_NFRAMES);
@@ -104,10 +104,10 @@ int test_serialize_robust(){
        handle would do: must not produce bogus (null) localmotions ---- */
   for(i=0; i<len; i++) if(buf[i]==0x1a){ first1a = i; break; }
   test_bool(first1a > 0);
-  sr_spit("srtest_trunc.trf", buf, first1a);
+  sr_spit(testOut("srtest_trunc.trf"), buf, first1a);
   fprintf(stderr,"** truncating transform file at first 0x1A: %li of %li bytes\n",
           first1a, len);
-  f = fopen("srtest_trunc.trf","rb");
+  f = fopen(testOut("srtest_trunc.trf"),"rb");
   test_bool(f!=0);
   test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
   for(i=0; i<vs_vector_size(&mlms); i++){
@@ -131,9 +131,9 @@ int test_serialize_robust(){
     unsigned char* copy = vs_malloc(len);
     memcpy(copy,buf,len);
     memcpy(copy+24+4,&bogus,4);  /* header(24) + frameNum(4) -> list length */
-    sr_spit("srtest_biglen.trf", copy, len);
+    sr_spit(testOut("srtest_biglen.trf"), copy, len);
     vs_free(copy);
-    f = fopen("srtest_biglen.trf","rb");
+    f = fopen(testOut("srtest_biglen.trf"),"rb");
     test_bool(f!=0);
     test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
     test_bool(vs_vector_size(&mlms)>=1);
@@ -145,8 +145,8 @@ int test_serialize_robust(){
   vs_free(buf);
 
   /* ---- 4. ascii file with CRLF line endings read from a binary handle ---- */
-  sr_write_file("srtest_ascii.trf", ASCII_SERIALIZATION_MODE, 0);
-  buf = sr_slurp("srtest_ascii.trf",&len);
+  sr_write_file(testOut("srtest_ascii.trf"), ASCII_SERIALIZATION_MODE, 0);
+  buf = sr_slurp(testOut("srtest_ascii.trf"),&len);
   test_bool(buf!=0);
   {
     unsigned char* crlf = vs_malloc(2*len);
@@ -155,11 +155,11 @@ int test_serialize_robust(){
       if(buf[i]=='\n') crlf[k++] = '\r';
       crlf[k++] = buf[i];
     }
-    sr_spit("srtest_ascii_crlf.trf", crlf, k);
+    sr_spit(testOut("srtest_ascii_crlf.trf"), crlf, k);
     vs_free(crlf);
   }
   vs_free(buf);
-  f = fopen("srtest_ascii_crlf.trf","rb");
+  f = fopen(testOut("srtest_ascii_crlf.trf"),"rb");
   test_bool(f!=0);
   test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
   test_bool(vs_vector_size(&mlms)==SR_NFRAMES);

--- a/tests/test_store_restore.c
+++ b/tests/test_store_restore.c
@@ -23,17 +23,17 @@ int test_store_restore(TestData* testdata, int serializationMode){
     if (i==0) vs_vector_del(&lms);
   }
 
-  FILE* f = fopen("lmtest","w");
+  FILE* f = fopen(testOut("lmtest"),"w");
   vsStoreLocalmotions(f,&lms,serializationMode);
   fclose(f);
-  f = fopen("lmtest","r");
+  f = fopen(testOut("lmtest"),"r");
   LocalMotions test = vsRestoreLocalmotions(f,serializationMode);
   fclose(f);
   vsStoreLocalmotions(stderr,&test,ASCII_SERIALIZATION_MODE);
   compare_localmotions(&lms,&test);
   fprintf(stderr,"\n** LM and LMS OKAY\n");
 
-  f = fopen("lmstest","w");
+  f = fopen(testOut("lmstest"),"w");
   md.frameNum=1;
   vsPrepareFile(&md,f);
   vsWriteToFile(&md,f,&lms);
@@ -41,7 +41,7 @@ int test_store_restore(TestData* testdata, int serializationMode){
   vsWriteToFile(&md,f,&test);
   fclose(f);
 
-  f = fopen("lmstest","r");
+  f = fopen(testOut("lmstest"),"r");
   test_bool(vsReadFileVersion(f,serializationMode)==1);
   LocalMotions read1;
   test_bool(vsReadFromFile(f,&read1,serializationMode)==1);
@@ -56,7 +56,7 @@ int test_store_restore(TestData* testdata, int serializationMode){
   vs_vector_del(&test);
   vs_vector_del(&lms);
 
-  f = fopen("lmstest","r");
+  f = fopen(testOut("lmstest"),"r");
   VSManyLocalMotions mlms;
   test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
   test_bool(vs_vector_size(&mlms)==2);

--- a/tests/test_transform.c
+++ b/tests/test_transform.c
@@ -112,8 +112,8 @@ void test_transform_performance(const TestData* testdata){
             numruns, timeC );
 
     if(it==VS_BiLinear){
-      storePGMImage("transformed.pgm", td.dest.data[0], testdata->fi);
-      storePGMImage("transformed_u.pgm", td.dest.data[1], testdata->fi_color);
+      storePGMImage(testOut("transformed.pgm"), td.dest.data[0], testdata->fi);
+      storePGMImage(testOut("transformed_u.pgm"), td.dest.data[1], testdata->fi_color);
       fprintf(stderr,"stored transformed.pgm\n");
     }
     vsFrameCopy(&cfinal,&td.dest,&testdata->fi);
@@ -135,8 +135,8 @@ void test_transform_performance(const TestData* testdata){
     fprintf(stderr,"***FP  elapsed time for %i runs: %i ms ****\n",
             numruns, timeCFP );
     if(it==VS_BiLinear){
-      storePGMImage("transformed_FP.pgm", td.dest.data[0], testdata->fi);
-      storePGMImage("transformed_u_FP.pgm", td.dest.data[1], testdata->fi_color);
+      storePGMImage(testOut("transformed_FP.pgm"), td.dest.data[0], testdata->fi);
+      storePGMImage(testOut("transformed_u_FP.pgm"), td.dest.data[1], testdata->fi_color);
       fprintf(stderr,"stored transformed_FP.pgm\n");
     }
     fprintf(stderr,"***Speedup %3.2f\n", (double)timeC/timeCFP);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -89,11 +89,11 @@ int main(int argc, char** argv){
     UNIT(generateFrames(&testdata, FRAMENUM));
   }
   if(contains(argv,argc,"--store", "Store frames to files")!=0){
-    storePGMImage("test1.pgm", testdata.frames[0].data[0], testdata.fi);
-    storePGMImage("test2.pgm", testdata.frames[1].data[0], testdata.fi);
-    storePGMImage("test3.pgm", testdata.frames[2].data[0], testdata.fi);
-    storePGMImage("test4.pgm", testdata.frames[3].data[0], testdata.fi);
-    storePGMImage("test5.pgm", testdata.frames[4].data[0], testdata.fi);
+    storePGMImage(testOut("test1.pgm"), testdata.frames[0].data[0], testdata.fi);
+    storePGMImage(testOut("test2.pgm"), testdata.frames[1].data[0], testdata.fi);
+    storePGMImage(testOut("test3.pgm"), testdata.frames[2].data[0], testdata.fi);
+    storePGMImage(testOut("test4.pgm"), testdata.frames[3].data[0], testdata.fi);
+    storePGMImage(testOut("test5.pgm"), testdata.frames[4].data[0], testdata.fi);
   }
 
 #ifdef USE_OMP
@@ -170,30 +170,26 @@ int main(int argc, char** argv){
 
   if(contains(argv,argc,"--dumpSynthetic", "dump synthetic frames as PPM for visual inspection")){
     int fmt;
-    char dir[256], prefix[512];
+    char prefix[512];
     for(fmt=0; fmt<SYN_NUM_FORMATS; fmt++){
       VSFrameInfo fi;
       VSFrame frames[SYN_NUM_FRAMES];
       int i;
-
-      sprintf(dir, "testdata/synthetic/%s", synFormatName(SYN_FORMATS[fmt]));
-      sprintf(prefix, "mkdir -p %s", dir);
-      if(system(prefix) != 0){
-        fprintf(stderr, "mkdir failed for %s\n", dir);
-        continue;
-      }
+      /* testOut() creates the per-format directory on the way */
+      const char* fmtname = synFormatName(SYN_FORMATS[fmt]);
 
       generateCircleFrames(frames, &fi, SYN_FORMATS[fmt], SYN_WIDTH, SYN_HEIGHT, SYN_NUM_FRAMES);
-      sprintf(prefix, "%s/circles", dir);
-      dumpFramesAsPPM(frames, &fi, SYN_NUM_FRAMES, prefix);
+      sprintf(prefix, "synthetic/%s/circles", fmtname);
+      dumpFramesAsPPM(frames, &fi, SYN_NUM_FRAMES, testOut(prefix));
       for(i=0; i<SYN_NUM_FRAMES; i++) vsFrameFree(&frames[i]);
 
       generateCircleSquareFrames(frames, &fi, SYN_FORMATS[fmt], SYN_WIDTH, SYN_HEIGHT, SYN_NUM_FRAMES);
-      sprintf(prefix, "%s/circles_squares", dir);
-      dumpFramesAsPPM(frames, &fi, SYN_NUM_FRAMES, prefix);
+      sprintf(prefix, "synthetic/%s/circles_squares", fmtname);
+      dumpFramesAsPPM(frames, &fi, SYN_NUM_FRAMES, testOut(prefix));
       for(i=0; i<SYN_NUM_FRAMES; i++) vsFrameFree(&frames[i]);
 
-      fprintf(stderr, "dumped synthetic PPM frames to %s\n", dir);
+      fprintf(stderr, "dumped synthetic PPM frames to %s/synthetic/%s\n",
+              TEST_OUTPUT_DIR, fmtname);
     }
   }
 

--- a/tests/testutils.c
+++ b/tests/testutils.c
@@ -1,4 +1,14 @@
 #include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#ifdef _WIN32
+#include <direct.h>
+#define TEST_MKDIR(p) _mkdir(p)
+#else
+#define TEST_MKDIR(p) mkdir(p, 0755)
+#endif
 
 #include "testutils.h"
 #include "libvidstab.h"
@@ -250,6 +260,46 @@ int loadPGMImage(const char* filename, VSFrame* frame, VSFrameInfo* fi)
   return 1;
 }
 
+
+/** mkdir -p, one path component at a time; an existing directory is not an
+    error */
+static int testMkdirP(char* path){
+  char* p;
+  for(p = path+1; *p; p++){
+    if(*p == '/'){
+      *p = '\0';
+      if(TEST_MKDIR(path) != 0 && errno != EEXIST){
+        vs_log_error("TEST", "Can't create output directory '%s'", path);
+        return 0;
+      }
+      *p = '/';
+    }
+  }
+  if(TEST_MKDIR(path) != 0 && errno != EEXIST){
+    vs_log_error("TEST", "Can't create output directory '%s'", path);
+    return 0;
+  }
+  return 1;
+}
+
+const char* testOut(const char* name){
+  /* a ring, so that more than one result can be alive at a time */
+  static char bufs[8][512];
+  static int next = 0;
+  char* buf = bufs[next];
+  char dir[512];
+  char* slash;
+  next = (next+1) % 8;
+
+  snprintf(buf, sizeof(bufs[0]), TEST_OUTPUT_DIR "/%s", name);
+  /* the directory the file goes into -- always at least TEST_OUTPUT_DIR, since
+     we just prefixed it, so the separator is there */
+  snprintf(dir, sizeof(dir), "%s", buf);
+  slash = strrchr(dir, '/');
+  *slash = '\0';
+  testMkdirP(dir);
+  return buf;
+}
 
 int storePGMImage(const char* filename, const uint8_t* data, VSFrameInfo fi ) {
   FILE *f = fopen (filename,"wb");

--- a/tests/testutils.h
+++ b/tests/testutils.h
@@ -46,4 +46,18 @@ int loadPGMImage(const char* filename, VSFrame* frame, VSFrameInfo* fi);
 
 int storePGMImage(const char* filename, const uint8_t* data, VSFrameInfo fi );
 
+/** directory every file the test suite writes goes into, relative to the
+    working directory the tests are run from, and gitignored */
+#define TEST_OUTPUT_DIR "testout"
+
+/** Builds TEST_OUTPUT_DIR "/" name and makes sure the directory it lives in
+    exists; name may contain subdirectories.  Use it for every path the tests
+    write to, so that a test run leaves nothing behind outside of
+    TEST_OUTPUT_DIR.
+
+    The result lives in a small ring of static buffers, so a few results can be
+    in flight at once -- two calls in the same argument list are fine -- but the
+    pointer must not be stored for later use. */
+const char* testOut(const char* name);
+
 #endif


### PR DESCRIPTION
A test run used to scatter files over the working directory: `*.pgm` from the boxblur and transform tests, `lmtest`/`lmstest` from the serialization round trip, five `srtest_*.trf` from the robustness test, and a `testdata/synthetic/` tree from `--dumpSynthetic`. Some were gitignored by name, some weren't, so the ignore list had to track the file names and a run left the tree dirty either way.

All of it now goes through one helper:

```c
#define TEST_OUTPUT_DIR "testout"
const char* testOut(const char* name);
```

`testOut()` prefixes the directory and creates it — including subdirectories in `name`, which is what the synthetic dump needs (`synthetic/PF_RGBA/circles`). That replaces the `system("mkdir -p ...")` call the dump used, so the suite no longer shells out. The result lives in a ring of static buffers so several can be in flight at once; the header documents that the pointer must not be stored.

`.gitignore` drops the four name-specific entries in favour of a single `testout/`.

Inputs are untouched — `--load` still reads `../frames/frame%03i.raw`.

### Testing

`./tests --all` → 28/28 passing, and after `rm -rf tests/testout` a full run plus `--dumpSynthetic --store` recreates everything under `tests/testout/` (including the six per-format `synthetic/` subdirectories); `git status` stays clean.

Note for whoever merges: `tests/testdata/` and a few stray `tests/*.pgm` from earlier runs are still on disk and now show up as untracked. I left them alone rather than deleting — `tests/testdata/synthetic/PF_RGB24/` contains hand-made `.png` conversions next to the suite's `.ppm` files, which do not look like something to throw away automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)