### PR TITLE
motiondetect: draw the 'show' overlay on packed pixel formats

### DIFF
--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -797,107 +797,142 @@ LocalMotions calcTransFields(VSMotionDetect* md,
 
 
 
+/* The overlay drawing below works for planar and packed formats alike. All
+   overlay colours are grey levels, so for packed formats the same value goes
+   into every colour channel; that makes PF_RGB24 and PF_BGR24 indistinguishable
+   here and removes any need to know the channel order. For planar formats only
+   plane 0 (luma) is drawn into, exactly as before. */
+
+/// bytes per pixel of the drawing surface: 1 for planar (luma plane only)
+static int drawBytesPerPixel(const VSMotionDetect* md) {
+  return md->fi.pFormat > PF_PACKED ? md->fi.bytesPerPixel : 1;
+}
+
 /** draws the field scanning area */
 void drawFieldScanArea(VSMotionDetect* md, const LocalMotion* lm, int maxShift) {
-  if (md->fi.pFormat > PF_PACKED)
-    return;
-  drawRectangle(md->currorig.data[0], md->currorig.linesize[0], md->fi.height, 1, lm->f.x, lm->f.y,
+  drawRectangle(md->currorig.data[0], md->currorig.linesize[0],
+                md->fi.width, md->fi.height, drawBytesPerPixel(md), lm->f.x, lm->f.y,
                 lm->f.size + 2 * maxShift, lm->f.size + 2 * maxShift, 80);
 }
 
 /** draws the field */
 void drawField(VSMotionDetect* md, const LocalMotion* lm, short box) {
-  if (md->fi.pFormat > PF_PACKED)
-    return;
   if(box)
-    drawBox(md->currorig.data[0], md->currorig.linesize[0], md->fi.height, 1,
+    drawBox(md->currorig.data[0], md->currorig.linesize[0],
+            md->fi.width, md->fi.height, drawBytesPerPixel(md),
             lm->f.x, lm->f.y, lm->f.size, lm->f.size, /*lm->match >100 ? 100 :*/ 40);
   else
-    drawRectangle(md->currorig.data[0], md->currorig.linesize[0], md->fi.height, 1,
+    drawRectangle(md->currorig.data[0], md->currorig.linesize[0],
+                  md->fi.width, md->fi.height, drawBytesPerPixel(md),
                   lm->f.x, lm->f.y, lm->f.size, lm->f.size, /*lm->match >100 ? 100 :*/ 40);
 }
 
 /** draws the transform data of this field */
 void drawFieldTrans(VSMotionDetect* md, const LocalMotion* lm, int color) {
-  if (md->fi.pFormat > PF_PACKED)
-    return;
+  int bpp = drawBytesPerPixel(md);
   Vec end = add_vec(field_to_vec(lm->f),lm->v);
-  drawBox(md->currorig.data[0], md->currorig.linesize[0], md->fi.height, 1,
+  drawBox(md->currorig.data[0], md->currorig.linesize[0],
+          md->fi.width, md->fi.height, bpp,
           lm->f.x, lm->f.y, 5, 5, 0); // draw center
-  drawBox(md->currorig.data[0], md->currorig.linesize[0], md->fi.height, 1,
+  drawBox(md->currorig.data[0], md->currorig.linesize[0],
+          md->fi.width, md->fi.height, bpp,
           lm->f.x + lm->v.x, lm->f.y + lm->v.y, 5, 5, 250); // draw translation
-  drawLine(md->currorig.data[0], md->currorig.linesize[0],  md->fi.height, 1,
+  drawLine(md->currorig.data[0], md->currorig.linesize[0],
+           md->fi.width, md->fi.height, bpp,
            (Vec*)&lm->f, &end, 3, color);
 
 }
 
 /**
- * draws a box at the given position x,y (center) in the given color
+ * draws a horizontal run of length pixels starting at x,y in the given color.
+ * Clipped to the frame. The color is written to every colour channel of a
+ * packed pixel except alpha, and to the single channel of a planar one.
+ * \param linesize distance between two rows in BYTES
+ * \param width,height frame dimensions in PIXELS
+ */
+void drawHLine(unsigned char* I, int linesize, int width, int height,
+               int bytesPerPixel, int x, int y, int length, unsigned char color) {
+  if (y < 0 || y >= height || length <= 0) return;
+  if (x < 0) { length += x; x = 0; }              // clip left
+  if (x + length > width) length = width - x;     // clip right
+  if (length <= 0) return;
+
+  int channels = bytesPerPixel > 3 ? 3 : bytesPerPixel; // never touch alpha
+  unsigned char* p = I + x * bytesPerPixel + y * linesize;
+  for (int k = 0; k < length; k++, p += bytesPerPixel)
+    for (int c = 0; c < channels; c++) p[c] = color;
+}
+
+/**
+ * draws a vertical run of length pixels starting at x,y in the given color.
+ * \see drawHLine
+ */
+void drawVLine(unsigned char* I, int linesize, int width, int height,
+               int bytesPerPixel, int x, int y, int length, unsigned char color) {
+  if (x < 0 || x >= width || length <= 0) return;
+  if (y < 0) { length += y; y = 0; }              // clip top
+  if (y + length > height) length = height - y;   // clip bottom
+  if (length <= 0) return;
+
+  int channels = bytesPerPixel > 3 ? 3 : bytesPerPixel;
+  unsigned char* p = I + x * bytesPerPixel + y * linesize;
+  for (int k = 0; k < length; k++, p += linesize)
+    for (int c = 0; c < channels; c++) p[c] = color;
+}
+
+/**
+ * draws a filled box at the given position x,y (center) in the given color
  (the same for all channels)
 */
-void drawBox(unsigned char* I, int width, int height, int bytesPerPixel, int x,
-       int y, int sizex, int sizey, unsigned char color) {
-
-  unsigned char* p = NULL;
-  int j, k;
-  p = I + ((x - sizex / 2) + (y - sizey / 2) * width) * bytesPerPixel;
-  for (j = 0; j < sizey; j++) {
-    for (k = 0; k < sizex * bytesPerPixel; k++) {
-      *p = color;
-      p++;
-    }
-    p += (width - sizex) * bytesPerPixel;
-  }
+void drawBox(unsigned char* I, int linesize, int width, int height, int bytesPerPixel,
+             int x, int y, int sizex, int sizey, unsigned char color) {
+  for (int j = 0; j < sizey; j++)
+    drawHLine(I, linesize, width, height, bytesPerPixel,
+              x - sizex / 2, y - sizey / 2 + j, sizex, color);
 }
 
 /**
  * draws a rectangle (not filled) at the given position x,y (center) in the given color
  at the first channel
 */
-void drawRectangle(unsigned char* I, int width, int height, int bytesPerPixel, int x,
-                   int y, int sizex, int sizey, unsigned char color) {
-
-  unsigned char* p;
-  int k;
-  p = I + ((x - sizex / 2) + (y - sizey / 2) * width) * bytesPerPixel;
-  for (k = 0; k < sizex; k++) { *p = color; p+= bytesPerPixel; } // upper line
-  p = I + ((x - sizex / 2) + (y + sizey / 2) * width) * bytesPerPixel;
-  for (k = 0; k < sizex; k++) { *p = color; p+= bytesPerPixel; } // lower line
-  p = I + ((x - sizex / 2) + (y - sizey / 2) * width) * bytesPerPixel;
-  for (k = 0; k < sizey; k++) { *p = color; p+= width * bytesPerPixel; } // left line
-  p = I + ((x + sizex / 2) + (y - sizey / 2) * width) * bytesPerPixel;
-  for (k = 0; k < sizey; k++) { *p = color; p+= width * bytesPerPixel; } // right line
+void drawRectangle(unsigned char* I, int linesize, int width, int height, int bytesPerPixel,
+                   int x, int y, int sizex, int sizey, unsigned char color) {
+  drawHLine(I, linesize, width, height, bytesPerPixel,
+            x - sizex / 2, y - sizey / 2, sizex, color); // upper line
+  drawHLine(I, linesize, width, height, bytesPerPixel,
+            x - sizex / 2, y + sizey / 2, sizex, color); // lower line
+  drawVLine(I, linesize, width, height, bytesPerPixel,
+            x - sizex / 2, y - sizey / 2, sizey, color); // left line
+  drawVLine(I, linesize, width, height, bytesPerPixel,
+            x + sizex / 2, y - sizey / 2, sizey, color); // right line
 }
 
 /**
  * draws a line from a to b with given thickness(not filled) at the given position x,y (center) in the given color
  at the first channel
 */
-void drawLine(unsigned char* I, int width, int height, int bytesPerPixel,
+void drawLine(unsigned char* I, int linesize, int width, int height, int bytesPerPixel,
               Vec* a, Vec* b, int thickness, unsigned char color) {
-  unsigned char* p;
   Vec div = sub_vec(*b,*a);
   if(div.y==0){ // horizontal line
     if(div.x<0) {*a=*b; div.x*=-1;}
-    for(int r=-thickness/2; r<=thickness/2; r++){
-      p = I + ((a->x) + (a->y+r) * width) * bytesPerPixel;
-      for (int k = 0; k <= div.x; k++) { *p = color; p+= bytesPerPixel; }
-    }
+    for(int r=-thickness/2; r<=thickness/2; r++)
+      drawHLine(I, linesize, width, height, bytesPerPixel,
+                a->x, a->y + r, div.x + 1, color);
   }else{
     if(div.x==0){ // vertical line
       if(div.y<0) {*a=*b; div.y*=-1;}
-      for(int r=-thickness/2; r<=thickness/2; r++){
-        p = I + ((a->x+r) + (a->y) * width) * bytesPerPixel;
-        for (int k = 0; k <= div.y; k++) { *p = color; p+= width * bytesPerPixel; }
-      }
+      for(int r=-thickness/2; r<=thickness/2; r++)
+        drawVLine(I, linesize, width, height, bytesPerPixel,
+                  a->x + r, a->y, div.y + 1, color);
     }else{
       double m = (double)div.x/(double)div.y;
       int horlen = thickness + fabs(m);
       for( int c=0; c<= abs(div.y); c++){
         int dy = div.y<0 ? -c : c;
         int x = a->x + m*dy - horlen/2;
-        p = I + (x + (a->y+dy) * width) * bytesPerPixel;
-        for( int k=0; k<= horlen; k++){ *p = color; p+= bytesPerPixel; }
+        drawHLine(I, linesize, width, height, bytesPerPixel,
+                  x, a->y + dy, horlen + 1, color);
       }
     }
   }

--- a/src/motiondetect_internal.h
+++ b/src/motiondetect_internal.h
@@ -69,12 +69,22 @@ VS_API LocalMotions calcTransFields(VSMotionDetect* md, VSMotionDetectFields* fi
 VS_API void drawFieldScanArea(VSMotionDetect* md, const LocalMotion* motion, int maxShift);
 VS_API void drawField(VSMotionDetect* md, const LocalMotion* motion, short box);
 VS_API void drawFieldTrans(VSMotionDetect* md, const LocalMotion* motion, int color);
-VS_API void drawBox(unsigned char* I, int width, int height, int bytesPerPixel,
+/* Overlay drawing. \param linesize distance between two rows in BYTES,
+   \param width,height frame dimensions in PIXELS. Shapes are clipped to the
+   frame. bytesPerPixel selects the layout: 1 draws into a planar luma plane,
+   3 or 4 into a packed pixel (alpha of a 4 byte pixel is left untouched).
+   Colours are grey levels, so packed channel order does not matter. */
+VS_API void drawHLine(unsigned char* I, int linesize, int width, int height,
+               int bytesPerPixel, int x, int y, int length, unsigned char color);
+VS_API void drawVLine(unsigned char* I, int linesize, int width, int height,
+               int bytesPerPixel, int x, int y, int length, unsigned char color);
+
+VS_API void drawBox(unsigned char* I, int linesize, int width, int height, int bytesPerPixel,
              int x, int y, int sizex, int sizey, unsigned char color);
-VS_API void drawRectangle(unsigned char* I, int width, int height, int bytesPerPixel,
+VS_API void drawRectangle(unsigned char* I, int linesize, int width, int height, int bytesPerPixel,
                    int x, int y, int sizex, int sizey, unsigned char color);
 
-VS_API void drawLine(unsigned char* I, int width, int height, int bytesPerPixel,
+VS_API void drawLine(unsigned char* I, int linesize, int width, int height, int bytesPerPixel,
               Vec* a, Vec* b, int thickness, unsigned char color);
 
 /// \param linesize1,linesize2 distance between two rows in BYTES of I1 resp. I2

--- a/tests/test_draw.c
+++ b/tests/test_draw.c
@@ -1,0 +1,290 @@
+/*
+   test_draw.c
+
+   Characterization + behaviour tests for the overlay drawing primitives used
+   by the 'show' option (drawBox / drawRectangle / drawLine).
+
+   The geometry tests here were written against the pre-existing planar
+   implementation and pin its exact output, so that rebuilding the primitives
+   on top of drawHLine/drawVLine cannot silently change what 'show' renders.
+   The clipping tests describe the intended behaviour for shapes that reach
+   past the frame edge.
+
+   This file is part of vid.stab video stabilization library
+   and distributed under the GNU GPL, see the top of motiondetect.c.
+*/
+
+/* logical frame; the buffer is deliberately taller than DRAW_H so that writes
+   past the bottom edge land inside the allocation and can be detected instead
+   of corrupting the heap */
+#define DRAW_STRIDE 64
+#define DRAW_W      64
+#define DRAW_H      48
+#define DRAW_ROWS   64   /* rows actually allocated */
+#define DRAW_BUFSZ  (DRAW_STRIDE * DRAW_ROWS)
+
+/* golden values for the diagonal line, captured from the original
+   implementation (12,10)->(28,26), thickness 3 */
+#define DIAG_EXPECT_COUNT 85
+#define DIAG_EXPECT_SUM   99620
+
+/* golden values for the end-to-end planar overlay, captured by running
+   test_draw_planar_show() against the implementation as it stood before the
+   primitives were rebuilt (origin/master at the time of this change) */
+#define PLANAR_SHOW_CHECKSUM 4339987323UL
+#define PLANAR_SHOW_NONZERO  72349
+
+static void draw_clear(unsigned char* b){ memset(b, 0, DRAW_BUFSZ); }
+
+/* mark a filled span of a single row in the expectation buffer */
+static void exp_hspan(unsigned char* e, int x, int y, int len, unsigned char c){
+  for (int k = 0; k < len; k++) e[(x + k) + y * DRAW_STRIDE] = c;
+}
+static void exp_vspan(unsigned char* e, int x, int y, int len, unsigned char c){
+  for (int k = 0; k < len; k++) e[x + (y + k) * DRAW_STRIDE] = c;
+}
+
+/* report the first differing pixel, to make a failure diagnosable */
+static int draw_cmp(const unsigned char* got, const unsigned char* exp, const char* what){
+  for (int y = 0; y < DRAW_ROWS; y++){
+    for (int x = 0; x < DRAW_STRIDE; x++){
+      int i = x + y * DRAW_STRIDE;
+      if (got[i] != exp[i]){
+        fprintf(stderr, "  %s: first mismatch at (%d,%d): got %d, expected %d\n",
+                what, x, y, got[i], exp[i]);
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+/* number of pixels written outside the logical frame */
+static int draw_outside_count(const unsigned char* b){
+  int n = 0;
+  for (int y = 0; y < DRAW_ROWS; y++)
+    for (int x = 0; x < DRAW_STRIDE; x++)
+      if ((y >= DRAW_H || x >= DRAW_W) && b[x + y * DRAW_STRIDE] != 0) n++;
+  return n;
+}
+
+void test_draw_geometry(void){
+  unsigned char* buf = (unsigned char*)vs_malloc(DRAW_BUFSZ);
+  unsigned char* exp = (unsigned char*)vs_malloc(DRAW_BUFSZ);
+
+  /* --- drawBox: filled, sizex x sizey, top-left at (x-sizex/2, y-sizey/2) --- */
+  draw_clear(buf); draw_clear(exp);
+  drawBox(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, 20, 20, 8, 6, 200);
+  for (int r = 0; r < 6; r++) exp_hspan(exp, 20 - 4, 20 - 3 + r, 8, 200);
+  fprintf(stderr,"*** drawBox: filled 8x6 box\n");
+  test_bool(draw_cmp(buf, exp, "drawBox"));
+
+  /* --- drawRectangle: outline. Note the deliberate asymmetry of the original
+     implementation: the horizontal lines span sizex columns starting at
+     x-sizex/2, while the right vertical line sits at x+sizex/2, which for even
+     sizex is one column past the end of those horizontal lines. Same for the
+     lower horizontal line vs. the vertical extent. This is pinned on purpose. */
+  draw_clear(buf); draw_clear(exp);
+  drawRectangle(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, 30, 24, 10, 8, 100);
+  exp_hspan(exp, 30 - 5, 24 - 4, 10, 100);          /* upper */
+  exp_hspan(exp, 30 - 5, 24 + 4, 10, 100);          /* lower */
+  exp_vspan(exp, 30 - 5, 24 - 4,  8, 100);          /* left  */
+  exp_vspan(exp, 30 + 5, 24 - 4,  8, 100);          /* right */
+  fprintf(stderr,"*** drawRectangle: 10x8 outline\n");
+  test_bool(draw_cmp(buf, exp, "drawRectangle"));
+
+  /* --- drawLine, horizontal: thickness rows, endpoints inclusive --- */
+  draw_clear(buf); draw_clear(exp);
+  { Vec a = {10, 30}, b = {25, 30};
+    drawLine(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, &a, &b, 3, 150); }
+  for (int r = -1; r <= 1; r++) exp_hspan(exp, 10, 30 + r, 25 - 10 + 1, 150);
+  fprintf(stderr,"*** drawLine: horizontal, thickness 3\n");
+  test_bool(draw_cmp(buf, exp, "drawLine/horizontal"));
+
+  /* --- drawLine, vertical --- */
+  draw_clear(buf); draw_clear(exp);
+  { Vec a = {40, 8}, b = {40, 20};
+    drawLine(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, &a, &b, 3, 150); }
+  for (int r = -1; r <= 1; r++) exp_vspan(exp, 40 + r, 8, 20 - 8 + 1, 150);
+  fprintf(stderr,"*** drawLine: vertical, thickness 3\n");
+  test_bool(draw_cmp(buf, exp, "drawLine/vertical"));
+
+  /* --- drawLine, diagonal: geometry involves floating point slope, so pin it
+     by the exact set of touched pixels rather than a closed form --- */
+  draw_clear(buf);
+  { Vec a = {12, 10}, b = {28, 26};
+    drawLine(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, &a, &b, 3, 150); }
+  int diag_count = 0, diag_sum = 0;
+  for (int i = 0; i < DRAW_BUFSZ; i++)
+    if (buf[i]) { diag_count++; diag_sum += i; }
+  fprintf(stderr,"*** drawLine: diagonal (count=%d checksum=%d)\n", diag_count, diag_sum);
+  test_bool(diag_count == DIAG_EXPECT_COUNT);
+  test_bool(diag_sum   == DIAG_EXPECT_SUM);
+
+  vs_free(buf); vs_free(exp);
+}
+
+/* Shapes that reach past the frame edge must be clipped, not written out of
+   bounds. Every case below would scribble outside the logical frame in the
+   original implementation. */
+void test_draw_clipping(void){
+  unsigned char* buf = (unsigned char*)vs_malloc(DRAW_BUFSZ);
+
+  unsigned char* exp = (unsigned char*)vs_malloc(DRAW_BUFSZ);
+
+  fprintf(stderr,"*** clipping: shapes overlapping each frame edge\n");
+
+  /* A clipped box must equal exactly the intersection of the box with the
+     frame. Checking the whole buffer (not just a count of out-of-frame pixels)
+     is what catches horizontal overrun, which wraps into the neighbouring row
+     rather than leaving the frame and so is invisible to a bounds count. */
+  struct { const char* name; int x, y, sx, sy; } cases[] = {
+    {"left edge",   2,          20,         16,  8},
+    {"right edge",  DRAW_W - 2, 20,         16,  8},
+    {"bottom edge", 20,         DRAW_H - 2,  8, 16},
+    {"top edge",    20,         2,           8, 16},
+  };
+  for (unsigned ci = 0; ci < sizeof(cases)/sizeof(cases[0]); ci++){
+    int x0 = cases[ci].x - cases[ci].sx / 2, y0 = cases[ci].y - cases[ci].sy / 2;
+    draw_clear(buf); draw_clear(exp);
+    drawBox(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1,
+            cases[ci].x, cases[ci].y, cases[ci].sx, cases[ci].sy, 200);
+    for (int yy = y0; yy < y0 + cases[ci].sy; yy++)
+      for (int xx = x0; xx < x0 + cases[ci].sx; xx++)
+        if (xx >= 0 && xx < DRAW_W && yy >= 0 && yy < DRAW_H)
+          exp[xx + yy * DRAW_STRIDE] = 200;
+    test_bool(draw_cmp(buf, exp, cases[ci].name));
+    test_bool(draw_outside_count(buf) == 0);
+  }
+  vs_free(exp);
+
+  /* entirely outside: nothing at all may be written */
+  draw_clear(buf);
+  drawBox(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, -50, -50, 8, 8, 200);
+  drawBox(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, DRAW_W + 50, DRAW_H + 50, 8, 8, 200);
+  for (int i = 0; i < DRAW_BUFSZ; i++) test_bool(buf[i] == 0);
+
+  /* rectangle and lines crossing edges */
+  draw_clear(buf);
+  drawRectangle(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, 4, DRAW_H - 3, 20, 12, 100);
+  test_bool(draw_outside_count(buf) == 0);
+
+  draw_clear(buf);
+  { Vec a = {-20, 25}, b = {DRAW_W + 20, 25};
+    drawLine(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, &a, &b, 3, 150); }
+  test_bool(draw_outside_count(buf) == 0);
+
+  draw_clear(buf);
+  { Vec a = {30, -20}, b = {30, DRAW_H + 20};
+    drawLine(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, &a, &b, 3, 150); }
+  test_bool(draw_outside_count(buf) == 0);
+
+  draw_clear(buf);
+  { Vec a = {-10, -10}, b = {DRAW_W + 10, DRAW_H + 10};
+    drawLine(buf, DRAW_STRIDE, DRAW_W, DRAW_H, 1, &a, &b, 3, 150); }
+  test_bool(draw_outside_count(buf) == 0);
+
+  vs_free(buf);
+}
+
+/* End-to-end guard on the planar overlay: run the detector with show enabled
+   over two planar frames and check the rendered frame against a golden
+   checksum captured from the implementation before the primitives were
+   rebuilt. This test deliberately uses only the public entry points, so it
+   compiles unchanged against either implementation. */
+void test_draw_planar_show(void){
+  VSFrameInfo fi;
+  VSFrame f1, f2;
+  VSMotionDetectConfig mdconf = vsMotionDetectGetDefaultConfig("test_planar_show");
+  VSMotionDetect md;
+  LocalMotions lms;
+  unsigned long sum = 0;
+  int count = 0;
+
+  fprintf(stderr,"*** planar show: overlay output must not change\n");
+  test_bool(vsFrameInfoInit(&fi, 320, 240, PF_YUV420P) == 1);
+  vsFrameAllocate(&f1,&fi);
+  vsFrameAllocate(&f2,&fi);
+
+  /* deterministic content: a fixed pseudo random luma plane, shifted by (8,-6) */
+  unsigned int seed = 12345;
+  for(int y=0; y<fi.height; y++){
+    for(int x=0; x<fi.width; x++){
+      seed = seed * 1103515245u + 12345u;
+      f1.data[0][x + y*f1.linesize[0]] = (seed >> 16) & 0xFF;
+    }
+  }
+  for(int p=1; p<3; p++)
+    for(int y=0; y<fi.height/2; y++)
+      memset(f1.data[p] + y*f1.linesize[p], 128, fi.width/2);
+  vsFrameCopy(&f2,&f1,&fi);
+  for(int y=0; y<fi.height; y++){
+    for(int x=0; x<fi.width; x++){
+      int sx = x - 8, sy = y + 6;
+      f2.data[0][x + y*f2.linesize[0]] =
+        (sx>=0 && sy>=0 && sx<fi.width && sy<fi.height)
+        ? f1.data[0][sx + sy*f1.linesize[0]] : 0;
+    }
+  }
+
+  mdconf.show = 2;
+  test_bool(vsMotionDetectInit(&md, &mdconf, &fi) == VS_OK);
+  md.conf.numThreads = 1;
+  test_bool(vsMotionDetection(&md, &lms, &f1) == VS_OK);
+  vs_vector_del(&lms);
+  test_bool(vsMotionDetection(&md, &lms, &f2) == VS_OK);
+  vs_vector_del(&lms);
+
+  for(int y=0; y<fi.height; y++)
+    for(int x=0; x<fi.width; x++){
+      unsigned char v = f2.data[0][x + y*f2.linesize[0]];
+      sum += (unsigned long)v * (unsigned long)(x + 3*y + 1);
+      count += (v != 0);
+    }
+  fprintf(stderr,"  planar show checksum=%lu nonzero=%d\n", sum, count);
+  test_bool(sum   == PLANAR_SHOW_CHECKSUM);
+  test_bool(count == PLANAR_SHOW_NONZERO);
+
+  vsMotionDetectionCleanup(&md);
+  vsFrameFree(&f1);
+  vsFrameFree(&f2);
+}
+
+/* The primitives must treat bytesPerPixel uniformly: 1 byte for planar (luma
+   only), 3 for RGB24/BGR24, and 3-of-4 for RGBA with alpha left untouched.
+   Because every overlay colour is a grey level, RGB and BGR are identical. */
+void test_draw_packed(void){
+  const int W = 32, H = 16;
+  fprintf(stderr,"*** packed: bytesPerPixel 3 and 4, grey overlay, alpha preserved\n");
+
+  for (int bpp = 3; bpp <= 4; bpp++){
+    int linesize = W * bpp;
+    unsigned char* buf = (unsigned char*)vs_malloc(linesize * H);
+    memset(buf, 0, linesize * H);
+    /* pre-fill alpha so we can tell whether it survives */
+    if (bpp == 4)
+      for (int y = 0; y < H; y++)
+        for (int x = 0; x < W; x++) buf[x*bpp + y*linesize + 3] = 0xAB;
+
+    drawBox(buf, linesize, W, H, bpp, 10, 8, 6, 4, 200);
+
+    int drawn = 0, greyOk = 1, alphaOk = 1, outside = 0;
+    for (int y = 0; y < H; y++){
+      for (int x = 0; x < W; x++){
+        unsigned char* p = buf + x*bpp + y*linesize;
+        int inBox = (x >= 10-3 && x < 10-3+6 && y >= 8-2 && y < 8-2+4);
+        int set = (p[0] || p[1] || p[2]);
+        if (inBox){
+          drawn++;
+          if (!(p[0] == 200 && p[1] == 200 && p[2] == 200)) greyOk = 0;
+        } else if (set) outside++;
+        if (bpp == 4 && p[3] != 0xAB) alphaOk = 0;
+      }
+    }
+    test_bool(drawn == 6*4);
+    test_bool(greyOk);
+    test_bool(outside == 0);
+    test_bool(alphaOk);
+    vs_free(buf);
+  }
+}

--- a/tests/test_packed.c
+++ b/tests/test_packed.c
@@ -290,6 +290,62 @@ static void test_packed_motiondetect(VSPixelFormat pf){
   vsFrameFree(&f2);
 }
 
+/* --- the 'show' overlay on packed frames --------------------------------- */
+
+/* With show enabled the detector draws the fields and motion vectors into the
+   frame. This used to be skipped entirely for packed formats. */
+static void test_packed_show(VSPixelFormat pf){
+  VSFrameInfo fi;
+  VSFrame f1, f2, before;
+  VSMotionDetectConfig mdconf = vsMotionDetectGetDefaultConfig("test_packed_show");
+  VSMotionDetect md;
+  LocalMotions lms;
+  const int dx = 8, dy = -6;
+  int x, y, c, changed = 0, grey = 1, alphaOk = 1;
+
+  fprintf(stderr,"--- show overlay, %s ---\n", packedFormatName(pf));
+  test_bool(vsFrameInfoInit(&fi, 320, 240, pf) == 1);
+  vsFrameAllocate(&f1,&fi);
+  vsFrameAllocate(&f2,&fi);
+  vsFrameAllocate(&before,&fi);
+  fillPackedNoise(&f1,&fi,7);
+  shiftPacked(&f2,&f1,&fi,dx,dy);
+  vsFrameCopy(&before,&f2,&fi);
+
+  mdconf.show = 2;   /* 2 also draws the field scan areas */
+  test_bool(vsMotionDetectInit(&md, &mdconf, &fi) == VS_OK);
+  md.conf.numThreads = 1;
+  test_bool(vsMotionDetection(&md, &lms, &f1) == VS_OK);
+  vs_vector_del(&lms);
+  test_bool(vsMotionDetection(&md, &lms, &f2) == VS_OK);
+  vs_vector_del(&lms);
+
+  for(y=0; y<fi.height; y++){
+    for(x=0; x<fi.width; x++){
+      const uint8_t* p = packedPixel(&f2,&fi,x,y);
+      const uint8_t* q = packedPixel(&before,&fi,x,y);
+      int diff = 0;
+      for(c=0; c<3; c++) if(p[c]!=q[c]) diff = 1;
+      if(diff){
+        changed++;
+        /* every overlay colour is a grey level */
+        if(!(p[0]==p[1] && p[1]==p[2])) grey = 0;
+      }
+      if(fi.bytesPerPixel==4 && p[3]!=q[3]) alphaOk = 0;
+    }
+  }
+  fprintf(stderr,"  overlay pixels drawn: %i (grey=%i alphaUntouched=%i)\n",
+          changed, grey, alphaOk);
+  test_bool(changed > 100);   /* something was actually drawn */
+  test_bool(grey);
+  test_bool(alphaOk);
+
+  vsMotionDetectionCleanup(&md);
+  vsFrameFree(&f1);
+  vsFrameFree(&f2);
+  vsFrameFree(&before);
+}
+
 void test_packed(void){
   test_packed_frameinfo();
   test_packed_identity(PF_RGB24);
@@ -299,6 +355,9 @@ void test_packed(void){
   test_packed_translate(PF_RGBA);
   test_packed_motiondetect(PF_RGB24);
   test_packed_motiondetect(PF_RGBA);
+  test_packed_show(PF_RGB24);
+  test_packed_show(PF_BGR24);
+  test_packed_show(PF_RGBA);
 }
 
 /*

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -46,6 +46,7 @@
 #include "test_localmotion2transform.c"
 #include "test_determinism.c"
 #include "test_packed.c"
+#include "test_draw.c"
 #include "test_synthetic.c"
 #ifdef VS_HAVE_LPSOLVER
 #include "test_campathopt.c"
@@ -158,6 +159,13 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testPK", "packed pixel formats")){
     UNIT(test_packed());
+  }
+
+  if(all || contains(argv,argc,"--testDRAW", "overlay drawing primitives")){
+    UNIT(test_draw_geometry());
+    UNIT(test_draw_clipping());
+    UNIT(test_draw_packed());
+    UNIT(test_draw_planar_show());
   }
 
   if(all || contains(argv,argc,"--testSYN", "synthetic circles across pixel formats")){


### PR DESCRIPTION
Addresses #33 by @Karry — same goal, reworked implementation.

`drawFieldScanArea()`, `drawField()` and `drawFieldTrans()` each began with `if (md->fi.pFormat > PF_PACKED) return;`, so `show` silently did nothing for `PF_RGB24`, `PF_BGR24` and `PF_RGBA` — despite ffmpeg advertising all three for `vidstabdetect`. The primitives beneath them walked the frame with a single pointer and a hardcoded one-byte pixel, so they could only ever work on a planar luma plane.

### Approach

`drawHLine()`/`drawVLine()` become the only place that knows about pixel layout; `drawBox()`, `drawRectangle()` and `drawLine()` are rebuilt on top of them. A pixel is addressed as `I + x*bytesPerPixel + y*linesize` — the convention 8da5ae2 established — and the colour goes into `min(bytesPerPixel,3)` channels: one for planar luma, three for RGB24/BGR24, three of four for RGBA with **alpha left untouched**.

The simplifying observation: every overlay colour is a grey level (0, 40, 64, 80, 180, 250), so all channels get the same value and **the packed channel order never has to be known** — RGB24 and BGR24 take an identical path. That removes the need for a `uint32_t` colour type, per-call-site colour selection, and format-enum threading; call sites are unchanged apart from passing frame geometry.

### Clipping (a real bug, not just new-feature plumbing)

The primitives now take both a byte `linesize` and a pixel `width`, and clip. Previously `height` was accepted and ignored and there was no `width` at all, so any shape reaching past an edge was written **out of bounds**: a box straddling the top or bottom edge wrote whole rows outside the frame, and one straddling a side edge wrapped into the neighbouring row. `drawFieldScanArea()` draws a box of `size + 2*maxShift` around a field — exactly the shape most likely to reach an edge.

### Planar output is unchanged

Deliberately, including the original geometry's quirks: a rectangle's horizontal spans start at `x-sizex/2` and cover `sizex` columns while its right edge sits at `x+sizex/2`, and line endpoints are inclusive. An end-to-end checksum captured from the previous implementation guards this and matches exactly.

### Tests

New `--testDRAW`, plus a `show` case in `--testPK`:

- **Geometry** — written against the pre-refactor implementation and verified to reproduce it exactly, including a golden pixel set for the diagonal line.
- **Clipping** — all four edges, as exact expected pixel sets so horizontal wrap into the neighbouring row is caught, not merely writes that leave the frame. All four cases were confirmed to **fail** against the old primitives (48/48/40 differing pixels, and 48 written before the buffer for the top edge).
- **Packed layout** — grey channels, alpha preserved, nothing drawn outside.
- **Planar end-to-end checksum** — uses only public entry points, so it compiles against either implementation.
- **`show=2` detection over RGB24/BGR24/RGBA** — asserts the overlay is actually drawn (29479 pixels), is grey, and preserves alpha. Identical pixel count for all three formats confirms order-independence.

Full suite **32/32**, no compiler warnings. `--testDRAW` and `--testPK` are clean under ASan and UBSan.

### Unrelated pre-existing issue found

`--all` under ASan trips a heap-buffer-overflow in `interpolateBiLin_float` (`transformfloat.c:115`, via `test_transform_implementation`), plus UBSan `left shift of negative value` at `transformfixedpoint.c:194-195`. Both reproduce identically on `origin/master` and are untouched by this change — flagging rather than widening scope here.

Supersedes #33 (closing keywords do not auto-close pull requests, so #33 needs closing by hand once this lands).
