### PR TITLE
transform: fix out of bounds reads at the frame border in the float interpolators

### DIFF
--- a/src/transformfixedpoint.c
+++ b/src/transformfixedpoint.c
@@ -32,9 +32,13 @@
 //#include <math.h>
 //#include <libgen.h>
 
-#define iToFp8(v)  ((v)<<8)
+/* Left shifting a negative signed value is undefined behaviour, and these are
+   reached with negative coordinates whenever a sample falls outside the frame
+   (interpolateLin, interpolateBiLinBorder, ...). Shift as unsigned and convert
+   back: identical bit pattern on two's complement, but well defined. */
+#define iToFp8(v)  ((int32_t)((uint32_t)(v)<<8))
 #define fToFp8(v)  ((int32_t)((v)*((float)0xFF)))
-#define iToFp16(v) ((v)<<16)
+#define iToFp16(v) ((int32_t)((uint32_t)(v)<<16))
 #define fToFp16(v) ((int32_t)((v)*((double)0xFFFF)))
 #define fp16To8(v) ((v)>>8)
 //#define fp16To8(v) ( (v) && 0x80 == 1 ? ((v)>>8 + 1) : ((v)>>8) )

--- a/src/transformfloat.c
+++ b/src/transformfloat.c
@@ -68,7 +68,10 @@ void _FLT(interpolateBiCub)(uint8_t *rv, float x, float y,
                             int width, int height, uint8_t def)
 {
   // do a simple linear interpolation at the border
-  if (x < 1 || x > width - 2 || y < 1 || y > height - 2) {
+  /* the interior path reads x_f+2 and y_f+2 unchecked, so it needs
+     floor(x) <= width-3, i.e. x < width-2. Same off by one as in
+     interpolateBiLin above; the fixed point twin tests ix_f > width-3. */
+  if (x < 1 || x >= width - 2 || y < 1 || y >= height - 2) {
     _FLT(interpolateBiLinBorder)(rv, x, y, img, img_linesize, width, height, def);
   } else {
     int x_f = myfloor(x);
@@ -105,7 +108,13 @@ void _FLT(interpolateBiLin)(uint8_t *rv, float x, float y,
                             const uint8_t *img, int img_linesize,
                             int width, int height, uint8_t def)
 {
-  if (x < 0 || x > width - 1 || y < 0 || y > height - 1) {
+  /* the interior path reads x_f+1 and y_f+1 unchecked, so it needs
+     floor(x) <= width-2 and floor(y) <= height-2, i.e. x < width-1 and
+     y < height-1. A coordinate exactly on the last row or column belongs to
+     the border path (where those neighbours carry interpolation weight 0
+     anyway). This mirrors the fixed point twin, which tests the already
+     floored ix_f against width-2. */
+  if (x < 0 || x >= width - 1 || y < 0 || y >= height - 1) {
     _FLT(interpolateBiLinBorder)(rv, x, y, img, img_linesize, width, height, def);
   } else {
     int x_f = myfloor(x);

--- a/tests/test_interpolate.c
+++ b/tests/test_interpolate.c
@@ -1,0 +1,123 @@
+/*
+   test_interpolate.c
+
+   Boundary tests for the interpolation kernels.
+
+   The interesting coordinates are the ones exactly on the last row/column:
+   there the "ceil" neighbour of a bi-linear interpolation is one pixel past
+   the end of the image. Its interpolation weight is zero, so the *result* is
+   correct either way -- only a sanitizer (or a guard page) can see the read.
+   That is why these cases survived so long, and why this file is meant to be
+   run under ASan/UBSan as well as normally.
+
+   The image buffer is allocated to exactly width*height bytes so that any
+   overrun lands in ASan's redzone rather than in slack the allocator handed
+   out anyway.
+
+   This file is part of vid.stab video stabilization library
+   and distributed under the GNU GPL, see the top of transform.c.
+*/
+
+#define IP_W 16
+#define IP_H 12
+
+/* iToFp16() is private to transformfixedpoint.c; this is the same conversion,
+   written so that it is defined for negative values too */
+static fp16 iToFp16_t(int v){ return (fp16)((uint32_t)v << 16); }
+
+/* img[x,y] = x + 16*y, so every pixel is distinct and the expected value of a
+   bi-linear sample is easy to state */
+static unsigned char* ip_make(void){
+  unsigned char* img = (unsigned char*)vs_malloc(IP_W * IP_H);
+  for (int y = 0; y < IP_H; y++)
+    for (int x = 0; x < IP_W; x++)
+      img[x + y*IP_W] = (unsigned char)(x + 16*y);
+  return img;
+}
+
+void test_interpolate_borders(void){
+  unsigned char* img = ip_make();
+  uint8_t out;
+
+  fprintf(stderr,"*** float bi-linear on the last row/column\n");
+  /* exactly the bottom right pixel: both ceil neighbours are out of range */
+  _FLT(interpolateBiLin)(&out, (float)(IP_W-1), (float)(IP_H-1),
+                         img, IP_W, IP_W, IP_H, 0);
+  test_bool(out == img[(IP_W-1) + (IP_H-1)*IP_W]);
+
+  /* last column, interior row */
+  _FLT(interpolateBiLin)(&out, (float)(IP_W-1), 4.0f,
+                         img, IP_W, IP_W, IP_H, 0);
+  test_bool(out == img[(IP_W-1) + 4*IP_W]);
+
+  /* last row, interior column */
+  _FLT(interpolateBiLin)(&out, 4.0f, (float)(IP_H-1),
+                         img, IP_W, IP_W, IP_H, 0);
+  test_bool(out == img[4 + (IP_H-1)*IP_W]);
+
+  /* halfway along the last row: interpolates between two valid pixels */
+  _FLT(interpolateBiLin)(&out, 4.5f, (float)(IP_H-1),
+                         img, IP_W, IP_W, IP_H, 0);
+  test_bool(out == (img[4 + (IP_H-1)*IP_W] + img[5 + (IP_H-1)*IP_W]) / 2);
+
+  /* an ordinary interior sample must be unaffected by any of this */
+  _FLT(interpolateBiLin)(&out, 4.0f, 4.0f, img, IP_W, IP_W, IP_H, 0);
+  test_bool(out == img[4 + 4*IP_W]);
+  _FLT(interpolateBiLin)(&out, 4.5f, 4.0f, img, IP_W, IP_W, IP_H, 0);
+  test_bool(out == (img[4 + 4*IP_W] + img[5 + 4*IP_W]) / 2);
+
+  fprintf(stderr,"*** fixed point bi-linear on the last row/column\n");
+  interpolateBiLin(&out, iToFp16_t(IP_W-1), iToFp16_t(IP_H-1),
+                   img, IP_W, IP_W, IP_H, 0);
+  test_bool(abs((int)out - (int)img[(IP_W-1) + (IP_H-1)*IP_W]) <= 1);
+  interpolateBiLin(&out, iToFp16_t(4), iToFp16_t(IP_H-1),
+                   img, IP_W, IP_W, IP_H, 0);
+  test_bool(abs((int)out - (int)img[4 + (IP_H-1)*IP_W]) <= 1);
+
+  /* negative and past-the-end coordinates: must be well defined, and must not
+     left shift a negative value (UBSan) */
+  fprintf(stderr,"*** negative / out of range coordinates\n");
+  interpolateLin(&out, iToFp16_t(-10), iToFp16_t(3), img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == 77);
+  interpolateLin(&out, iToFp16_t(IP_W+5), iToFp16_t(3), img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == 77);
+
+  /* interpolateBiLinBorder blurs the border pixel outwards over w=10 pixels
+     before def takes over completely, so def is only reached beyond that */
+  interpolateBiLin(&out, iToFp16_t(-10), iToFp16_t(-10), img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == img[0]);                       /* exactly w out: border pixel */
+  interpolateBiLin(&out, iToFp16_t(-30), iToFp16_t(-30), img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == 77);                           /* well beyond w: def */
+  interpolateBiLin(&out, iToFp16_t(IP_W+30), iToFp16_t(IP_H+30),
+                   img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == 77);
+
+  _FLT(interpolateLin)(&out, -10.0f, 3.0f, img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == 77);
+  _FLT(interpolateBiLin)(&out, -10.0f, -10.0f, img, IP_W, IP_W, IP_H, 77);
+  test_bool(out == 77);
+
+  /* sweep every coordinate on and just past the border, both kernels; the
+     point is the memory access pattern, so the assertion is only that the
+     call returns a value in range */
+  fprintf(stderr,"*** border sweep\n");
+  for (int i = -2; i <= IP_W + 1; i++){
+    float fx = (float)i;
+    _FLT(interpolateBiLin)(&out, fx, (float)(IP_H-1), img, IP_W, IP_W, IP_H, 0);
+    _FLT(interpolateBiLin)(&out, fx, 0.0f,            img, IP_W, IP_W, IP_H, 0);
+    _FLT(interpolateBiCub)(&out, fx, (float)(IP_H-1), img, IP_W, IP_W, IP_H, 0);
+    interpolateBiLin(&out, iToFp16_t(i), iToFp16_t(IP_H-1), img, IP_W, IP_W, IP_H, 0);
+    interpolateBiCub(&out, iToFp16_t(i), iToFp16_t(IP_H-1), img, IP_W, IP_W, IP_H, 0);
+  }
+  for (int i = -2; i <= IP_H + 1; i++){
+    float fy = (float)i;
+    _FLT(interpolateBiLin)(&out, (float)(IP_W-1), fy, img, IP_W, IP_W, IP_H, 0);
+    _FLT(interpolateBiLin)(&out, 0.0f,            fy, img, IP_W, IP_W, IP_H, 0);
+    _FLT(interpolateBiCub)(&out, (float)(IP_W-1), fy, img, IP_W, IP_W, IP_H, 0);
+    interpolateBiLin(&out, iToFp16_t(IP_W-1), iToFp16_t(i), img, IP_W, IP_W, IP_H, 0);
+    interpolateBiCub(&out, iToFp16_t(IP_W-1), iToFp16_t(i), img, IP_W, IP_W, IP_H, 0);
+  }
+  test_bool(1);  /* reaching here without a sanitizer report is the result */
+
+  vs_free(img);
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -33,6 +33,7 @@
 
 #include "test_frameinfo.c"
 #include "test_transform.c"
+#include "test_interpolate.c"
 #include "test_transform_prepare.c"
 #include "test_compareimg.c"
 #include "test_simd_equivalence.c"
@@ -109,6 +110,10 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testTI", "transform_implementation")){
     UNIT(test_transform_implementation(&testdata));
+  }
+
+  if(all || contains(argv,argc,"--testIP", "interpolation borders")){
+    UNIT(test_interpolate_borders());
   }
 
   if(all || contains(argv,argc,"--testTP", "transform_performance")){


### PR DESCRIPTION
Fixes the sanitizer failures noted in #164: an ASan heap-buffer-overflow in `interpolateBiLin_float` (`transformfloat.c:115`, via `--testTI`) and UBSan `left shift of negative value` at `transformfixedpoint.c:194-195`. Both are long-standing and unrelated to any recent change.

### Root cause

`interpolateBiLin()` splits into a range-checked border path and a fast interior path that reads `x_f+1` / `y_f+1` with the **unchecked** `PIX()`. The interior path therefore needs `floor(x) <= width-2`, but the guard was:

```c
if (x < 0 || x > width - 1 || y < 0 || y > height - 1)
```

A coordinate landing exactly on the last column or row still took the interior path — `floor(width-1)` is `width-1`, its ceil neighbour is `width`, and `PIX()` read one column past the row, or for `y` a whole row past the end of the plane.

The fixed-point twin gets this right, testing the already-floored `ix_f` against `width-2`. The float version compares the *real* coordinate against a bound derived for the *floored* one, and `>` admits the boundary. Changed to `>=`.

`interpolateBiCub_float()` has the identical off-by-one: it reads `x_f+2` / `y_f+2`, so needs `floor(x) <= width-3`, but guarded with `x > width - 2`. Its fixed-point twin again gets it right with `ix_f > width-3`.

**Why it survived so long:** a sample exactly on the last row/column gives the offending neighbours an interpolation weight of *zero*, so the output is correct either way — only a sanitizer or a guard page can see the read. That is the same reasoning behind 8da5ae2, which fixed the equivalent case in `interpolateN` by routing it through the range-checked accessor.

### The UBSan report

`iToFp16()`/`iToFp8()` left-shift a signed value, undefined for negative input, and they are reached with negative coordinates whenever a sample falls outside the frame (`interpolateLin`, `interpolateBiLinBorder`). Now shifted as unsigned and converted back — identical bit pattern on two's complement, but defined.

### Impact on output

**Rendered output is unchanged.** `transformed.pgm`, `transformed_u.pgm`, `transformed_FP.pgm` and `transformed_u_FP.pgm` are byte-identical to those produced before this change.

The one intended behavioural difference: bi-cubic sampling exactly on the second-to-last row/column now falls back to the bi-linear border path instead of reading out of bounds — which is what the fixed-point implementation has always done.

### Tests

New `tests/test_interpolate.c` (`--testIP`) samples the last row and column, the first row and column, and coordinates well outside the frame, for both the float and fixed-point bi-linear and bi-cubic kernels, on an exactly-sized allocation so an overrun lands in ASan's redzone rather than allocator slack. **It reproduces the original report at its first assertion.**

It also pins a piece of behaviour that is easy to guess wrong: `interpolateBiLinBorder` blurs the border pixel outwards over ten pixels before `def` takes over, rather than returning `def` immediately.

Full suite **33/33**, clean under ASan and UBSan, no compiler warnings.
