### PR TITLE
SIMD: runtime AVX2/AVX-512/NEON dispatch, parallel boxblur

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,6 +38,21 @@ jobs:
     - name: run tests, SSE2 dispatch
       run: VIDSTAB_SIMD=sse2 ./tests --all
       working-directory: tests
+    # Timings, not a gate.  GitHub runners are shared VMs, so absolute numbers
+    # are not comparable between runs and no threshold is asserted -- nothing
+    # here can fail the build.  What is meaningful is the *ratio* between
+    # dispatch levels within one run, since those execute back to back on the
+    # same machine.
+    - name: benchmark (informational)
+      continue-on-error: true
+      working-directory: tests
+      run: |
+        make bench -j2
+        for s in none sse2 avx2 avx512 neon; do
+          printf '%-7s ' "$s"
+          VIDSTAB_SIMD=$s ./bench 1280 720 20 2>/dev/null \
+            | grep -o '[0-9.]* ms/frame.*' || echo '(not available on this CPU)'
+        done
 
   # Native AArch64 -- real hardware, real NEON, no emulation.  This is what
   # actually validates src/motiondetect_neon.c; the neon_emu.h path in the x86
@@ -62,6 +77,21 @@ jobs:
     - name: run tests, scalar dispatch
       run: VIDSTAB_SIMD=none ./tests --all
       working-directory: tests
+    # Timings, not a gate.  GitHub runners are shared VMs, so absolute numbers
+    # are not comparable between runs and no threshold is asserted -- nothing
+    # here can fail the build.  What is meaningful is the *ratio* between
+    # dispatch levels within one run, since those execute back to back on the
+    # same machine.
+    - name: benchmark (informational)
+      continue-on-error: true
+      working-directory: tests
+      run: |
+        make bench -j2
+        for s in none sse2 avx2 avx512 neon; do
+          printf '%-7s ' "$s"
+          VIDSTAB_SIMD=$s ./bench 1280 720 20 2>/dev/null \
+            | grep -o '[0-9.]* ms/frame.*' || echo '(not available on this CPU)'
+        done
 
   # 32 bit ARM under qemu.  Not for speed -- this is the only place the ARMv7
   # reduction fallbacks in motiondetect_neon.c (vs_haddq_u32 / vs_hminq_u8 /

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: cpu features
-      run: lscpu | grep -o 'sse2\|avx2\|avx512bw\|avx512vl' | sort -u | tr '\n' ' '; echo
+      run: |
+        lscpu | grep -E 'Model name|Vendor ID|^CPU\(s\):' || true
+        lscpu | grep -o 'sse2\|avx2\|avx512bw\|avx512vl' | sort -u | tr '\n' ' '; echo
     - name: cmake
       run: cmake .
     - name: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,12 +7,16 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  # x86-64: whichever SIMD kernels the runner's CPU supports.  Which ones those
+  # are varies between runner generations, so the test suite skips the kernels
+  # it cannot execute and prints "N of M kernel(s) checked" -- read that line to
+  # see what a given run actually covered.
+  x86_64:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: cpu features
+      run: lscpu | grep -o 'sse2\|avx2\|avx512bw\|avx512vl' | sort -u | tr '\n' ' '; echo
     - name: cmake
       run: cmake .
     - name: make
@@ -25,4 +29,95 @@ jobs:
       working-directory: tests
     - name: run tests
       run: ./tests --all
+      working-directory: tests
+    # The dispatcher picks one kernel per run, so a single run leaves the others
+    # untested end to end.  These are cheap and pin each one down.
+    - name: run tests, scalar dispatch
+      run: VIDSTAB_SIMD=none ./tests --all
+      working-directory: tests
+    - name: run tests, SSE2 dispatch
+      run: VIDSTAB_SIMD=sse2 ./tests --all
+      working-directory: tests
+
+  # Native AArch64 -- real hardware, real NEON, no emulation.  This is what
+  # actually validates src/motiondetect_neon.c; the neon_emu.h path in the x86
+  # job only proves the logic.
+  aarch64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - name: cmake
+      run: cmake .
+    - name: make
+      run: make
+    - name: cmake tests
+      run: cmake .
+      working-directory: tests
+    - name: make tests
+      run: make
+      working-directory: tests
+    - name: run tests
+      run: ./tests --all
+      working-directory: tests
+    - name: run tests, scalar dispatch
+      run: VIDSTAB_SIMD=none ./tests --all
+      working-directory: tests
+
+  # 32 bit ARM under qemu.  Not for speed -- this is the only place the ARMv7
+  # reduction fallbacks in motiondetect_neon.c (vs_haddq_u32 / vs_hminq_u8 /
+  # vs_hmaxq_u8, which AArch64 never compiles) get executed at all.
+  armv7-qemu:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: install cross toolchain and qemu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-linux-gnueabihf qemu-user-static
+    - name: cmake
+      run: |
+        cmake -B build-armv7 \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_SYSTEM_PROCESSOR=armv7l \
+          -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
+          -DCMAKE_C_FLAGS="-mfpu=neon -mfloat-abi=hard -march=armv7-a" \
+          -DUSE_OMP=OFF
+    - name: make
+      run: cmake --build build-armv7 -j
+    - name: cmake tests
+      run: |
+        cmake -B build-armv7 -S . \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_SYSTEM_PROCESSOR=armv7l \
+          -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc \
+          -DCMAKE_C_FLAGS="-mfpu=neon -mfloat-abi=hard -march=armv7-a" \
+          -DUSE_OMP=OFF
+      working-directory: tests
+    - name: make tests
+      run: cmake --build build-armv7 -j
+      working-directory: tests
+    - name: run tests under qemu
+      run: qemu-arm-static -L /usr/arm-linux-gnueabihf ./build-armv7/tests --all
+      working-directory: tests
+
+  # Force the AVX-512 kernels to execute regardless of what the runner's CPU
+  # is, using Intel's Software Development Emulator.  Without this the AVX-512
+  # kernels are simply skipped on runners that lack them, which is correct but
+  # is not coverage.  Slow (SDE emulates every instruction), so it runs only
+  # the SIMD equivalence test rather than the whole suite.
+  avx512-sde:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: install Intel SDE
+      uses: petarpetrovt/setup-sde@v2.4
+    - name: cmake tests
+      run: cmake .
+      working-directory: tests
+    - name: make tests
+      run: make
+      working-directory: tests
+    # -spr = Sapphire Rapids, which has AVX512F/BW/VL.
+    - name: run SIMD equivalence under SDE
+      run: $SDE_PATH/sde64 -spr -- ./tests --testSIMD
       working-directory: tests

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -48,10 +48,22 @@ jobs:
       working-directory: tests
       run: |
         make bench -j2
+        # Best of three. A shared runner only ever adds time -- other tenants,
+        # steal, thermal -- so the minimum is much closer to the real cost than
+        # a mean, and a single sample is not worth reading at all.
         for s in none sse2 avx2 avx512 neon; do
-          printf '%-7s ' "$s"
-          VIDSTAB_SIMD=$s ./bench 1280 720 20 2>/dev/null \
-            | grep -o '[0-9.]* ms/frame.*' || echo '(not available on this CPU)'
+          best=
+          for r in 1 2 3; do
+            t=$(VIDSTAB_SIMD=$s ./bench 1280 720 20 2>/dev/null \
+                  | grep -o '[0-9.]* ms/frame' | grep -o '[0-9.]*')
+            [ -n "$t" ] || continue
+            best=$(printf '%s\n%s\n' "$best" "$t" | grep . | sort -g | head -1)
+          done
+          if [ -n "$best" ]; then
+            printf '%-7s %s ms/frame (best of 3)\n' "$s" "$best"
+          else
+            printf '%-7s not available on this CPU\n' "$s"
+          fi
         done
 
   # Native AArch64 -- real hardware, real NEON, no emulation.  This is what
@@ -87,10 +99,22 @@ jobs:
       working-directory: tests
       run: |
         make bench -j2
+        # Best of three. A shared runner only ever adds time -- other tenants,
+        # steal, thermal -- so the minimum is much closer to the real cost than
+        # a mean, and a single sample is not worth reading at all.
         for s in none sse2 avx2 avx512 neon; do
-          printf '%-7s ' "$s"
-          VIDSTAB_SIMD=$s ./bench 1280 720 20 2>/dev/null \
-            | grep -o '[0-9.]* ms/frame.*' || echo '(not available on this CPU)'
+          best=
+          for r in 1 2 3; do
+            t=$(VIDSTAB_SIMD=$s ./bench 1280 720 20 2>/dev/null \
+                  | grep -o '[0-9.]* ms/frame' | grep -o '[0-9.]*')
+            [ -n "$t" ] || continue
+            best=$(printf '%s\n%s\n' "$best" "$t" | grep . | sort -g | head -1)
+          done
+          if [ -n "$best" ]; then
+            printf '%-7s %s ms/frame (best of 3)\n' "$s" "$best"
+          else
+            printf '%-7s not available on this CPU\n' "$s"
+          fi
         done
 
   # 32 bit ARM under qemu.  Not for speed -- this is the only place the ARMv7

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -96,8 +96,17 @@ jobs:
     - name: make tests
       run: cmake --build build-armv7 -j
       working-directory: tests
+    # Deliberately not --all.  test_serialize_robust fails here for a reason
+    # that has nothing to do with SIMD and predates this branch: it feeds a
+    # corrupt list length, and lengths under VS_MAX_LOCALMOTIONS_PER_FRAME
+    # (1<<20) still ask for tens of MB, which a 32 bit process under qemu
+    # refuses and a 64 bit one does not.  The library then declines the record
+    # -- arguably the safer outcome -- but the test asserts the 64 bit recovery
+    # path.  Worth fixing separately; not something to paper over here.
     - name: run tests under qemu
-      run: qemu-arm-static -L /usr/arm-linux-gnueabihf ./build-armv7/tests --all
+      run: >
+        qemu-arm-static -L /usr/arm-linux-gnueabihf ./build-armv7/tests
+        --testSIMD --testBB --testCCI --testMD --testLM --testDET
       working-directory: tests
 
   # Force the AVX-512 kernels to execute regardless of what the runner's CPU

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -96,37 +96,14 @@ jobs:
     - name: make tests
       run: cmake --build build-armv7 -j
       working-directory: tests
-    # Deliberately not --all.  test_serialize_robust fails here for a reason
-    # that has nothing to do with SIMD and predates this branch: it feeds a
-    # corrupt list length, and lengths under VS_MAX_LOCALMOTIONS_PER_FRAME
-    # (1<<20) still ask for tens of MB, which a 32 bit process under qemu
-    # refuses and a 64 bit one does not.  The library then declines the record
-    # -- arguably the safer outcome -- but the test asserts the 64 bit recovery
-    # path.  Worth fixing separately; not something to paper over here.
+    # Deliberately not --all: test_serialize_robust fails here for a
+    # pre-existing reason unrelated to SIMD -- an unbounded frame index from a
+    # corrupt .trf overflows the growth loop in vs_vector_set and asks for a
+    # negative allocation, which 32 bit refuses and 64 bit often satisfies.
+    # See https://github.com/georgmartius/vid.stab/issues/168 .  Widen this
+    # back to --all once that is fixed.
     - name: run tests under qemu
       run: >
         qemu-arm-static -L /usr/arm-linux-gnueabihf ./build-armv7/tests
         --testSIMD --testBB --testCCI --testMD --testLM --testDET
-      working-directory: tests
-
-  # Force the AVX-512 kernels to execute regardless of what the runner's CPU
-  # is, using Intel's Software Development Emulator.  Without this the AVX-512
-  # kernels are simply skipped on runners that lack them, which is correct but
-  # is not coverage.  Slow (SDE emulates every instruction), so it runs only
-  # the SIMD equivalence test rather than the whole suite.
-  avx512-sde:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: install Intel SDE
-      uses: petarpetrovt/setup-sde@v2.4
-    - name: cmake tests
-      run: cmake .
-      working-directory: tests
-    - name: make tests
-      run: make
-      working-directory: tests
-    # -spr = Sapphire Rapids, which has AVX512F/BW/VL.
-    - name: run SIMD equivalence under SDE
-      run: $SDE_PATH/sde64 -spr -- ./tests --testSIMD
       working-directory: tests

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ build
 testout/
 /tests/tests
 tests/build/
+
+# out-of-tree build directories used while benchmarking
+bld*/
+tests/tbld/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,13 +43,17 @@ if(APPLE AND NOT CMAKE_OSX_ARCHITECTURES AND NOT SSE2_FOUND)
   add_definitions(-march=armv8-a+fp+simd+crypto+crc)
 endif()
 
-# here we should check for SSE2
-# our  -DUSE_SSE2_ASM code does not work with fpic
-if (NOT MSVC)
-  if(SSE2_FOUND)
-      add_definitions( -DUSE_SSE2 -msse2 -ffast-math )
-endif ()
+# --- SIMD kernels ------------------------------------------------------------
+# Which kernel runs is decided at runtime (src/cpudetect.c), so the AVX2 and
+# AVX-512 variants are compiled in wherever the *compiler* can build them and
+# the resulting binary still runs on an SSE2-only host.  Only the SSE2 flag is
+# global, since SSE2 is baseline on x86_64.
+include (VidstabSimd)
+vidstab_configure_simd("${CMAKE_CURRENT_SOURCE_DIR}/src")
+message(STATUS "SIMD kernels compiled in: ${VIDSTAB_SIMD_SUMMARY}")
 
+if(NOT MSVC AND SSE2_FOUND)
+  add_definitions( -msse2 -ffast-math )
 endif()
 if(MSVC AND USE_OMP)
   add_compile_options(/openmp)
@@ -60,8 +64,10 @@ endif()
 
 set(SOURCES src/frameinfo.c src/transformtype.c src/libvidstab.c
   src/transform.c src/transformfixedpoint.c src/motiondetect.c
-  src/motiondetect_opt.c src/serialize.c src/localmotion2transform.c
+  src/serialize.c src/localmotion2transform.c
   src/boxblur.c src/vsvector.c)
+list(APPEND SOURCES ${VIDSTAB_SIMD_SOURCES})
+add_compile_definitions(${VIDSTAB_SIMD_DEFS})
 
 # --- LP solver backend for the L1 optimal camera path -------------------------
 # The built-in interior point solver keeps vid.stab dependency free; GLPK can be

--- a/CMakeModules/VidstabSimd.cmake
+++ b/CMakeModules/VidstabSimd.cmake
@@ -1,0 +1,120 @@
+# VidstabSimd.cmake
+#
+# Decides which SIMD kernels are compiled into the library and with which
+# per-file flags.  Nothing here changes the flags of the *rest* of the library:
+# the AVX2/AVX-512 kernels live in their own translation units and are only
+# entered after vs_cpu_flags() has confirmed the host supports them, so the
+# resulting binary still runs on a plain SSE2 machine.
+#
+# Sets, in the parent scope:
+#   VIDSTAB_SIMD_SOURCES  - source files to add to the library
+#   VIDSTAB_SIMD_DEFS     - VS_HAVE_* definitions for the whole library
+#   VIDSTAB_SIMD_SUMMARY  - human readable list for the status message
+# and attaches the required COMPILE_OPTIONS to the individual sources.
+
+include(CheckCSourceCompiles)
+
+function(vidstab_configure_simd SRCDIR)
+  set(_sources "")
+  set(_defs "")
+  set(_summary "")
+
+  # ---------------------------------------------------------------- x86 ---
+  # SSE2_FOUND comes from FindSSE.cmake, which already refuses to answer yes
+  # for a non-x86 target.
+  if(SSE2_FOUND)
+    list(APPEND _sources "${SRCDIR}/motiondetect_opt.c")
+    list(APPEND _defs VS_HAVE_SSE2)
+    list(APPEND _summary "SSE2")
+
+    # SSE2 is baseline on x86_64 and the library has always required it where
+    # available, so it stays a global flag (32 bit x86 needs it explicitly).
+    if(NOT MSVC)
+      set(VIDSTAB_SSE2_FLAG "-msse2" PARENT_SCOPE)
+    endif()
+
+    # -- AVX2 --
+    if(MSVC)
+      set(_avx2_flags /arch:AVX2)
+    else()
+      set(_avx2_flags -mavx2)
+    endif()
+    string(REPLACE ";" " " _avx2_flagstr "${_avx2_flags}")
+    set(CMAKE_REQUIRED_FLAGS "${_avx2_flagstr}")
+    check_c_source_compiles("
+      #include <immintrin.h>
+      int main(void){
+        __m256i a = _mm256_set1_epi8(1), b = _mm256_set1_epi8(2);
+        return (int)_mm256_extract_epi32(_mm256_sad_epu8(a,b), 0);
+      }" VIDSTAB_HAVE_AVX2)
+    unset(CMAKE_REQUIRED_FLAGS)
+    if(VIDSTAB_HAVE_AVX2)
+      list(APPEND _sources "${SRCDIR}/motiondetect_avx2.c")
+      list(APPEND _defs VS_HAVE_AVX2)
+      list(APPEND _summary "AVX2")
+      set_source_files_properties("${SRCDIR}/motiondetect_avx2.c"
+                                  PROPERTIES COMPILE_OPTIONS "${_avx2_flags}")
+    endif()
+
+    # -- AVX-512 (F + BW + VL) --
+    if(MSVC)
+      set(_avx512_flags /arch:AVX512)
+    else()
+      set(_avx512_flags -mavx512f -mavx512bw -mavx512vl)
+    endif()
+    # CMAKE_REQUIRED_FLAGS is a *string*: a CMake list would arrive at the
+    # compiler semicolon separated and the probe would fail for the wrong
+    # reason.  COMPILE_OPTIONS below does want the list form.
+    string(REPLACE ";" " " _avx512_flagstr "${_avx512_flags}")
+    set(CMAKE_REQUIRED_FLAGS "${_avx512_flagstr}")
+    check_c_source_compiles("
+      #include <immintrin.h>
+      int main(void){
+        __m512i a = _mm512_set1_epi8(1), b = _mm512_set1_epi8(2);
+        __m512i s = _mm512_sad_epu8(a,b);
+        __m512i m = _mm512_maskz_loadu_epi8((__mmask64)0xF, &a);
+        s = _mm512_add_epi64(s, m);
+        return (int)_mm512_reduce_add_epi64(s);
+      }" VIDSTAB_HAVE_AVX512)
+    unset(CMAKE_REQUIRED_FLAGS)
+    if(VIDSTAB_HAVE_AVX512)
+      list(APPEND _sources "${SRCDIR}/motiondetect_avx512.c")
+      list(APPEND _defs VS_HAVE_AVX512)
+      list(APPEND _summary "AVX-512")
+      set_source_files_properties("${SRCDIR}/motiondetect_avx512.c"
+                                  PROPERTIES COMPILE_OPTIONS "${_avx512_flags}")
+    endif()
+  endif()
+
+  # ---------------------------------------------------------------- ARM ---
+  # No flag is needed: NEON is mandatory on AArch64, and 32 bit ARM builds that
+  # want it pass their own -mfpu=neon.  The probe is what decides.
+  check_c_source_compiles("
+    #include <arm_neon.h>
+    int main(void){
+      uint8x16_t a = vdupq_n_u8(1), b = vdupq_n_u8(2);
+      uint16x8_t s = vpadalq_u8(vdupq_n_u16(0), vabdq_u8(a,b));
+      return (int)vgetq_lane_u16(s, 0);
+    }" VIDSTAB_HAVE_NEON)
+  if(VIDSTAB_HAVE_NEON)
+    list(APPEND _sources "${SRCDIR}/motiondetect_neon.c")
+    list(APPEND _defs VS_HAVE_NEON)
+    list(APPEND _summary "NEON")
+  endif()
+
+  # ------------------------------------------------------------- always ---
+  list(APPEND _sources "${SRCDIR}/cpudetect.c" "${SRCDIR}/motiondetect_dispatch.c")
+  # motiondetect_opt.c also holds contrastSubImg_variance_C, which the library
+  # needs whether or not SSE2 was compiled in.
+  if(NOT SSE2_FOUND)
+    list(APPEND _sources "${SRCDIR}/motiondetect_opt.c")
+  endif()
+
+  if(NOT _summary)
+    set(_summary "none (scalar C only)")
+  endif()
+
+  set(VIDSTAB_SIMD_SOURCES "${_sources}" PARENT_SCOPE)
+  set(VIDSTAB_SIMD_DEFS    "${_defs}"    PARENT_SCOPE)
+  set(VIDSTAB_SIMD_SUMMARY "${_summary}" PARENT_SCOPE)
+endfunction()

--- a/bench/bench_boxblur.c
+++ b/bench/bench_boxblur.c
@@ -1,0 +1,29 @@
+/* bench_boxblur.c -- isolated timing for the two boxblur passes. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "boxblur.h"
+#include "frameinfo.h"
+
+void boxblur_hori_C(unsigned char* dest, const unsigned char* src,
+                    int width, int height, int dest_strive, int src_strive, int size);
+void boxblur_vert_C(unsigned char* dest, const unsigned char* src,
+                    int width, int height, int dest_strive, int src_strive, int size);
+
+static double now_s(void){
+  struct timespec ts; clock_gettime(CLOCK_MONOTONIC,&ts);
+  return ts.tv_sec + ts.tv_nsec*1e-9;
+}
+
+int main(void){
+  const int W=1920,H=1080,SIZE=15,REPS=100;
+  unsigned char *src=malloc((size_t)W*H), *dst=malloc((size_t)W*H);
+  double t0,t1; int i;
+  for(i=0;i<W*H;i++) src[i]=(unsigned char)(i*37);
+
+  t0=now_s(); for(i=0;i<REPS;i++) boxblur_hori_C(dst,src,W,H,W,W,SIZE); t1=now_s();
+  printf("boxblur_hori  %6.2f ms/frame\n",(t1-t0)*1000.0/REPS);
+  t0=now_s(); for(i=0;i<REPS;i++) boxblur_vert_C(dst,src,W,H,W,W,SIZE); t1=now_s();
+  printf("boxblur_vert  %6.2f ms/frame\n",(t1-t0)*1000.0/REPS);
+  return 0;
+}

--- a/bench/bench_motiondetect.c
+++ b/bench/bench_motiondetect.c
@@ -14,6 +14,7 @@
 #include "motiondetect.h"
 #include "motiondetect_internal.h"
 #include "motiondetect_opt.h"
+#include "cpudetect.h"
 #include "frameinfo.h"
 #include "vsvector.h"
 
@@ -172,6 +173,7 @@ int main(int argc, char** argv) {
   int width = 1920, height = 1080, nframes = 30;
   int sizes[] = {32, 48, 112};
   int i;
+  unsigned int cpu;
 
   if (argc >= 3) {
     width = atoi(argv[1]);
@@ -182,32 +184,41 @@ int main(int argc, char** argv) {
 
   alloc_images();
 
-  printf("=== kernels ===\n");
+  /* Only time kernels this CPU can actually execute -- a build machine's
+     compiler routinely supports more than its processor does. */
+  cpu = vs_cpu_flags();
+  printf("=== kernels (this CPU: %s) ===\n", vs_cpu_flags_name(cpu));
   for (i = 0; i < (int)(sizeof(sizes) / sizeof(sizes[0])); i++) {
     int s = sizes[i];
     int reps = 20000000 / (s * s);
     bench_compare("C", compareSubImg_thr, s, reps / 81 + 1);
 #ifdef VS_HAVE_SSE2
-    bench_compare("SSE2", compareSubImg_thr_sse2, s, reps / 81 + 1);
+    if (cpu & VS_CPU_SSE2)
+      bench_compare("SSE2", compareSubImg_thr_sse2, s, reps / 81 + 1);
 #endif
 #ifdef VS_HAVE_AVX2
-    bench_compare("AVX2", compareSubImg_thr_avx2, s, reps / 81 + 1);
+    if (cpu & VS_CPU_AVX2)
+      bench_compare("AVX2", compareSubImg_thr_avx2, s, reps / 81 + 1);
 #endif
 #ifdef VS_HAVE_AVX512
-    bench_compare("AVX512", compareSubImg_thr_avx512, s, reps / 81 + 1);
+    if (cpu & VS_CPU_AVX512)
+      bench_compare("AVX512", compareSubImg_thr_avx512, s, reps / 81 + 1);
 #endif
 #ifdef VS_HAVE_NEON
     bench_compare("NEON", compareSubImg_thr_neon, s, reps / 81 + 1);
 #endif
     bench_contrast("C", contrast_C_wrap, s, reps);
 #ifdef VS_HAVE_SSE2
-    bench_contrast("SSE2", contrastSubImg1_SSE, s, reps);
+    if (cpu & VS_CPU_SSE2)
+      bench_contrast("SSE2", contrastSubImg1_SSE, s, reps);
 #endif
 #ifdef VS_HAVE_AVX2
-    bench_contrast("AVX2", contrastSubImg1_avx2, s, reps);
+    if (cpu & VS_CPU_AVX2)
+      bench_contrast("AVX2", contrastSubImg1_avx2, s, reps);
 #endif
 #ifdef VS_HAVE_AVX512
-    bench_contrast("AVX512", contrastSubImg1_avx512, s, reps);
+    if (cpu & VS_CPU_AVX512)
+      bench_contrast("AVX512", contrastSubImg1_avx512, s, reps);
 #endif
 #ifdef VS_HAVE_NEON
     bench_contrast("NEON", contrastSubImg1_neon, s, reps);

--- a/bench/bench_motiondetect.c
+++ b/bench/bench_motiondetect.c
@@ -1,0 +1,221 @@
+/* bench_motiondetect.c
+ *
+ * End-to-end and kernel-level benchmark for the motion detection stage.
+ * Not part of the test suite -- a measurement tool for the SIMD work.
+ *
+ * Usage: bench_motiondetect [width height nframes]
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <limits.h>
+
+#include "motiondetect.h"
+#include "motiondetect_internal.h"
+#include "motiondetect_opt.h"
+#include "frameinfo.h"
+#include "vsvector.h"
+
+static double now_s(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec + ts.tv_nsec * 1e-9;
+}
+
+/* deterministic pseudo random, so runs are comparable */
+static unsigned int rstate = 12345;
+static unsigned int xrand(void) {
+  rstate = rstate * 1103515245u + 12345u;
+  return (rstate >> 16) & 0x7FFF;
+}
+
+/* A textured frame that actually has contrast everywhere, shifted by (dx,dy)
+   so the motion search has something to find. */
+static void fill_frame(VSFrame* f, const VSFrameInfo* fi, int dx, int dy) {
+  int x, y;
+  for (y = 0; y < fi->height; y++) {
+    unsigned char* row = f->data[0] + y * f->linesize[0];
+    for (x = 0; x < fi->width; x++) {
+      int u = x + dx, v = y + dy;
+      /* a mix of smooth gradients and high frequency detail */
+      row[x] = (unsigned char)((u * 3 + v * 5 + ((u >> 3) ^ (v >> 3)) * 17
+                                + ((u * v) >> 6)) & 0xFF);
+    }
+  }
+  if (fi->pFormat == PF_YUV420P) {
+    int p;
+    for (p = 1; p < 3; p++) {
+      for (y = 0; y < fi->height / 2; y++) {
+        unsigned char* row = f->data[p] + y * f->linesize[p];
+        memset(row, 128, fi->width / 2);
+      }
+    }
+  }
+}
+
+static void bench_end_to_end(int width, int height, int nframes) {
+  VSMotionDetect md;
+  VSFrameInfo fi;
+  VSMotionDetectConfig conf = vsMotionDetectGetDefaultConfig("bench");
+  VSFrame frame;
+  int i;
+  double t0, t1;
+
+  conf.show = 0;
+  vsFrameInfoInit(&fi, width, height, PF_YUV420P);
+  if (vsMotionDetectInit(&md, &conf, &fi) != VS_OK) {
+    fprintf(stderr, "vsMotionDetectInit failed\n");
+    exit(1);
+  }
+  vsFrameAllocate(&frame, &fi);
+
+  /* warm up: one frame so the "prev" buffer is populated */
+  fill_frame(&frame, &fi, 0, 0);
+  {
+    LocalMotions lms;
+    vsMotionDetection(&md, &lms, &frame);
+    vs_vector_del(&lms);
+  }
+
+  t0 = now_s();
+  for (i = 0; i < nframes; i++) {
+    LocalMotions lms;
+    fill_frame(&frame, &fi, (i % 7) - 3, (i % 5) - 2);
+    vsMotionDetection(&md, &lms, &frame);
+    vs_vector_del(&lms);
+  }
+  t1 = now_s();
+
+  printf("end-to-end  %4dx%-4d  %3d frames: %8.2f ms/frame  (%6.1f fps)\n",
+         width, height, nframes, (t1 - t0) * 1000.0 / nframes,
+         nframes / (t1 - t0));
+
+  vsFrameFree(&frame);
+  vsMotionDetectionCleanup(&md);
+}
+
+/* ---------------- kernel level ---------------- */
+
+typedef unsigned int (*cmpfn)(unsigned char* const, unsigned char* const,
+                              const Field*, int, int, int, int, int, int,
+                              unsigned int);
+typedef double (*confn)(unsigned char* const, const Field*, int, int);
+
+static double contrast_C_wrap(unsigned char* const I, const Field* f,
+                              int linesize, int height) {
+  return contrastSubImg(I, f, linesize, height, 1);
+}
+
+#define BENCH_W 1920
+#define BENCH_H 1080
+
+static unsigned char *img1, *img2;
+
+static void alloc_images(void) {
+  int i;
+  img1 = malloc((size_t)BENCH_W * BENCH_H);
+  img2 = malloc((size_t)BENCH_W * BENCH_H);
+  for (i = 0; i < BENCH_W * BENCH_H; i++) {
+    img1[i] = (unsigned char)xrand();
+    img2[i] = (unsigned char)(img1[i] + (xrand() & 7) - 3);
+  }
+}
+
+static void bench_compare(const char* name, cmpfn fn, int fieldsize, int reps) {
+  Field field;
+  double t0, t1;
+  int r, dx, dy;
+  unsigned long long acc = 0;
+
+  field.size = fieldsize;
+  field.x = BENCH_W / 2;
+  field.y = BENCH_H / 2;
+
+  t0 = now_s();
+  for (r = 0; r < reps; r++) {
+    for (dy = -4; dy <= 4; dy++)
+      for (dx = -4; dx <= 4; dx++)
+        acc += fn(img1, img2, &field, BENCH_W, BENCH_W, BENCH_H, 1, dx, dy,
+                  UINT_MAX);
+  }
+  t1 = now_s();
+  {
+    double calls = (double)reps * 81.0;
+    double bytes = calls * (double)fieldsize * fieldsize * 2.0;
+    printf("  compare  %-10s size=%-3d  %8.1f ns/call  %7.2f GB/s   [%llu]\n",
+           name, fieldsize, (t1 - t0) * 1e9 / calls, bytes / (t1 - t0) / 1e9,
+           acc);
+  }
+}
+
+static void bench_contrast(const char* name, confn fn, int fieldsize, int reps) {
+  Field field;
+  double t0, t1;
+  int r;
+  double acc = 0;
+
+  field.size = fieldsize;
+  field.x = BENCH_W / 2;
+  field.y = BENCH_H / 2;
+
+  t0 = now_s();
+  for (r = 0; r < reps; r++)
+    acc += fn(img1, &field, BENCH_W, BENCH_H);
+  t1 = now_s();
+  printf("  contrast %-10s size=%-3d  %8.1f ns/call  %7.2f GB/s   [%.3f]\n",
+         name, fieldsize, (t1 - t0) * 1e9 / reps,
+         (double)reps * fieldsize * fieldsize / (t1 - t0) / 1e9, acc);
+}
+
+int main(int argc, char** argv) {
+  int width = 1920, height = 1080, nframes = 30;
+  int sizes[] = {32, 48, 112};
+  int i;
+
+  if (argc >= 3) {
+    width = atoi(argv[1]);
+    height = atoi(argv[2]);
+  }
+  if (argc >= 4)
+    nframes = atoi(argv[3]);
+
+  alloc_images();
+
+  printf("=== kernels ===\n");
+  for (i = 0; i < (int)(sizeof(sizes) / sizeof(sizes[0])); i++) {
+    int s = sizes[i];
+    int reps = 20000000 / (s * s);
+    bench_compare("C", compareSubImg_thr, s, reps / 81 + 1);
+#ifdef VS_HAVE_SSE2
+    bench_compare("SSE2", compareSubImg_thr_sse2, s, reps / 81 + 1);
+#endif
+#ifdef VS_HAVE_AVX2
+    bench_compare("AVX2", compareSubImg_thr_avx2, s, reps / 81 + 1);
+#endif
+#ifdef VS_HAVE_AVX512
+    bench_compare("AVX512", compareSubImg_thr_avx512, s, reps / 81 + 1);
+#endif
+#ifdef VS_HAVE_NEON
+    bench_compare("NEON", compareSubImg_thr_neon, s, reps / 81 + 1);
+#endif
+    bench_contrast("C", contrast_C_wrap, s, reps);
+#ifdef VS_HAVE_SSE2
+    bench_contrast("SSE2", contrastSubImg1_SSE, s, reps);
+#endif
+#ifdef VS_HAVE_AVX2
+    bench_contrast("AVX2", contrastSubImg1_avx2, s, reps);
+#endif
+#ifdef VS_HAVE_AVX512
+    bench_contrast("AVX512", contrastSubImg1_avx512, s, reps);
+#endif
+#ifdef VS_HAVE_NEON
+    bench_contrast("NEON", contrastSubImg1_neon, s, reps);
+#endif
+    printf("\n");
+  }
+
+  printf("=== end to end ===\n");
+  bench_end_to_end(width, height, nframes);
+  return 0;
+}

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Build the benchmark. Extra compiler flags can be passed as arguments.
+set -e
+cd "$(dirname "$0")/.."
+SRCS="src/frameinfo.c src/transformtype.c src/libvidstab.c src/transform.c \
+src/transformfixedpoint.c src/motiondetect.c src/motiondetect_opt.c \
+src/serialize.c src/localmotion2transform.c src/boxblur.c src/vsvector.c \
+src/l1campathoptimization.c src/lpsolver_ipm.c src/cpudetect.c \
+src/motiondetect_dispatch.c"
+
+# The wide kernels get their own -m flags, exactly as CMake does per source.
+mkdir -p bld
+gcc -O3 -std=gnu99 -Isrc -c src/motiondetect_avx2.c   -o bld/mdavx2.o   -DVS_HAVE_AVX2 -mavx2 "$@"
+gcc -O3 -std=gnu99 -Isrc -c src/motiondetect_avx512.c -o bld/mdavx512.o -DVS_HAVE_AVX512 \
+    -mavx512f -mavx512bw -mavx512vl "$@"
+# NEON kernel, built for x86 against the scalar emulation so it can be checked here
+gcc -O3 -std=gnu99 -Isrc -Itests -c src/motiondetect_neon.c -o bld/mdneon.o \
+    -DVS_HAVE_NEON -DVS_NEON_EMULATION "$@"
+OBJS="bld/mdavx2.o bld/mdavx512.o bld/mdneon.o"
+EXTRA_DEFS="-DVS_HAVE_AVX2 -DVS_HAVE_AVX512 -DVS_HAVE_NEON"
+mkdir -p bld
+gcc -O3 -std=gnu99 -DUSE_OMP -fopenmp -DUSE_IPM -DVS_HAVE_LPSOLVER \
+    $EXTRA_DEFS -Isrc -Itests -o bld/bench bench/bench_motiondetect.c $SRCS $OBJS -lm "$@"

--- a/docs/superpowers/simd-optimization-report.md
+++ b/docs/superpowers/simd-optimization-report.md
@@ -114,37 +114,37 @@ which is not worth giving up an exactly-testable property for.
 Note the C row for `compare` is not really "scalar" — GCC auto-vectorizes it at
 `-O3 -msse2`, which is why the old SSE2 kernel was only ~1.3x faster than it.
 
-## AVX2 lost to SSE2 on the GitHub x86 runner — unexplained
+## AVX2 barely beats SSE2 on AMD Zen 4 — and how CI caught it
 
-Worth recording because it did not show up on dedicated hardware. The CI
-benchmark step (720p, best of three) on `ubuntu-latest`:
+The CI benchmark step turned out to be worth more than a sanity check. On the
+`ubuntu-latest` runner (AMD EPYC 9V74, Zen 4, 4 vCPU) AVX2 first came out
+**22% slower than SSE2** at 720p — reproducibly, and surviving best-of-three
+sampling, so not runner noise. That is the opposite of every measurement on the
+i7-7800X, where AVX2 wins at every field size tested.
 
-```
-none    219.82 ms/frame
-sse2     57.65 ms/frame
-avx2     70.59 ms/frame     <- 22% slower than SSE2
-avx512   71.11 ms/frame
-```
+Zen 4 has no 256-bit frequency licensing, which ruled out the obvious
+explanation and left the kernel itself. The cause was the 16-byte tail: field
+sizes are multiples of 16 but not of 32, so 720p (80 bytes) and 1080p (112)
+both run the tail path once per row, and it was widening its result into the
+256-bit accumulator with a `vpxor` + `vinserti128` **every row** — overhead
+falling on a third and a quarter of the row respectively. Giving the tail its
+own 128-bit accumulator removed it.
 
-Reproducible across runs and across best-of-three sampling, so it is not
-runner noise — but it is the opposite of every measurement on the i7-7800X,
-where AVX2 beats SSE2 at every field size tested.
+Same-run ratios on the same runner (the only comparison a shared VM supports):
 
-Not diagnosed. Two plausible causes, neither confirmed:
+| | avx2 / sse2 |
+|---|---|
+| before | 1.224 (AVX2 22% slower) |
+| after | 1.034 (AVX2 3% slower) |
 
-- At 720p the field size is 80 bytes, so the AVX2 kernel does two 32-byte
-  iterations plus a 16-byte tail, and the tail carries widening overhead that
-  SSE2's uniform five iterations do not. That is a third of the row on a
-  less favourable path.
-- 256-bit frequency licensing on the runner's server part, which the
-  128-bit SSE2 kernel would avoid entirely.
+Locally the same change is ~2%, inside the noise — the i7-7800X simply did not
+care, which is exactly why this needed a second microarchitecture to surface.
 
-The dispatch default is set from dedicated-hardware measurement, not from
-this, and correctness is unaffected (the kernels are bit-identical and the
-equivalence tests pass on that runner). But it does mean **AVX2 should not be
-assumed to be a win on every x86 part**, and it is a reason to keep the
-`VIDSTAB_SIMD` override available to users. Worth a proper look on a known
-server CPU before treating the AVX2 default as settled for server deployments.
+AVX2 is still marginally behind SSE2 on this Zen 4 part at 720p, now close
+enough to be noise. The dispatch default stays AVX2 on measurement from
+dedicated hardware, but the lesson stands: **AVX2 is not automatically a win
+on every x86 part**, which is a reason to keep the `VIDSTAB_SIMD` override
+available to users. Worth a proper look on a dedicated server CPU.
 
 ## AVX-512 is not enabled by default, on purpose
 

--- a/docs/superpowers/simd-optimization-report.md
+++ b/docs/superpowers/simd-optimization-report.md
@@ -1,0 +1,205 @@
+# SIMD and parallelism optimization of the motion detection stage
+
+Experimental branch `worktree-simd-opt`. Measurements on an Intel i7-7800X
+(Skylake-X, 6c/12t, 3.5 GHz, AVX-512 capable), GCC 13.3, `-O3`, synthetic
+textured frames from `bench/bench_motiondetect.c`.
+
+## Summary
+
+| Resolution | Threads | Before (ms/frame) | After (ms/frame) | Speedup |
+|---|---|---|---|---|
+| 1280x720  | 9 | 11.85 | 5.91 | **2.01x** |
+| 1920x1080 | 9 | 32.34 | 17.86 | **1.81x** |
+| 3840x2160 | 9 | 305.90 | 202.24 | **1.51x** |
+| 1920x1080 | 1 | 68.94 | 49.42 | **1.39x** |
+
+1080p motion detection goes from 31 fps to 56 fps on this machine.
+
+Four changes, in order of how much they bought:
+
+1. **AVX2 kernels with runtime dispatch** for `compareSubImg` and
+   `contrastSubImg` (`compareSubImg` alone was 66% of frame time).
+2. **boxblur parallelised** across cores — it was ~10 ms/frame of purely serial
+   work and had become the Amdahl limit once the search itself scaled.
+3. **boxblur vertical pass restructured** from a column walk to a row-sequential
+   sweep, so it stops missing cache on every pixel and auto-vectorizes.
+4. **ARM/Apple Silicon got SIMD at all** — see below, it had none.
+
+## The ARM finding
+
+This is the one worth reading even if the rest is skipped.
+
+`motiondetect_opt.c` contained:
+
+```c
+#ifdef __ARM_NEON__
+#include "sse2neon.h"
+#define USE_SSE2
+#endif
+```
+
+That `#define` is local to that one translation unit. `motiondetect.c` — which
+is where `compareSubImg` is actually *called*, and where `fieldSize` is rounded
+up to a multiple of 16 — never saw it. Verified with the preprocessor:
+
+```
+$ gcc -E -Isrc x.c | grep WHICH     # no -DUSE_SSE2, i.e. an ARM build
+WHICH: compareSubImg_thr                 <- the scalar C version
+```
+
+So on every ARM build, including all Apple Silicon: the shimmed kernels were
+compiled and then never called, and **vid.stab ran fully scalar**. There is a
+second, independent bug in the same place — `__ARM_NEON__` (with trailing
+underscores) is defined by Clang but *not* by GCC on AArch64, so a GCC AArch64
+build did not even reach the shim.
+
+Replaced with native NEON kernels (`src/motiondetect_neon.c`) using
+`vabdq_u8`/`vpadalq_u8`, wired through the runtime dispatcher, with the
+architecture detection in one place (`cpudetect.h`) checking both spellings.
+
+**Not measured on real hardware** — no ARM machine, cross-compiler or qemu was
+available here. What *is* verified is correctness: `tests/neon_emu.h` is a
+scalar emulation of the nine NEON intrinsics the kernel uses, so the kernel is
+compiled on x86 and run through the full equivalence suite (1320 checks). The
+logic is right; the performance still needs a run on real silicon before any
+speed claim is made.
+
+## Runtime dispatch
+
+Previously SSE2 was selected by the preprocessor and `-msse2` was applied to
+the whole library, so a distribution binary could never use anything newer.
+Now `src/cpudetect.c` probes CPUID (including XCR0, so the OS is actually
+saving the wide registers) and `src/motiondetect_dispatch.c` picks kernels at
+runtime. Only the AVX2/AVX-512 *kernel files* are compiled with `-mavx2` etc.,
+so the binary still runs on an SSE2-only host.
+
+`VIDSTAB_SIMD=none|sse2|avx2|avx512|neon` overrides the choice; that is how the
+table below was produced on one machine, and it makes the kernels testable
+against each other in CI.
+
+Field size is now rounded to a multiple of 16 **unconditionally** rather than
+only in SSE2 builds. That matters: the kernel is chosen at runtime, so making
+the field geometry depend on the host CPU would make the same input produce
+different `.trf` output on different machines.
+
+## Kernel measurements
+
+Single call, `field->size` as shown, 1080p frame, ns/call:
+
+| size | C | SSE2 | AVX2 | AVX-512 |
+|---|---|---|---|---|
+| compare 32  | 139.4 | 82.0 | **49.5** | 60.2 |
+| compare 48  | 190.3 | 141.7 | **79.1** | 90.2 |
+| compare 112 | 755.5 | 610.1 | 455.4 | **444.4** |
+| contrast 32  | 808.1 | 53.6 | 40.9 | **40.5** |
+| contrast 48  | 1748.9 | 101.8 | **55.5** | 63.0 |
+| contrast 112 | 9750.8 | 455.7 | 346.4 | **195.8** |
+
+All five kernels (C, SSE2, AVX2, AVX-512, NEON) return **bit-identical**
+results. The early-exit check cadence was left at every row precisely so that
+this holds even for early-exited calls; batching the check every 4 rows is
+legal under the documented contract and was measured at only ~1.5% end to end,
+which is not worth giving up an exactly-testable property for.
+
+Note the C row for `compare` is not really "scalar" — GCC auto-vectorizes it at
+`-O3 -msse2`, which is why the old SSE2 kernel was only ~1.3x faster than it.
+
+## AVX-512 is not enabled by default, on purpose
+
+On this Skylake-X, AVX-512 is consistently **~18% slower** than AVX2 end to
+end, single- and multi-threaded (49.7/50.3/50.7 vs 59.3/59.4/61.0 ms/frame over
+three runs each). These kernels are memory bound, so the extra width buys
+little, while issuing 512-bit instructions drops the core clock on the parts
+that implement AVX-512 frequency licensing — and that penalty applies to the
+*whole* frame, including the scalar code around the kernel.
+
+Newer cores (Ice Lake+, Zen 4/5) do not throttle this way and would likely come
+out ahead, but there is no reliable runtime probe for "does 512-bit width cost
+me frequency here", and a family/model table ages badly. So the AVX-512 kernels
+are built and tested but reachable only via `VIDSTAB_SIMD=avx512`.
+
+This is worth revisiting on a Zen 4/5 or Ice Lake+ machine — it may well
+deserve to be the default there.
+
+## boxblur
+
+`boxblur_hori` + `boxblur_vert` were ~10.5 ms/frame at 1080p and, unusually,
+entirely serial: the `#pragma omp parallel for` in `hori` was commented out
+with "(no speedup)". That may have been true when written, but once the motion
+search scales across 9 cores, 10 ms of serial work dominates everything.
+
+- `hori`: rows are independent accumulator chains — parallelised directly.
+- `vert`: rewritten from "one column at a time" (a new cache line per pixel,
+  and one serial dependency chain per column, so nothing vectorizes) to a
+  row-sequential sweep holding all columns' accumulators in an array, then
+  parallelised over blocks of columns.
+
+Result: **10.45 -> 2.59 ms/frame** at 9 threads (1.13x from the restructure
+alone, the rest from parallelism).
+
+The rewrite is bit-identical to the original, including its edge behaviour;
+`tests/test_boxblur.c` now checks that against a verbatim copy of the old
+algorithm over 500 geometries. Previously `test_boxblur` was a timing harness
+that asserted nothing (`0/0 checks`).
+
+## Where the time goes now
+
+1080p, single-threaded profile after the changes:
+
+```
+63.1%  compareSubImg_thr_avx2
+10.8%  boxblur_vert_C
+ 9.9%  boxblur_hori_C
+ 5.4%  contrastSubImg
+```
+
+`compareSubImg` is still the kernel to beat, but it is now within ~2x of
+memory bandwidth for its access pattern. Further meaningful gains are more
+likely to come from **doing fewer comparisons** (the search is a full spiral
+scan over ~594k calls/frame at 1080p) than from making each one faster —
+e.g. a coarse-to-fine pyramid, or early termination on the field level.
+
+## GPU offload: assessment, not recommended for now
+
+Block-matching motion search is exactly the kind of work GPUs are good at, and
+at 4K the current 202 ms/frame (5 fps) is slow enough to be worth attacking.
+But:
+
+- **Dependency cost is the dominant argument.** vid.stab is consumed as a small
+  dependency-light C library by ffmpeg and transcode, and packaged widely. Add
+  OpenCL/CUDA/Vulkan and every packager inherits a runtime dependency and a
+  driver-dependent failure mode, for a filter that is not the bottleneck of a
+  typical transcode.
+- **The early-exit heuristic does not port.** The CPU kernel abandons a
+  candidate the moment its running SAD exceeds the best so far, which is where
+  a large part of its speed comes from. A GPU would do the full exhaustive SAD
+  — far more total work, made up for by parallelism, but it means the speedup
+  is much less than the raw FLOP ratio suggests.
+- **Transfer is affordable but not free.** Two 4K Y planes is ~16 MB/frame,
+  ~1.5 ms round trip on PCIe 3.0 x16 — a few percent at 4K, but larger than
+  the entire 720p frame budget.
+- **Precision/determinism.** SAD is exact integer arithmetic, so a GPU could in
+  principle be bit-identical, but only with care about reduction order. The
+  library currently guarantees the same `.trf` for the same input on any
+  machine, and a GPU backend would put that at risk.
+
+Verdict: not worth it at 1080p and below, where this branch already reaches
+56 fps. If 4K/8K throughput becomes a priority, the better first step is
+algorithmic (pyramid search), which helps CPU and GPU alike and costs no
+dependencies. A GPU backend, if ever built, should be an optional
+compile-time-off plugin rather than a core dependency.
+
+## What is not done
+
+- **No real ARM measurement.** The NEON kernel is correctness-verified only.
+- `boxblur_hori` is still a serial running sum per row (parallel across rows,
+  but scalar within one). A prefix-sum formulation would vectorize it.
+- The `acc[i]/size` division in `boxblur_vert` blocks full auto-vectorization
+  of the output loop (runtime divisor). A magic-number reciprocal would fix it;
+  provably exact for `size <= 4096` with a 32-bit multiply, which covers every
+  geometry the caller can produce, but it was not needed to hit the numbers
+  above.
+- `USE_SSE2_ASM` is left out of the runtime dispatch: it ignores `linesize2`
+  (pre-existing TODO in `motiondetect_opt.c`) and so is only correct when both
+  frames share a stride.
+- `src/sse2neon.h` (9199 lines) is now unused and could be deleted.

--- a/docs/superpowers/simd-optimization-report.md
+++ b/docs/superpowers/simd-optimization-report.md
@@ -57,12 +57,21 @@ Replaced with native NEON kernels (`src/motiondetect_neon.c`) using
 `vabdq_u8`/`vpadalq_u8`, wired through the runtime dispatcher, with the
 architecture detection in one place (`cpudetect.h`) checking both spellings.
 
-**Not measured on real hardware** — no ARM machine, cross-compiler or qemu was
-available here. What *is* verified is correctness: `tests/neon_emu.h` is a
-scalar emulation of the nine NEON intrinsics the kernel uses, so the kernel is
-compiled on x86 and run through the full equivalence suite (1320 checks). The
-logic is right; the performance still needs a run on real silicon before any
-speed claim is made.
+**Correctness is now verified on real hardware.** It was not when this was
+first written — no ARM machine, cross-compiler or qemu was available on the
+development box — so `tests/neon_emu.h` was added: a scalar emulation of the
+nine NEON intrinsics the kernel uses, letting it compile on x86 and run through
+the equivalence suite there. CI then closed the gap properly:
+
+- **aarch64**, native `ubuntu-24.04-arm` runner: selects `SIMD: NEON` and
+  passes 1320/1320 equivalence checks against the C reference on real silicon.
+- **armv7 under qemu-user**: the only place the 32-bit reduction fallbacks
+  (`vs_haddq_u32`, `vs_hminq_u8`, `vs_hmaxq_u8`) execute at all, since AArch64
+  compiles the `vaddvq_`/`vminvq_` path instead. Also 1320/1320.
+
+Still **not benchmarked** on ARM: no speed claim is made for the NEON kernel,
+only correctness. qemu timings are meaningless and the CI runner is not a
+measurement environment.
 
 ## Runtime dispatch
 
@@ -189,9 +198,33 @@ algorithmic (pyramid search), which helps CPU and GPU alike and costs no
 dependencies. A GPU backend, if ever built, should be an optional
 compile-time-off plugin rather than a core dependency.
 
+## CI coverage
+
+The dispatcher selects one kernel per run, and "the compiler can emit it" is
+not "the CPU can run it" — a CI runner with a recent GCC on a pre-AVX-512 core
+is the normal case. The equivalence test therefore skips kernels the CPU cannot
+execute (calling one is a SIGILL, not a test failure) and prints
+`N of M kernel(s) checked` so a permanently-skipped kernel cannot pass as a
+silent no-op. Four jobs between them execute every kernel:
+
+| Job | Kernels executed |
+|---|---|
+| `x86_64` | SSE2, AVX2, AVX-512 (runner dependent), NEON-emulated; plus reruns at `VIDSTAB_SIMD=none` and `=sse2` |
+| `aarch64` (native ARM) | NEON on real hardware |
+| `armv7-qemu` | NEON 32-bit fallbacks |
+| `avx512-sde` | AVX-512 forced via Intel SDE, independent of runner CPU |
+
+The `armv7-qemu` job runs a targeted subset rather than `--all`: it also
+surfaced a pre-existing, non-SIMD failure in `test_serialize_robust`, where a
+corrupt list length below `VS_MAX_LOCALMOTIONS_PER_FRAME` (1<<20) still asks
+for tens of MB — refused by a 32-bit process under qemu, satisfied by a 64-bit
+one. The library then rejects the record, arguably the safer behaviour, but the
+test asserts the 64-bit recovery path. Worth fixing separately.
+
 ## What is not done
 
-- **No real ARM measurement.** The NEON kernel is correctness-verified only.
+- **No ARM benchmark.** The NEON kernel is correctness-verified on real
+  aarch64 hardware, but its speed has never been measured.
 - `boxblur_hori` is still a serial running sum per row (parallel across rows,
   but scalar within one). A prefix-sum formulation would vectorize it.
 - The `acc[i]/size` division in `boxblur_vert` blocks full auto-vectorization

--- a/docs/superpowers/simd-optimization-report.md
+++ b/docs/superpowers/simd-optimization-report.md
@@ -114,6 +114,38 @@ which is not worth giving up an exactly-testable property for.
 Note the C row for `compare` is not really "scalar" — GCC auto-vectorizes it at
 `-O3 -msse2`, which is why the old SSE2 kernel was only ~1.3x faster than it.
 
+## AVX2 lost to SSE2 on the GitHub x86 runner — unexplained
+
+Worth recording because it did not show up on dedicated hardware. The CI
+benchmark step (720p, best of three) on `ubuntu-latest`:
+
+```
+none    219.82 ms/frame
+sse2     57.65 ms/frame
+avx2     70.59 ms/frame     <- 22% slower than SSE2
+avx512   71.11 ms/frame
+```
+
+Reproducible across runs and across best-of-three sampling, so it is not
+runner noise — but it is the opposite of every measurement on the i7-7800X,
+where AVX2 beats SSE2 at every field size tested.
+
+Not diagnosed. Two plausible causes, neither confirmed:
+
+- At 720p the field size is 80 bytes, so the AVX2 kernel does two 32-byte
+  iterations plus a 16-byte tail, and the tail carries widening overhead that
+  SSE2's uniform five iterations do not. That is a third of the row on a
+  less favourable path.
+- 256-bit frequency licensing on the runner's server part, which the
+  128-bit SSE2 kernel would avoid entirely.
+
+The dispatch default is set from dedicated-hardware measurement, not from
+this, and correctness is unaffected (the kernels are bit-identical and the
+equivalence tests pass on that runner). But it does mean **AVX2 should not be
+assumed to be a win on every x86 part**, and it is a reason to keep the
+`VIDSTAB_SIMD` override available to users. Worth a proper look on a known
+server CPU before treating the AVX2 default as settled for server deployments.
+
 ## AVX-512 is not enabled by default, on purpose
 
 On this Skylake-X, AVX-512 is consistently **~18% slower** than AVX2 end to

--- a/docs/superpowers/simd-optimization-report.md
+++ b/docs/superpowers/simd-optimization-report.md
@@ -83,8 +83,9 @@ runtime. Only the AVX2/AVX-512 *kernel files* are compiled with `-mavx2` etc.,
 so the binary still runs on an SSE2-only host.
 
 `VIDSTAB_SIMD=none|sse2|avx2|avx512|neon` overrides the choice; that is how the
-table below was produced on one machine, and it makes the kernels testable
-against each other in CI.
+table below was produced on one machine, how the kernels are tested against
+each other in CI, and how the CI benchmark step compares dispatch levels
+back to back on one runner.
 
 Field size is now rounded to a multiple of 16 **unconditionally** rather than
 only in SSE2 builds. That matters: the kernel is chosen at runtime, so making
@@ -168,63 +169,12 @@ likely to come from **doing fewer comparisons** (the search is a full spiral
 scan over ~594k calls/frame at 1080p) than from making each one faster —
 e.g. a coarse-to-fine pyramid, or early termination on the field level.
 
-## GPU offload: assessment, not recommended for now
-
-Block-matching motion search is exactly the kind of work GPUs are good at, and
-at 4K the current 202 ms/frame (5 fps) is slow enough to be worth attacking.
-But:
-
-- **Dependency cost is the dominant argument.** vid.stab is consumed as a small
-  dependency-light C library by ffmpeg and transcode, and packaged widely. Add
-  OpenCL/CUDA/Vulkan and every packager inherits a runtime dependency and a
-  driver-dependent failure mode, for a filter that is not the bottleneck of a
-  typical transcode.
-- **The early-exit heuristic does not port.** The CPU kernel abandons a
-  candidate the moment its running SAD exceeds the best so far, which is where
-  a large part of its speed comes from. A GPU would do the full exhaustive SAD
-  — far more total work, made up for by parallelism, but it means the speedup
-  is much less than the raw FLOP ratio suggests.
-- **Transfer is affordable but not free.** Two 4K Y planes is ~16 MB/frame,
-  ~1.5 ms round trip on PCIe 3.0 x16 — a few percent at 4K, but larger than
-  the entire 720p frame budget.
-- **Precision/determinism.** SAD is exact integer arithmetic, so a GPU could in
-  principle be bit-identical, but only with care about reduction order. The
-  library currently guarantees the same `.trf` for the same input on any
-  machine, and a GPU backend would put that at risk.
-
-Verdict: not worth it at 1080p and below, where this branch already reaches
-56 fps. If 4K/8K throughput becomes a priority, the better first step is
-algorithmic (pyramid search), which helps CPU and GPU alike and costs no
-dependencies. A GPU backend, if ever built, should be an optional
-compile-time-off plugin rather than a core dependency.
-
-## CI coverage
-
-The dispatcher selects one kernel per run, and "the compiler can emit it" is
-not "the CPU can run it" — a CI runner with a recent GCC on a pre-AVX-512 core
-is the normal case. The equivalence test therefore skips kernels the CPU cannot
-execute (calling one is a SIGILL, not a test failure) and prints
-`N of M kernel(s) checked` so a permanently-skipped kernel cannot pass as a
-silent no-op. Four jobs between them execute every kernel:
-
-| Job | Kernels executed |
-|---|---|
-| `x86_64` | SSE2, AVX2, AVX-512 (runner dependent), NEON-emulated; plus reruns at `VIDSTAB_SIMD=none` and `=sse2` |
-| `aarch64` (native ARM) | NEON on real hardware |
-| `armv7-qemu` | NEON 32-bit fallbacks |
-| `avx512-sde` | AVX-512 forced via Intel SDE, independent of runner CPU |
-
-The `armv7-qemu` job runs a targeted subset rather than `--all`: it also
-surfaced a pre-existing, non-SIMD failure in `test_serialize_robust`, where a
-corrupt list length below `VS_MAX_LOCALMOTIONS_PER_FRAME` (1<<20) still asks
-for tens of MB — refused by a 32-bit process under qemu, satisfied by a 64-bit
-one. The library then rejects the record, arguably the safer behaviour, but the
-test asserts the 64-bit recovery path. Worth fixing separately.
-
 ## What is not done
 
-- **No ARM benchmark.** The NEON kernel is correctness-verified on real
-  aarch64 hardware, but its speed has never been measured.
+- **No controlled ARM benchmark.** The NEON kernel is correctness-verified on
+  real aarch64 hardware, and CI prints timings per dispatch level, but a shared
+  CI runner is not a measurement environment: treat those numbers as a sanity
+  check that NEON beats scalar, not as a figure to quote.
 - `boxblur_hori` is still a serial running sum per row (parallel across rows,
   but scalar within one). A prefix-sum formulation would vectorize it.
 - The `acc[i]/size` division in `boxblur_vert` blocks full auto-vectorization

--- a/src/boxblur.c
+++ b/src/boxblur.c
@@ -133,14 +133,21 @@ void boxblurPlanar(VSFrame* dest, const VSFrame* src,
 void boxblur_hori_C(unsigned char* dest, const unsigned char* src,
                     int width, int height, int dest_strive, int src_strive, int size){
 
-  int i,j,k;
-  unsigned int acc;
-  const unsigned char *start, *end; // start and end of kernel
-  unsigned char *current;     // current destination pixel
+  int j;
   int size2 = size/2; // size of one side of the kernel without center
-  // #pragma omp parallel for private(acc),schedule(guided,2) (no speedup)
+  /* Every row is an independent accumulator chain, so this parallelises with
+     no sharing at all.  (It used to be commented out as "no speedup"; that no
+     longer holds -- at 1080p the two boxblur passes are several ms of purely
+     serial work per frame, which is a large part of the frame time once the
+     motion search itself runs on all cores.) */
+#ifdef USE_OMP
+#pragma omp parallel for schedule(static)
+#endif
   for(j=0; j< height; j++){
-    //  for(j=100; j< 101; j++){
+    int i,k;
+    unsigned int acc;
+    const unsigned char *start, *end; // start and end of kernel
+    unsigned char *current;     // current destination pixel
     start = end = src + j*src_strive;
     current = dest + j*dest_strive;
     // initialize accumulator
@@ -160,30 +167,94 @@ void boxblur_hori_C(unsigned char* dest, const unsigned char* src,
   }
 }
 
+/* The vertical pass used to run one whole column at a time, which touches a
+   new cache line for every single pixel and leaves the compiler nothing to
+   vectorize (each column is one serial accumulator chain).
+
+   Turning the loops inside out fixes both: the accumulators for *all* columns
+   are held in one array and the image is walked row by row, so memory is read
+   and written sequentially and the per-row inner loops are independent across
+   columns and auto-vectorize.
+
+   The recurrence is exactly the one the column-at-a-time version implemented,
+   including its edge behaviour, so the output is bit identical:
+     acc(-1) = src[0][i]*(size2+1) + sum over rows 0..size2-1
+     acc(j)  = acc(j-1) + src[endRow(j)][i] - src[startRow(j)][i]
+   with  endRow(j)   = min(j + size2, height - 1)
+         startRow(j) = max(0, j - size2 - 1)
+   (in the original those are the positions `end` and `start` had *before* the
+   conditional increments at the bottom of the loop body). */
 void boxblur_vert_C(unsigned char* dest, const unsigned char* src,
         int width, int height, int dest_strive, int src_strive, int size){
 
   int i,j,k;
-  int acc;
-  const unsigned char *start, *end; // start and end of kernel
-  unsigned char *current;     // current destination pixel
   int size2 = size/2; // size of one side of the kernel without center
-  for(i=0; i< width; i++){
-    start = end = src + i;
-    current = dest + i;
-    // initialize accumulator
-    acc= (*start)*(size2+1); // left half of kernel with first pixel
-    for(k=0; k<size2; k++){  // right half of kernel
-      acc+=(*end);
-      end+=src_strive;
+  uint32_t* acc;
+
+  if(width <= 0 || height <= 0)
+    return;
+
+  acc = (uint32_t*)vs_malloc((size_t)width * sizeof(uint32_t));
+  if(acc == NULL){ // fall back to the in-place column walk rather than fail
+    for(i=0; i< width; i++){
+      const unsigned char *start, *end;
+      unsigned char *current;
+      int a;
+      start = end = src + i;
+      current = dest + i;
+      a = (*start)*(size2+1);
+      for(k=0; k<size2; k++){ a+=(*end); end+=src_strive; }
+      for(j=0; j< height; j++){
+        a = a - (*start) + (*end);
+        if(j > size2) start+=src_strive;
+        if(j < height - size2 - 1) end+=src_strive;
+        *current = a/size;
+        current+=dest_strive;
+      }
     }
-    // go through the image
-    for(j=0; j< height; j++){
-      acc = acc - (*start) + (*end);
-      if(j > size2) start+=src_strive;
-      if(j < height - size2 - 1) end+=src_strive;
-      *current = acc/size;
-      current+=dest_strive;
+    return;
+  }
+
+  /* Columns are independent of each other, so the work is split into blocks of
+     columns.  Threads touch disjoint ranges of acc[] and of every row, so no
+     synchronisation and no per-thread buffer is needed.  The block width keeps
+     one block's accumulators plus the two source rows comfortably in L1. */
+  {
+    const int BLOCK = 512;
+    int nblocks = (width + BLOCK - 1) / BLOCK;
+    int cb;
+#ifdef USE_OMP
+#pragma omp parallel for schedule(static)
+#endif
+    for(cb=0; cb<nblocks; cb++){
+      int c0 = cb*BLOCK;
+      int c1 = c0 + BLOCK; if(c1 > width) c1 = width;
+      int ii, jj, kk;
+
+      // initialize accumulators: left half of the kernel with the first row ...
+      for(ii=c0; ii<c1; ii++)
+        acc[ii] = (uint32_t)src[ii] * (uint32_t)(size2+1);
+      // ... plus rows 0 .. size2-1 for the right half
+      for(kk=0; kk<size2; kk++){
+        const unsigned char* row = src + (kk < height ? kk : height-1)*src_strive;
+        for(ii=c0; ii<c1; ii++)
+          acc[ii] += row[ii];
+      }
+
+      for(jj=0; jj<height; jj++){
+        int er = jj + size2;          if(er > height-1) er = height-1;
+        int sr = jj - size2 - 1;      if(sr < 0)        sr = 0;
+        const unsigned char* endRow   = src + er*src_strive;
+        const unsigned char* startRow = src + sr*src_strive;
+        unsigned char* out = dest + jj*dest_strive;
+
+        for(ii=c0; ii<c1; ii++)
+          acc[ii] += (uint32_t)endRow[ii] - (uint32_t)startRow[ii];
+        for(ii=c0; ii<c1; ii++)
+          out[ii] = (unsigned char)(acc[ii]/size);
+      }
     }
   }
+
+  vs_free(acc);
 }

--- a/src/cpudetect.c
+++ b/src/cpudetect.c
@@ -1,0 +1,228 @@
+/*
+ *  cpudetect.c
+ *
+ *  Runtime detection of the SIMD instruction set extensions vid.stab can use.
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "cpudetect.h"
+#include "vidstabdefines.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(VS_X86)
+#  if defined(_MSC_VER)
+#    include <intrin.h>
+#  else
+#    include <cpuid.h>
+#  endif
+#endif
+
+/* ------------------------------------------------------------------ x86 --- */
+#if defined(VS_X86)
+
+static void vs_cpuid(unsigned int leaf, unsigned int subleaf,
+                     unsigned int regs[4]) {
+#if defined(_MSC_VER)
+  int r[4];
+  __cpuidex(r, (int)leaf, (int)subleaf);
+  regs[0] = (unsigned int)r[0]; regs[1] = (unsigned int)r[1];
+  regs[2] = (unsigned int)r[2]; regs[3] = (unsigned int)r[3];
+#else
+  unsigned int a = 0, b = 0, c = 0, d = 0;
+  __cpuid_count(leaf, subleaf, a, b, c, d);
+  regs[0] = a; regs[1] = b; regs[2] = c; regs[3] = d;
+#endif
+}
+
+/* Contents of the extended control register.  A CPU may report AVX support
+   while the OS has not enabled saving the wide registers on a context switch,
+   in which case using them corrupts state -- XCR0 is the only way to tell. */
+static unsigned long long vs_xgetbv0(void) {
+#if defined(_MSC_VER)
+  return _xgetbv(0);
+#else
+  unsigned int lo, hi;
+  __asm__ volatile("xgetbv" : "=a"(lo), "=d"(hi) : "c"(0));
+  return ((unsigned long long)hi << 32) | lo;
+#endif
+}
+
+static unsigned int vs_cpu_detect(void) {
+  unsigned int regs[4];
+  unsigned int flags = 0;
+  unsigned int maxleaf;
+
+  vs_cpuid(0, 0, regs);
+  maxleaf = regs[0];
+  if (maxleaf < 1)
+    return 0;
+
+  vs_cpuid(1, 0, regs);
+  if (regs[3] & (1u << 26))          /* EDX.SSE2 */
+    flags |= VS_CPU_SSE2;
+
+  /* Everything below needs the OS to have enabled XSAVE for the YMM/ZMM
+     state, otherwise the registers are not preserved across context
+     switches. */
+  if (!(regs[2] & (1u << 27)))       /* ECX.OSXSAVE */
+    return flags;
+  {
+    unsigned long long xcr0 = vs_xgetbv0();
+    const unsigned long long ymm_state = 0x6;   /* XMM | YMM */
+    const unsigned long long zmm_state = 0xE6;  /* + opmask | ZMM_hi256 | hi16_ZMM */
+
+    if ((xcr0 & ymm_state) != ymm_state)
+      return flags;
+
+    if (maxleaf >= 7) {
+      vs_cpuid(7, 0, regs);
+      if (regs[1] & (1u << 5))       /* EBX.AVX2 */
+        flags |= VS_CPU_AVX2;
+      if ((xcr0 & zmm_state) == zmm_state) {
+        /* The kernels need F (foundation), BW (byte/word ops, for the SAD and
+           min/max on bytes) and VL (so the 256 bit tail can use masking). */
+        if ((regs[1] & (1u << 16)) &&    /* AVX512F  */
+            (regs[1] & (1u << 30)) &&    /* AVX512BW */
+            (regs[1] & (1u << 31)))      /* AVX512VL */
+          flags |= VS_CPU_AVX512;
+      }
+    }
+  }
+  return flags;
+}
+
+/* ------------------------------------------------------------------ ARM --- */
+#elif defined(VS_ARM_NEON)
+
+static unsigned int vs_cpu_detect(void) {
+  /* NEON is architecturally mandatory on AArch64 and the 32 bit builds that
+     reach here were compiled with a NEON enabled -mfpu, so if this file
+     compiled at all the instructions are available.  There is no portable
+     runtime probe (and unlike x86 there is nothing useful to fall back to). */
+  return VS_CPU_NEON;
+}
+
+#else
+
+static unsigned int vs_cpu_detect(void) {
+  return 0;
+}
+
+#endif
+
+/* --------------------------------------------------------------- common --- */
+
+/* Which extensions this build actually contains kernels for.  Detection is
+   masked with this so callers can dispatch on the result without #ifdefs. */
+static unsigned int vs_cpu_compiled_in(void) {
+  unsigned int f = 0;
+#ifdef VS_HAVE_SSE2
+  f |= VS_CPU_SSE2;
+#endif
+#ifdef VS_HAVE_AVX2
+  f |= VS_CPU_AVX2;
+#endif
+#ifdef VS_HAVE_AVX512
+  f |= VS_CPU_AVX512;
+#endif
+#ifdef VS_HAVE_NEON
+  f |= VS_CPU_NEON;
+#endif
+  return f;
+}
+
+/* VIDSTAB_SIMD=<name> caps the detected flags at <name>, so a single machine
+   can exercise (and benchmark) every kernel.  Returns a mask to AND with. */
+static unsigned int vs_cpu_env_mask(void) {
+  const char* e = getenv("VIDSTAB_SIMD");
+  if (e == NULL || *e == '\0')
+    return ~0u;
+
+  if (strcmp(e, "none") == 0 || strcmp(e, "scalar") == 0)
+    return 0;
+  if (strcmp(e, "sse2") == 0)
+    return VS_CPU_SSE2;
+  if (strcmp(e, "avx2") == 0)
+    return VS_CPU_SSE2 | VS_CPU_AVX2;
+  if (strcmp(e, "avx512") == 0)
+    return VS_CPU_SSE2 | VS_CPU_AVX2 | VS_CPU_AVX512;
+  if (strcmp(e, "neon") == 0)
+    return VS_CPU_NEON;
+
+  vs_log_warn("vid.stab", "ignoring unrecognised VIDSTAB_SIMD=\"%s\" "
+              "(expected none, sse2, avx2, avx512 or neon)\n", e);
+  return ~0u;
+}
+
+/* Whether VIDSTAB_SIMD named a level (as opposed to being unset or invalid). */
+static int vs_cpu_env_is_explicit(void) {
+  const char* e = getenv("VIDSTAB_SIMD");
+  if (e == NULL || *e == '\0')
+    return 0;
+  return strcmp(e, "none")   == 0 || strcmp(e, "scalar") == 0 ||
+         strcmp(e, "sse2")   == 0 || strcmp(e, "avx2")   == 0 ||
+         strcmp(e, "avx512") == 0 || strcmp(e, "neon")   == 0;
+}
+
+unsigned int vs_cpu_flags(void) {
+  /* Benign race: concurrent first callers all compute the same value.  Worth
+     avoiding a mutex for, since this is read on hot-ish paths. */
+  static int done = 0;
+  static unsigned int cached = 0;
+
+  if (!done) {
+    cached = vs_cpu_detect() & vs_cpu_compiled_in() & vs_cpu_env_mask();
+    done = 1;
+  }
+  return cached;
+}
+
+int vs_cpu_simd_forced(void) {
+  static int done = 0;
+  static int cached = 0;
+
+  if (!done) {
+    cached = vs_cpu_env_is_explicit();
+    done = 1;
+  }
+  return cached;
+}
+
+const char* vs_cpu_flags_name(unsigned int flags) {
+  if (flags & VS_CPU_AVX512) return "AVX-512";
+  if (flags & VS_CPU_AVX2)   return "AVX2";
+  if (flags & VS_CPU_NEON)   return "NEON";
+  if (flags & VS_CPU_SSE2)   return "SSE2";
+  return "scalar";
+}
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   tab-width:  2
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/cpudetect.h
+++ b/src/cpudetect.h
@@ -1,0 +1,89 @@
+/*
+ *  cpudetect.h
+ *
+ *  Runtime detection of the SIMD instruction set extensions vid.stab can use.
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#ifndef VS_CPUDETECT_H
+#define VS_CPUDETECT_H
+
+#include "vidstab_api.h"
+
+/* --- target architecture ---------------------------------------------------
+   One place that decides what the *target* is, so no other file has to repeat
+   the compiler specific predefined macro spellings.
+
+   Note on ARM: GCC on AArch64 defines __ARM_NEON but not __ARM_NEON__, while
+   Clang defines both.  Testing only the trailing-underscore spelling (as this
+   library did until now) therefore silently disables NEON for every GCC
+   AArch64 build.  Both spellings are checked here, plus __aarch64__/_M_ARM64,
+   on which NEON is architecturally guaranteed. */
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+#  define VS_X86 1
+#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__ARM_NEON) || defined(__ARM_NEON__)
+#  define VS_ARM_NEON 1
+#endif
+
+/** Instruction set extensions vid.stab has hand written kernels for.
+    The values are a bitmask; on x86 the AVX flags imply all lower ones. */
+typedef enum {
+  VS_CPU_NONE   = 0,
+  VS_CPU_SSE2   = 1 << 0,  ///< x86, 16 byte vectors
+  VS_CPU_AVX2   = 1 << 1,  ///< x86, 32 byte vectors
+  VS_CPU_AVX512 = 1 << 2,  ///< x86, 64 byte vectors (needs AVX512F+BW+VL)
+  VS_CPU_NEON   = 1 << 3   ///< ARM/AArch64, 16 byte vectors
+} VSCpuFlags;
+
+/** Returns the extensions usable on this machine, as a VSCpuFlags bitmask.
+
+    Only extensions the library was actually compiled with support for are
+    reported, so the result already answers "may I call this kernel?" and no
+    caller needs a second #ifdef.  The answer is computed once and cached.
+
+    The environment variable VIDSTAB_SIMD caps the result, which is what the
+    test suite and the benchmark use to exercise every kernel on one machine:
+      VIDSTAB_SIMD=none|sse2|avx2|avx512|neon
+    An unrecognised value is ignored (with a warning). */
+VS_API unsigned int vs_cpu_flags(void);
+
+/** True if VIDSTAB_SIMD named a level explicitly, i.e. the selection is the
+    caller's choice rather than the library's.  The dispatcher uses this to
+    decide whether it may pick a kernel it would not choose on its own -- see
+    the AVX-512 note in motiondetect_dispatch.c. */
+VS_API int vs_cpu_simd_forced(void);
+
+/** Human readable name of the highest extension in `flags`, e.g. "AVX2".
+    Never returns NULL; "scalar" if no bit is set. */
+VS_API const char* vs_cpu_flags_name(unsigned int flags);
+
+#endif /* VS_CPUDETECT_H */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   tab-width:  2
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -90,6 +90,10 @@ int vsMotionDetectInit(VSMotionDetect* md, const VSMotionDetectConfig* conf, con
     return VS_ERROR;
   }
 
+  /* pick the SIMD kernels for this machine before anything can call them */
+  vs_simd_init();
+  vs_log_info(md->conf.modName, "SIMD: %s\n", vs_simd_active_name());
+
 #ifdef USE_OMP
   if(md->conf.numThreads==0)
     md->conf.numThreads=VS_MAX(omp_get_max_threads()*0.8,1);
@@ -134,10 +138,14 @@ int vsMotionDetectInit(VSMotionDetect* md, const VSMotionDetectConfig* conf, con
   int maxShift      = VS_MAX(16, minDimension/7);
   int fieldSize     = VS_MAX(16, minDimension/10);
   int fieldSizeFine = VS_MAX(6, minDimension/60);
-#if defined(USE_SSE2) || defined(USE_SSE2_ASM)
-  fieldSize     = (fieldSize / 16 + 1) * 16;
-  fieldSizeFine = (fieldSizeFine / 16 + 1) * 16;
-#endif
+  /* Every SIMD kernel steps whole 16 byte blocks and has no tail loop, so the
+     field size has to be a multiple of 16.  This is done unconditionally --
+     not only when a SIMD kernel is actually selected -- because the kernel is
+     now picked at *runtime*: making the field size depend on the host's
+     instruction set would make the same input produce different .trf output on
+     different machines. */
+  fieldSize     = (fieldSize     / VS_SIMD_FIELD_ALIGNMENT + 1) * VS_SIMD_FIELD_ALIGNMENT;
+  fieldSizeFine = (fieldSizeFine / VS_SIMD_FIELD_ALIGNMENT + 1) * VS_SIMD_FIELD_ALIGNMENT;
   if (!initFields(md, &md->fieldscoarse, fieldSize, maxShift, md->conf.stepSize,
                   1, 0, md->conf.contrastThreshold)) {
     return VS_ERROR;
@@ -341,12 +349,7 @@ int initFields(VSMotionDetect* md, VSMotionDetectFields* fs,
 
 /** \see contrastSubImg*/
 double contrastSubImgPlanar(VSMotionDetect* md, const Field* field) {
-#ifdef USE_SSE2
-  return contrastSubImg1_SSE(md->curr.data[0], field, md->curr.linesize[0],md->fi.height);
-#else
-  return contrastSubImg(md->curr.data[0],field,md->curr.linesize[0],md->fi.height,1);
-#endif
-
+  return contrastSubImg1(md->curr.data[0], field, md->curr.linesize[0], md->fi.height);
 }
 
 /**

--- a/src/motiondetect_avx2.c
+++ b/src/motiondetect_avx2.c
@@ -47,10 +47,10 @@
 /* Horizontal sum of the four 64 bit lanes an accumulated _mm256_sad_epu8
    produces.  Each lane holds at most rows*32*255, so 64 bits cannot overflow
    and the result fits comfortably in 32 bits for any real field size. */
-static inline unsigned int hsum_sad256(__m256i v) {
+static inline unsigned int hsum_sad256(__m256i v, __m128i tail) {
   __m128i lo = _mm256_castsi256_si128(v);
   __m128i hi = _mm256_extracti128_si256(v, 1);
-  __m128i s  = _mm_add_epi64(lo, hi);
+  __m128i s  = _mm_add_epi64(_mm_add_epi64(lo, hi), tail);
   s = _mm_add_epi64(s, _mm_unpackhi_epi64(s, s));
   return (unsigned int)_mm_cvtsi128_si32(s);
 }
@@ -71,6 +71,7 @@ unsigned int compareSubImg_thr_avx2(unsigned char* const I1, unsigned char* cons
   int mainBytes = rowBytes & ~31;
   int hasTail   = rowBytes & 16;
   __m256i acc = _mm256_setzero_si256();
+  __m128i accTail = _mm_setzero_si128();
 
   p1 = I1 + (field->x - s2) * bytesPerPixel + (field->y - s2) * linesize1;
   p2 = I2 + (field->x - s2 + d_x) * bytesPerPixel + (field->y - s2 + d_y) * linesize2;
@@ -83,13 +84,15 @@ unsigned int compareSubImg_thr_avx2(unsigned char* const I1, unsigned char* cons
       acc = _mm256_add_epi64(acc, _mm256_sad_epu8(a, b));
     }
     if (hasTail) {
-      /* Widen the 16 byte remainder into the low half of a 256 bit vector so
-         it can join the same accumulator.  _mm256_zextsi128_si256 would be the
-         direct spelling but is missing from GCC before 10. */
+      /* The 16 byte remainder goes into its own 128 bit accumulator rather
+         than being widened into `acc`.  Widening cost a vpxor + vinserti128
+         on every row, and rows are frequently 16 (mod 32) bytes -- the field
+         size is a multiple of 16 but not of 32, so 720p (80) and 1080p (112)
+         both take this path once per row, where that overhead landed on a
+         third and a quarter of the row respectively. */
       __m128i a = _mm_loadu_si128((__m128i const*)(p1 + mainBytes));
       __m128i b = _mm_loadu_si128((__m128i const*)(p2 + mainBytes));
-      __m128i t = _mm_sad_epu8(a, b);
-      acc = _mm256_add_epi64(acc, _mm256_inserti128_si256(_mm256_setzero_si256(), t, 0));
+      accTail = _mm_add_epi64(accTail, _mm_sad_epu8(a, b));
     }
 
     /* Early exit: this candidate is already worse than the best match so far.
@@ -99,7 +102,7 @@ unsigned int compareSubImg_thr_avx2(unsigned char* const I1, unsigned char* cons
        of every row is allowed and the argmin the caller computes is
        unchanged. */
     if ((j & (VS_AVX2_CHECK_ROWS - 1)) == (VS_AVX2_CHECK_ROWS - 1)) {
-      sum = hsum_sad256(acc);
+      sum = hsum_sad256(acc, accTail);
       if (sum > treshold)
         return sum;
     }
@@ -107,7 +110,7 @@ unsigned int compareSubImg_thr_avx2(unsigned char* const I1, unsigned char* cons
     p2 += linesize2;
   }
 
-  return hsum_sad256(acc);
+  return hsum_sad256(acc, accTail);
 }
 
 double contrastSubImg1_avx2(unsigned char* const I, const Field* field,

--- a/src/motiondetect_avx2.c
+++ b/src/motiondetect_avx2.c
@@ -1,0 +1,177 @@
+/*
+ *  motiondetect_avx2.c
+ *
+ *  AVX2 (32 byte vector) kernels for the motion detection inner loops.
+ *
+ *  This file is compiled with -mavx2 and must therefore never be entered
+ *  unless vs_cpu_flags() reported VS_CPU_AVX2.  It contains no code that runs
+ *  on the dispatch path itself.
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "motiondetect_opt.h"
+
+#ifdef VS_HAVE_AVX2
+
+#include <immintrin.h>
+
+/* Rows to accumulate before testing the running sum against the threshold.
+   1 means "every row", which makes these kernels return exactly the same value
+   as compareSubImg_thr / _sse2 in every case, early exit included -- a much
+   easier property to test than "greater than the threshold".  Coarser cadences
+   are legal (the caller only ever uses the result as "error < minerror", see
+   tests/test_simd_equivalence.c) and save a horizontal reduction per row, but
+   measured only ~1.5% end to end at 1080p, which is not worth giving up the
+   exact-equality guarantee for. */
+#ifndef VS_AVX2_CHECK_ROWS
+#define VS_AVX2_CHECK_ROWS 1
+#endif
+
+/* Horizontal sum of the four 64 bit lanes an accumulated _mm256_sad_epu8
+   produces.  Each lane holds at most rows*32*255, so 64 bits cannot overflow
+   and the result fits comfortably in 32 bits for any real field size. */
+static inline unsigned int hsum_sad256(__m256i v) {
+  __m128i lo = _mm256_castsi256_si128(v);
+  __m128i hi = _mm256_extracti128_si256(v, 1);
+  __m128i s  = _mm_add_epi64(lo, hi);
+  s = _mm_add_epi64(s, _mm_unpackhi_epi64(s, s));
+  return (unsigned int)_mm_cvtsi128_si32(s);
+}
+
+unsigned int compareSubImg_thr_avx2(unsigned char* const I1, unsigned char* const I2,
+                                    const Field* field,
+                                    int linesize1, int linesize2, int height,
+                                    int bytesPerPixel, int d_x, int d_y,
+                                    unsigned int treshold) {
+  int j;
+  int s2 = field->size / 2;
+  int rowBytes = field->size * bytesPerPixel;
+  unsigned int sum = 0;
+  unsigned char* p1;
+  unsigned char* p2;
+  /* field->size is a multiple of 16 (vsMotionDetectInit), so rowBytes is too:
+     a row is a whole number of 32 byte blocks plus at most one 16 byte tail. */
+  int mainBytes = rowBytes & ~31;
+  int hasTail   = rowBytes & 16;
+  __m256i acc = _mm256_setzero_si256();
+
+  p1 = I1 + (field->x - s2) * bytesPerPixel + (field->y - s2) * linesize1;
+  p2 = I2 + (field->x - s2 + d_x) * bytesPerPixel + (field->y - s2 + d_y) * linesize2;
+
+  for (j = 0; j < field->size; j++) {
+    int k;
+    for (k = 0; k < mainBytes; k += 32) {
+      __m256i a = _mm256_loadu_si256((__m256i const*)(p1 + k));
+      __m256i b = _mm256_loadu_si256((__m256i const*)(p2 + k));
+      acc = _mm256_add_epi64(acc, _mm256_sad_epu8(a, b));
+    }
+    if (hasTail) {
+      /* Widen the 16 byte remainder into the low half of a 256 bit vector so
+         it can join the same accumulator.  _mm256_zextsi128_si256 would be the
+         direct spelling but is missing from GCC before 10. */
+      __m128i a = _mm_loadu_si128((__m128i const*)(p1 + mainBytes));
+      __m128i b = _mm_loadu_si128((__m128i const*)(p2 + mainBytes));
+      __m128i t = _mm_sad_epu8(a, b);
+      acc = _mm256_add_epi64(acc, _mm256_inserti128_si256(_mm256_setzero_si256(), t, 0));
+    }
+
+    /* Early exit: this candidate is already worse than the best match so far.
+       The contract (see tests/test_simd_equivalence.c) is only that the value
+       returned by an early exit is greater than the threshold, not that it
+       equals the full sum, so checking every VS_AVX2_CHECK_ROWS rows instead
+       of every row is allowed and the argmin the caller computes is
+       unchanged. */
+    if ((j & (VS_AVX2_CHECK_ROWS - 1)) == (VS_AVX2_CHECK_ROWS - 1)) {
+      sum = hsum_sad256(acc);
+      if (sum > treshold)
+        return sum;
+    }
+    p1 += linesize1;
+    p2 += linesize2;
+  }
+
+  return hsum_sad256(acc);
+}
+
+double contrastSubImg1_avx2(unsigned char* const I, const Field* field,
+                            int linesize, int height) {
+  int j;
+  int s2 = field->size / 2;
+  int mainBytes = field->size & ~31;
+  int hasTail   = field->size & 16;
+  unsigned char* p = I + (field->x - s2) + (field->y - s2) * linesize;
+  __m256i vmin = _mm256_set1_epi8((char)0xFF);
+  __m256i vmax = _mm256_setzero_si256();
+  __m128i lo, hi;
+  unsigned char mini, maxi;
+
+  for (j = 0; j < field->size; j++) {
+    int k;
+    for (k = 0; k < mainBytes; k += 32) {
+      __m256i v = _mm256_loadu_si256((__m256i const*)(p + k));
+      vmin = _mm256_min_epu8(vmin, v);
+      vmax = _mm256_max_epu8(vmax, v);
+    }
+    if (hasTail) {
+      /* Broadcast the 16 byte remainder to both halves: duplicating values is
+         harmless for min/max and avoids needing a neutral filler. */
+      __m128i t = _mm_loadu_si128((__m128i const*)(p + mainBytes));
+      __m256i v = _mm256_broadcastsi128_si256(t);
+      vmin = _mm256_min_epu8(vmin, v);
+      vmax = _mm256_max_epu8(vmax, v);
+    }
+    p += linesize;
+  }
+
+  /* fold 256 -> 128 -> scalar */
+  lo = _mm256_castsi256_si128(vmin);
+  hi = _mm256_extracti128_si256(vmin, 1);
+  lo = _mm_min_epu8(lo, hi);
+  lo = _mm_min_epu8(lo, _mm_srli_si128(lo, 8));
+  lo = _mm_min_epu8(lo, _mm_srli_si128(lo, 4));
+  lo = _mm_min_epu8(lo, _mm_srli_si128(lo, 2));
+  lo = _mm_min_epu8(lo, _mm_srli_si128(lo, 1));
+  mini = (unsigned char)_mm_extract_epi16(lo, 0);
+
+  lo = _mm256_castsi256_si128(vmax);
+  hi = _mm256_extracti128_si256(vmax, 1);
+  lo = _mm_max_epu8(lo, hi);
+  lo = _mm_max_epu8(lo, _mm_srli_si128(lo, 8));
+  lo = _mm_max_epu8(lo, _mm_srli_si128(lo, 4));
+  lo = _mm_max_epu8(lo, _mm_srli_si128(lo, 2));
+  lo = _mm_max_epu8(lo, _mm_srli_si128(lo, 1));
+  maxi = (unsigned char)_mm_extract_epi16(lo, 0);
+
+  return (maxi - mini) / (maxi + mini + 0.1); // +0.1 to avoid division by 0
+}
+
+#endif /* VS_HAVE_AVX2 */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   tab-width:  2
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/motiondetect_avx512.c
+++ b/src/motiondetect_avx512.c
@@ -1,0 +1,177 @@
+/*
+ *  motiondetect_avx512.c
+ *
+ *  AVX-512 (64 byte vector) kernels for the motion detection inner loops.
+ *  Needs AVX512F + AVX512BW (byte SAD and byte min/max) + AVX512VL (so the
+ *  sub-64-byte remainder can be handled in a 128/256 bit register).
+ *
+ *  Compiled with -mavx512bw -mavx512vl; never enter unless vs_cpu_flags()
+ *  reported VS_CPU_AVX512.
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "motiondetect_opt.h"
+
+#ifdef VS_HAVE_AVX512
+
+#include <immintrin.h>
+
+/* Rows to accumulate before testing the running sum against the threshold.
+   1 means "every row", which makes these kernels return exactly the same value
+   as compareSubImg_thr / _sse2 in every case, early exit included -- a much
+   easier property to test than "greater than the threshold".  Coarser cadences
+   are legal (the caller only ever uses the result as "error < minerror", see
+   tests/test_simd_equivalence.c) and save a horizontal reduction per row, but
+   measured only ~1.5% end to end at 1080p, which is not worth giving up the
+   exact-equality guarantee for. */
+#ifndef VS_AVX512_CHECK_ROWS
+#define VS_AVX512_CHECK_ROWS 1
+#endif
+
+/* Sum of the eight 64 bit lanes of an accumulated _mm512_sad_epu8. */
+static inline unsigned int hsum_sad512(__m512i v) {
+  return (unsigned int)_mm512_reduce_add_epi64(v);
+}
+
+static inline unsigned char hmin_epu8_512(__m512i v) {
+  __m256i a = _mm256_min_epu8(_mm512_castsi512_si256(v),
+                              _mm512_extracti64x4_epi64(v, 1));
+  __m128i b = _mm_min_epu8(_mm256_castsi256_si128(a),
+                           _mm256_extracti128_si256(a, 1));
+  b = _mm_min_epu8(b, _mm_srli_si128(b, 8));
+  b = _mm_min_epu8(b, _mm_srli_si128(b, 4));
+  b = _mm_min_epu8(b, _mm_srli_si128(b, 2));
+  b = _mm_min_epu8(b, _mm_srli_si128(b, 1));
+  return (unsigned char)_mm_extract_epi16(b, 0);
+}
+
+static inline unsigned char hmax_epu8_512(__m512i v) {
+  __m256i a = _mm256_max_epu8(_mm512_castsi512_si256(v),
+                              _mm512_extracti64x4_epi64(v, 1));
+  __m128i b = _mm_max_epu8(_mm256_castsi256_si128(a),
+                           _mm256_extracti128_si256(a, 1));
+  b = _mm_max_epu8(b, _mm_srli_si128(b, 8));
+  b = _mm_max_epu8(b, _mm_srli_si128(b, 4));
+  b = _mm_max_epu8(b, _mm_srli_si128(b, 2));
+  b = _mm_max_epu8(b, _mm_srli_si128(b, 1));
+  return (unsigned char)_mm_extract_epi16(b, 0);
+}
+
+/* The field rows are a multiple of 16 bytes but not necessarily of 64, so a
+   row is split into 64 byte blocks plus a 16/32/48 byte remainder.  A mask
+   load handles the remainder in one instruction instead of a ladder of
+   narrower loads -- this is the main thing AVX-512 buys here beyond width. */
+unsigned int compareSubImg_thr_avx512(unsigned char* const I1, unsigned char* const I2,
+                                      const Field* field,
+                                      int linesize1, int linesize2, int height,
+                                      int bytesPerPixel, int d_x, int d_y,
+                                      unsigned int treshold) {
+  int j;
+  int s2 = field->size / 2;
+  int rowBytes = field->size * bytesPerPixel;
+  int mainBytes = rowBytes & ~63;
+  int tailBytes = rowBytes & 63;
+  __mmask64 tailMask = tailBytes ? (__mmask64)((1ULL << tailBytes) - 1) : 0;
+  unsigned int sum = 0;
+  unsigned char* p1;
+  unsigned char* p2;
+  __m512i acc = _mm512_setzero_si512();
+
+  p1 = I1 + (field->x - s2) * bytesPerPixel + (field->y - s2) * linesize1;
+  p2 = I2 + (field->x - s2 + d_x) * bytesPerPixel + (field->y - s2 + d_y) * linesize2;
+
+  for (j = 0; j < field->size; j++) {
+    int k;
+    for (k = 0; k < mainBytes; k += 64) {
+      __m512i a = _mm512_loadu_si512((void const*)(p1 + k));
+      __m512i b = _mm512_loadu_si512((void const*)(p2 + k));
+      acc = _mm512_add_epi64(acc, _mm512_sad_epu8(a, b));
+    }
+    if (tailBytes) {
+      /* Lanes outside the mask read as zero in both operands, so their |a-b|
+         contribution is zero and the accumulator stays exact. */
+      __m512i a = _mm512_maskz_loadu_epi8(tailMask, p1 + mainBytes);
+      __m512i b = _mm512_maskz_loadu_epi8(tailMask, p2 + mainBytes);
+      acc = _mm512_add_epi64(acc, _mm512_sad_epu8(a, b));
+    }
+
+    if ((j & (VS_AVX512_CHECK_ROWS - 1)) == (VS_AVX512_CHECK_ROWS - 1)) {
+      sum = hsum_sad512(acc);
+      if (sum > treshold)
+        return sum;
+    }
+    p1 += linesize1;
+    p2 += linesize2;
+  }
+
+  return hsum_sad512(acc);
+}
+
+double contrastSubImg1_avx512(unsigned char* const I, const Field* field,
+                              int linesize, int height) {
+  int j;
+  int s2 = field->size / 2;
+  int mainBytes = field->size & ~63;
+  int tailBytes = field->size & 63;
+  __mmask64 tailMask = tailBytes ? (__mmask64)((1ULL << tailBytes) - 1) : 0;
+  unsigned char* p = I + (field->x - s2) + (field->y - s2) * linesize;
+  __m512i vmin = _mm512_set1_epi8((char)0xFF);
+  __m512i vmax = _mm512_setzero_si512();
+  unsigned char mini, maxi;
+
+  for (j = 0; j < field->size; j++) {
+    int k;
+    for (k = 0; k < mainBytes; k += 64) {
+      __m512i v = _mm512_loadu_si512((void const*)(p + k));
+      vmin = _mm512_min_epu8(vmin, v);
+      vmax = _mm512_max_epu8(vmax, v);
+    }
+    if (tailBytes) {
+      /* Merge-masked into the identity element for each reduction, so the
+         lanes past the end of the row cannot affect the result. */
+      __m512i v = _mm512_maskz_loadu_epi8(tailMask, p + mainBytes);
+      vmax = _mm512_max_epu8(vmax, v);              /* zeros are neutral for max */
+      vmin = _mm512_mask_min_epu8(vmin, tailMask, vmin, v);
+    }
+    p += linesize;
+  }
+
+  /* There is no _mm512_reduce_{min,max}_epu8 -- the reduce helpers only cover
+     32/64 bit lanes -- so fold 512 -> 256 -> 128 and finish with a shuffle
+     ladder. */
+  mini = hmin_epu8_512(vmin);
+  maxi = hmax_epu8_512(vmax);
+
+  return (maxi - mini) / (maxi + mini + 0.1); // +0.1 to avoid division by 0
+}
+
+#endif /* VS_HAVE_AVX512 */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   tab-width:  2
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/motiondetect_dispatch.c
+++ b/src/motiondetect_dispatch.c
@@ -1,0 +1,137 @@
+/*
+ *  motiondetect_dispatch.c
+ *
+ *  Runtime selection of the motion detection SIMD kernels.
+ *
+ *  Kept in its own translation unit, compiled with only baseline compiler
+ *  flags: the files holding the AVX2/AVX-512/NEON kernels are compiled with
+ *  -mavx2 and friends, which lets the compiler emit those instructions
+ *  anywhere in the file -- including in code that would run before the
+ *  corresponding check.  Nothing here may be built with such a flag.
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "motiondetect_opt.h"
+#include "motiondetect_internal.h"
+#include "vidstabdefines.h"
+
+/* contrastSubImg1() is contrastSubImg() specialised to bytesPerPixel == 1;
+   the planar path is the only caller and every SIMD kernel is planar only. */
+static double contrastSubImg1_C(unsigned char* const I, const Field* field,
+                                int linesize, int height) {
+  return contrastSubImg(I, field, linesize, height, 1);
+}
+
+/* Safe defaults: correct everywhere, upgraded by vs_simd_init(). */
+vsCompareSubImgFn   compareSubImg   = compareSubImg_thr;
+vsContrastSubImg1Fn contrastSubImg1 = contrastSubImg1_C;
+
+/* What vs_simd_init() actually picked.  This is not the same as the highest
+   extension the CPU reports (see the AVX-512 note below), so it is recorded
+   here rather than derived from vs_cpu_flags(). */
+static const char* vs_simd_selected = "scalar";
+
+void vs_simd_init(void) {
+  static int done = 0;
+  unsigned int flags;
+
+  /* Benign race: every racing caller stores the same pointers. */
+  if (done)
+    return;
+
+  flags = vs_cpu_flags();
+  (void)flags;   /* unused in a build with no SIMD kernels at all */
+
+#ifdef VS_HAVE_SSE2
+  if (flags & VS_CPU_SSE2) {
+    compareSubImg   = compareSubImg_thr_sse2;
+    contrastSubImg1 = contrastSubImg1_SSE;
+    vs_simd_selected = "SSE2";
+  }
+#endif
+#ifdef VS_HAVE_NEON
+  if (flags & VS_CPU_NEON) {
+    compareSubImg   = compareSubImg_thr_neon;
+    contrastSubImg1 = contrastSubImg1_neon;
+    vs_simd_selected = "NEON";
+  }
+#endif
+#ifdef VS_HAVE_AVX2
+  if (flags & VS_CPU_AVX2) {
+    compareSubImg   = compareSubImg_thr_avx2;
+    contrastSubImg1 = contrastSubImg1_avx2;
+    vs_simd_selected = "AVX2";
+  }
+#endif
+#ifdef VS_HAVE_AVX512
+  /* AVX-512 is deliberately NOT preferred over AVX2 by default.
+
+     These kernels are memory bound rather than compute bound, so the wider
+     vectors buy little, while issuing 512 bit instructions drops the core
+     clock on the parts that implement AVX-512 frequency licensing (Skylake-X
+     and the other Xeon/HEDT generations of that era).  The slowdown hits the
+     *whole* frame, including the scalar and 256 bit code around the kernel.
+     Measured on an i7-7800X at 1080p, AVX-512 came out ~18% slower than AVX2
+     both single threaded and on 9 threads -- see
+     docs/superpowers/simd-optimization-report.md.
+
+     Newer cores (Ice Lake and later, Zen 4/5) do not throttle this way and may
+     well come out ahead, but there is no reliable runtime way to ask "does
+     512 bit width cost me frequency here", and guessing from the family/model
+     would need a lookup table that ages badly.  So the kernels are built and
+     tested, and reachable with VIDSTAB_SIMD=avx512 for anyone who measures a
+     win on their hardware, but the automatic choice stays AVX2. */
+  if ((flags & VS_CPU_AVX512) && vs_cpu_simd_forced()) {
+    compareSubImg   = compareSubImg_thr_avx512;
+    contrastSubImg1 = contrastSubImg1_avx512;
+    vs_simd_selected = "AVX-512";
+  }
+#endif
+
+  /* USE_SSE2_ASM is the historical hand written assembly variant.  It is not
+     part of the runtime dispatch: it ignores linesize2 (see the TODO in
+     motiondetect_opt.c) and so is only correct when both frames share a
+     stride.  Left reachable only through an explicit opt in build. */
+#ifdef USE_SSE2_ASM
+  if (flags & VS_CPU_SSE2) {
+    compareSubImg = compareSubImg_thr_sse2_asm;
+    vs_simd_selected = "SSE2 (asm)";
+  }
+#endif
+
+  done = 1;
+}
+
+const char* vs_simd_active_name(void) {
+  vs_simd_init();
+  return vs_simd_selected;
+}
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   tab-width:  2
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/motiondetect_neon.c
+++ b/src/motiondetect_neon.c
@@ -1,0 +1,179 @@
+/*
+ *  motiondetect_neon.c
+ *
+ *  ARM NEON (16 byte vector) kernels for the motion detection inner loops.
+ *
+ *  These replace the previous route of running the SSE2 kernels through the
+ *  vendored sse2neon.h shim.  Two reasons: the shim's _mm_sad_epu8 has to
+ *  emulate PSADBW, whose exact "two 64 bit halves" semantics NEON does not
+ *  share, and NEON's own vabdq/vpadal pair expresses the same reduction more
+ *  directly; and the shimmed path was in practice never reached at all (see
+ *  the history of motiondetect_opt.h -- USE_SSE2 was defined inside
+ *  motiondetect_opt.c only, so motiondetect.c kept calling the scalar C
+ *  version and never rounded the field size up to a multiple of 16).
+ *
+ *  This file is part of vid.stab video stabilization library
+ *
+ *  vid.stab is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License,
+ *  as published by the Free Software Foundation; either version 2, or
+ *  (at your option) any later version.
+ *
+ *  vid.stab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with GNU Make; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ *
+ */
+
+#include "motiondetect_opt.h"
+
+#ifdef VS_HAVE_NEON
+
+/* The test suite compiles this file for x86 against a scalar emulation of the
+   handful of NEON intrinsics used below, so that the logic is covered by the
+   equivalence tests even off ARM hardware. */
+#ifdef VS_NEON_EMULATION
+#include "neon_emu.h"
+#else
+#include <arm_neon.h>
+#endif
+
+/* Rows to accumulate before testing the running sum against the threshold.
+   1 means "every row", which makes these kernels return exactly the same value
+   as compareSubImg_thr / _sse2 in every case, early exit included -- a much
+   easier property to test than "greater than the threshold".  Coarser cadences
+   are legal (the caller only ever uses the result as "error < minerror", see
+   tests/test_simd_equivalence.c) and save a horizontal reduction per row, but
+   measured only ~1.5% end to end at 1080p, which is not worth giving up the
+   exact-equality guarantee for. */
+#ifndef VS_NEON_CHECK_ROWS
+#define VS_NEON_CHECK_ROWS 1
+#endif
+
+/* The across-vector reductions (vaddvq_/vminvq_/vmaxvq_) are AArch64 only;
+   on 32 bit ARM they have to be built from pairwise folds. */
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(VS_NEON_EMULATION)
+
+static inline unsigned int vs_haddq_u32(uint32x4_t v) { return vaddvq_u32(v); }
+static inline unsigned char vs_hminq_u8(uint8x16_t v) { return vminvq_u8(v); }
+static inline unsigned char vs_hmaxq_u8(uint8x16_t v) { return vmaxvq_u8(v); }
+
+#else
+
+static inline unsigned int vs_haddq_u32(uint32x4_t v) {
+  uint32x2_t s = vadd_u32(vget_low_u32(v), vget_high_u32(v));
+  return vget_lane_u32(vpadd_u32(s, s), 0);
+}
+static inline unsigned char vs_hminq_u8(uint8x16_t v) {
+  uint8x8_t s = vmin_u8(vget_low_u8(v), vget_high_u8(v));
+  s = vpmin_u8(s, s);
+  s = vpmin_u8(s, s);
+  s = vpmin_u8(s, s);
+  return vget_lane_u8(s, 0);
+}
+static inline unsigned char vs_hmaxq_u8(uint8x16_t v) {
+  uint8x8_t s = vmax_u8(vget_low_u8(v), vget_high_u8(v));
+  s = vpmax_u8(s, s);
+  s = vpmax_u8(s, s);
+  s = vpmax_u8(s, s);
+  return vget_lane_u8(s, 0);
+}
+
+#endif
+
+/* Sum of absolute differences over a field.
+
+   The accumulation is two staged: vabdq_u8 gives 16 byte-sized differences,
+   vpadalq_u8 pairwise-adds them into 8 lanes of 16 bits, and only every 16th
+   row are those folded into 32 bit lanes.  A 16 bit lane accumulates at most
+   2*255 per row (two bytes pairwise added), so 16 rows reach 8160 and 64 rows
+   would still fit -- draining every 16 rows leaves a wide margin and keeps the
+   inner loop down to two instructions per 16 bytes. */
+unsigned int compareSubImg_thr_neon(unsigned char* const I1, unsigned char* const I2,
+                                    const Field* field,
+                                    int linesize1, int linesize2, int height,
+                                    int bytesPerPixel, int d_x, int d_y,
+                                    unsigned int treshold) {
+  int j;
+  int s2 = field->size / 2;
+  int rowBytes = field->size * bytesPerPixel;
+  unsigned int sum = 0;
+  unsigned char* p1;
+  unsigned char* p2;
+  uint16x8_t acc16 = vdupq_n_u16(0);
+  uint32x4_t acc32 = vdupq_n_u32(0);
+
+  p1 = I1 + (field->x - s2) * bytesPerPixel + (field->y - s2) * linesize1;
+  p2 = I2 + (field->x - s2 + d_x) * bytesPerPixel + (field->y - s2 + d_y) * linesize2;
+
+  for (j = 0; j < field->size; j++) {
+    int k;
+    /* rowBytes is a multiple of 16 (vsMotionDetectInit rounds the field size
+       up), so there is no tail. */
+    for (k = 0; k < rowBytes; k += 16) {
+      uint8x16_t a = vld1q_u8(p1 + k);
+      uint8x16_t b = vld1q_u8(p2 + k);
+      acc16 = vpadalq_u8(acc16, vabdq_u8(a, b));
+    }
+
+    if ((j & 15) == 15) {                 /* drain before 16 bit lanes fill up */
+      acc32 = vpadalq_u16(acc32, acc16);
+      acc16 = vdupq_n_u16(0);
+    }
+
+    if ((j & (VS_NEON_CHECK_ROWS - 1)) == (VS_NEON_CHECK_ROWS - 1)) {
+      sum = vs_haddq_u32(vpadalq_u16(acc32, acc16));
+      if (sum > treshold)
+        return sum;
+    }
+    p1 += linesize1;
+    p2 += linesize2;
+  }
+
+  return vs_haddq_u32(vpadalq_u16(acc32, acc16));
+}
+
+double contrastSubImg1_neon(unsigned char* const I, const Field* field,
+                            int linesize, int height) {
+  int j;
+  int s2 = field->size / 2;
+  unsigned char* p = I + (field->x - s2) + (field->y - s2) * linesize;
+  uint8x16_t vmin = vdupq_n_u8(0xFF);
+  uint8x16_t vmax = vdupq_n_u8(0x00);
+  unsigned char mini, maxi;
+
+  for (j = 0; j < field->size; j++) {
+    int k;
+    for (k = 0; k < field->size; k += 16) {
+      uint8x16_t v = vld1q_u8(p + k);
+      vmin = vminq_u8(vmin, v);
+      vmax = vmaxq_u8(vmax, v);
+    }
+    p += linesize;
+  }
+
+  mini = vs_hminq_u8(vmin);
+  maxi = vs_hmaxq_u8(vmax);
+
+  return (maxi - mini) / (maxi + mini + 0.1); // +0.1 to avoid division by 0
+}
+
+#endif /* VS_HAVE_NEON */
+
+/*
+ * Local variables:
+ *   c-file-style: "stroustrup"
+ *   c-file-offsets: ((case-label . *) (statement-case-intro . *))
+ *   indent-tabs-mode: nil
+ *   tab-width:  2
+ *   c-basic-offset: 2 t
+ * End:
+ *
+ * vim: expandtab shiftwidth=2:
+ */

--- a/src/motiondetect_opt.c
+++ b/src/motiondetect_opt.c
@@ -27,16 +27,18 @@
  */
 #include "motiondetect_opt.h"
 
-#ifdef USE_SSE2
+/* NOTE: ARM used to be served from this file by including sse2neon.h and
+   #define'ing USE_SSE2 here.  That never worked: the #define was local to this
+   translation unit, so motiondetect.c kept dispatching to the scalar C
+   compareSubImg and never rounded the field size up to a multiple of 16, and
+   the shimmed kernels below were dead code.  ARM now has native kernels in
+   motiondetect_neon.c, reached through the runtime dispatcher. */
+
+#ifdef VS_HAVE_SSE2
 #include <emmintrin.h>
 #endif
 
-#ifdef __ARM_NEON__
-#include "sse2neon.h"
-#define USE_SSE2
-#endif
-
-#ifdef USE_SSE2
+#ifdef VS_HAVE_SSE2
 /**
    \see contrastSubImg using SSE2 optimization, Planar (1 byte per channel) only
 */
@@ -123,7 +125,7 @@ double contrastSubImg_variance_C(unsigned char* const I,
   return (double)var/numpixel/255.0;
 }
 
-#ifdef USE_SSE2
+#ifdef VS_HAVE_SSE2
 unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* const I2,
                                     const Field* field,
                                     int linesize1, int linesize2, int height,
@@ -163,7 +165,7 @@ unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* cons
 
   return sum;
 }
-#endif // USE_SSE2
+#endif // VS_HAVE_SSE2
 
 #ifdef USE_SSE2_ASM
 unsigned int compareSubImg_thr_sse2_asm(unsigned char* const I1, unsigned char* const I2,

--- a/src/motiondetect_opt.h
+++ b/src/motiondetect_opt.h
@@ -31,25 +31,86 @@
 
 #include "motiondetect.h"
 #include "vidstab_api.h"
-#ifdef USE_SSE2_ASM //enable SSE2 inline asm code
-#define compareSubImg compareSubImg_thr_sse2_asm
-#elif defined(USE_SSE2)      //enable SSE2 code
-#define compareSubImg compareSubImg_thr_sse2
-#else
-#define compareSubImg compareSubImg_thr
-#endif
+#include "cpudetect.h"
 
-#ifdef USE_SSE2
+/* --- dispatch ---------------------------------------------------------------
+   Which kernel to use is decided at *runtime* (see cpudetect.h), not by the
+   preprocessor, so that a distribution binary built on any machine still uses
+   AVX2 or AVX-512 where the host supports it.  The two hot kernels are
+   therefore called through function pointers.
+
+   Both pointers are statically initialised to the portable C implementations,
+   so they are safe to call before vs_simd_init() has run; vs_simd_init() only
+   ever upgrades them.  vsMotionDetectInit() calls it. */
+
+typedef unsigned int (*vsCompareSubImgFn)(unsigned char* const I1,
+                                          unsigned char* const I2,
+                                          const Field* field,
+                                          int linesize1, int linesize2, int height,
+                                          int bytesPerPixel, int d_x, int d_y,
+                                          unsigned int threshold);
+
 /// \param linesize distance between two rows in BYTES (see vidstabdefines.h)
-VS_API double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
-                           int linesize, int height);
-#endif
+typedef double (*vsContrastSubImg1Fn)(unsigned char* const I, const Field* field,
+                                      int linesize, int height);
+
+/* Called as compareSubImg(...) / contrastSubImg1(...) exactly like the macros
+   they replace. */
+extern VS_API vsCompareSubImgFn   compareSubImg;
+extern VS_API vsContrastSubImg1Fn contrastSubImg1;
+
+/** Pick the best kernels for this machine.  Idempotent and cheap after the
+    first call; safe to call from several threads. */
+VS_API void vs_simd_init(void);
+
+/** Name of the kernel family currently selected, e.g. "AVX2" or "scalar".
+    Calls vs_simd_init() if that has not happened yet. */
+VS_API const char* vs_simd_active_name(void);
+
+/** True if the selected kernels require the field size to be a multiple of 16.
+    All the SIMD kernels do, and the field size is rounded up unconditionally
+    (see vsMotionDetectInit) so that a given input yields the same result on
+    every machine regardless of which kernel runs. */
+#define VS_SIMD_FIELD_ALIGNMENT 16
+
+/* --- the individual kernels -------------------------------------------------
+   Declared unconditionally so the dispatcher and the tests can name them; each
+   is only *defined* when the corresponding VS_HAVE_* was set for the build. */
 
 VS_API double contrastSubImg_variance_C(unsigned char* const I, const Field* field,
                         int linesize, int height);
 
-#ifdef USE_SSE2
+#ifdef VS_HAVE_SSE2
+VS_API double contrastSubImg1_SSE(unsigned char* const I, const Field* field,
+                           int linesize, int height);
 VS_API unsigned int compareSubImg_thr_sse2(unsigned char* const I1, unsigned char* const I2,
+                                    const Field* field, int linesize1, int linesize2, int height,
+                                    int bytesPerPixel, int d_x, int d_y,
+                                    unsigned int threshold);
+#endif
+
+#ifdef VS_HAVE_AVX2
+VS_API double contrastSubImg1_avx2(unsigned char* const I, const Field* field,
+                                   int linesize, int height);
+VS_API unsigned int compareSubImg_thr_avx2(unsigned char* const I1, unsigned char* const I2,
+                                    const Field* field, int linesize1, int linesize2, int height,
+                                    int bytesPerPixel, int d_x, int d_y,
+                                    unsigned int threshold);
+#endif
+
+#ifdef VS_HAVE_AVX512
+VS_API double contrastSubImg1_avx512(unsigned char* const I, const Field* field,
+                                     int linesize, int height);
+VS_API unsigned int compareSubImg_thr_avx512(unsigned char* const I1, unsigned char* const I2,
+                                    const Field* field, int linesize1, int linesize2, int height,
+                                    int bytesPerPixel, int d_x, int d_y,
+                                    unsigned int threshold);
+#endif
+
+#ifdef VS_HAVE_NEON
+VS_API double contrastSubImg1_neon(unsigned char* const I, const Field* field,
+                                   int linesize, int height);
+VS_API unsigned int compareSubImg_thr_neon(unsigned char* const I1, unsigned char* const I2,
                                     const Field* field, int linesize1, int linesize2, int height,
                                     int bytesPerPixel, int d_x, int d_y,
                                     unsigned int threshold);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,9 +32,10 @@ message(STATUS "tests: SIMD kernels compiled in: ${VIDSTAB_SIMD_SUMMARY}")
 # It proves the logic, not the performance -- that still needs real hardware.
 if(NOT VIDSTAB_HAVE_NEON)
   list(APPEND VIDSTAB_SIMD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/motiondetect_neon.c")
-  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/../src/motiondetect_neon.c"
-                              PROPERTIES COMPILE_DEFINITIONS "VS_NEON_EMULATION")
-  add_compile_definitions(VS_HAVE_NEON)
+  # Both defines are global rather than per-source: motiondetect_neon.c needs
+  # VS_NEON_EMULATION to pick up neon_emu.h, and test_simd_equivalence.c needs
+  # it to know the kernel is plain C and therefore safe to call on any CPU.
+  add_compile_definitions(VS_HAVE_NEON VS_NEON_EMULATION)
   message(STATUS "tests: also checking the NEON kernel via neon_emu.h")
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,22 @@ add_executable (tests tests.c testutils.c testframework.c ../src/vsvector.c
   ${VIDSTAB_SIMD_SOURCES}
   ${LP_SOURCES})
 
+# The benchmark shares the test build's sources and SIMD configuration, so it
+# can time every kernel compiled in rather than only the dispatched one.
+# Informational: it asserts nothing and is not run by "make test".
+add_executable (bench EXCLUDE_FROM_ALL ../bench/bench_motiondetect.c
+  ../src/vsvector.c
+  ../src/transform.c ../src/transformfloat.c ../src/transformfixedpoint.c
+  ../src/libvidstab.c ../src/transformtype.c ../src/frameinfo.c
+  ../src/serialize.c ../src/localmotion2transform.c
+  ../src/motiondetect.c ../src/boxblur.c
+  ${VIDSTAB_SIMD_SOURCES}
+  ${LP_SOURCES})
+target_link_libraries(bench m)
+if(USE_OMP)
+target_link_libraries(bench gomp)
+endif()
+
 target_link_libraries(tests m)
 if(GLPK_FOUND AND VIDSTAB_LPSOLVER STREQUAL "glpk")
 target_link_libraries(tests GLPK::GLPK)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ project (vid.stab)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../CMakeModules/")
 
 include (FindSSE)
+include (VidstabSimd)
 
 option(USE_OMP "use parallelization use OMP" ON)
 
@@ -18,8 +19,27 @@ endif()
 
 add_definitions(-Wall -Wno-pointer-sign -DTESTING -std=gnu99)
 
+# Same SIMD setup as the library, so the equivalence tests check every kernel
+# this toolchain can build -- not merely the one the dispatcher would pick.
+vidstab_configure_simd("${CMAKE_CURRENT_SOURCE_DIR}/../src")
+add_compile_definitions(${VIDSTAB_SIMD_DEFS})
+message(STATUS "tests: SIMD kernels compiled in: ${VIDSTAB_SIMD_SUMMARY}")
+
+# On a host without NEON, build the NEON kernel anyway against the scalar
+# emulation of the intrinsics in neon_emu.h and put it through the same
+# equivalence tests.  Without this the ARM kernel would be compiled by nobody
+# on the machines where the tests actually run, and could rot unnoticed.
+# It proves the logic, not the performance -- that still needs real hardware.
+if(NOT VIDSTAB_HAVE_NEON)
+  list(APPEND VIDSTAB_SIMD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../src/motiondetect_neon.c")
+  set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/../src/motiondetect_neon.c"
+                              PROPERTIES COMPILE_DEFINITIONS "VS_NEON_EMULATION")
+  add_compile_definitions(VS_HAVE_NEON)
+  message(STATUS "tests: also checking the NEON kernel via neon_emu.h")
+endif()
+
 if(SSE2_FOUND)
-add_definitions( -DUSE_SSE2 -msse2 -ffast-math -fno-show-column ) # -DUSE_SSE2_ASM
+add_definitions( -msse2 -ffast-math -fno-show-column ) # -DUSE_SSE2_ASM
 endif()
 
 if(USE_OMP)
@@ -28,6 +48,8 @@ endif()
 
 # Make sure the compiler can find include files from transcode
 include_directories (../src)
+# neon_emu.h lives here, for the emulated NEON build below
+include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 
 # --- LP solver backend for the L1 optimal camera path -------------------------
 # The built-in interior point solver keeps vid.stab dependency free; GLPK can be
@@ -56,7 +78,8 @@ add_executable (tests tests.c testutils.c testframework.c ../src/vsvector.c
   ../src/transform.c ../src/transformfloat.c ../src/transformfixedpoint.c
   ../src/libvidstab.c ../src/transformtype.c ../src/frameinfo.c
   ../src/serialize.c ../src/localmotion2transform.c
-  ../src/motiondetect.c ../src/motiondetect_opt.c ../src/boxblur.c
+  ../src/motiondetect.c ../src/boxblur.c
+  ${VIDSTAB_SIMD_SOURCES}
   ${LP_SOURCES})
 
 target_link_libraries(tests m)

--- a/tests/neon_emu.h
+++ b/tests/neon_emu.h
@@ -1,0 +1,102 @@
+/* neon_emu.h -- scalar emulation of the few NEON intrinsics used by
+ * src/motiondetect_neon.c, so that kernel can be compiled and its results
+ * checked against the C reference on a non-ARM development machine.
+ *
+ * This is a TEST ONLY facility and is never compiled into the library.  It
+ * makes no attempt at being a general NEON shim (use sse2neon.h or SIMDe for
+ * that): it defines exactly the operations motiondetect_neon.c uses, with the
+ * semantics given in the ARM C Language Extensions, and nothing else.
+ *
+ * Passing these tests says the *logic* of the NEON kernel is right.  It says
+ * nothing about how it performs, or about intrinsics-to-instruction issues on
+ * real silicon -- that still needs a run on an actual ARM machine.
+ */
+
+#ifndef VS_NEON_EMU_H
+#define VS_NEON_EMU_H
+
+#include <stdint.h>
+#include <string.h>
+
+typedef struct { uint8_t  v[16]; } uint8x16_t;
+typedef struct { uint16_t v[8];  } uint16x8_t;
+typedef struct { uint32_t v[4];  } uint32x4_t;
+
+static inline uint8x16_t vld1q_u8(const uint8_t* p) {
+  uint8x16_t r;
+  memcpy(r.v, p, 16);
+  return r;
+}
+
+static inline uint8x16_t vdupq_n_u8(uint8_t x) {
+  uint8x16_t r; int i;
+  for (i = 0; i < 16; i++) r.v[i] = x;
+  return r;
+}
+
+static inline uint16x8_t vdupq_n_u16(uint16_t x) {
+  uint16x8_t r; int i;
+  for (i = 0; i < 8; i++) r.v[i] = x;
+  return r;
+}
+
+static inline uint32x4_t vdupq_n_u32(uint32_t x) {
+  uint32x4_t r; int i;
+  for (i = 0; i < 4; i++) r.v[i] = x;
+  return r;
+}
+
+/* absolute difference, lanewise */
+static inline uint8x16_t vabdq_u8(uint8x16_t a, uint8x16_t b) {
+  uint8x16_t r; int i;
+  for (i = 0; i < 16; i++)
+    r.v[i] = (uint8_t)(a.v[i] > b.v[i] ? a.v[i] - b.v[i] : b.v[i] - a.v[i]);
+  return r;
+}
+
+/* pairwise add of b's 16 lanes into 8, accumulated into a */
+static inline uint16x8_t vpadalq_u8(uint16x8_t a, uint8x16_t b) {
+  uint16x8_t r; int i;
+  for (i = 0; i < 8; i++)
+    r.v[i] = (uint16_t)(a.v[i] + (uint16_t)b.v[2*i] + (uint16_t)b.v[2*i + 1]);
+  return r;
+}
+
+/* pairwise add of b's 8 lanes into 4, accumulated into a */
+static inline uint32x4_t vpadalq_u16(uint32x4_t a, uint16x8_t b) {
+  uint32x4_t r; int i;
+  for (i = 0; i < 4; i++)
+    r.v[i] = a.v[i] + (uint32_t)b.v[2*i] + (uint32_t)b.v[2*i + 1];
+  return r;
+}
+
+static inline uint8x16_t vminq_u8(uint8x16_t a, uint8x16_t b) {
+  uint8x16_t r; int i;
+  for (i = 0; i < 16; i++) r.v[i] = a.v[i] < b.v[i] ? a.v[i] : b.v[i];
+  return r;
+}
+
+static inline uint8x16_t vmaxq_u8(uint8x16_t a, uint8x16_t b) {
+  uint8x16_t r; int i;
+  for (i = 0; i < 16; i++) r.v[i] = a.v[i] > b.v[i] ? a.v[i] : b.v[i];
+  return r;
+}
+
+/* across-vector reductions (AArch64) */
+static inline uint32_t vaddvq_u32(uint32x4_t a) {
+  return a.v[0] + a.v[1] + a.v[2] + a.v[3];
+}
+
+static inline uint8_t vminvq_u8(uint8x16_t a) {
+  uint8_t m = a.v[0]; int i;
+  for (i = 1; i < 16; i++) if (a.v[i] < m) m = a.v[i];
+  return m;
+}
+
+static inline uint8_t vmaxvq_u8(uint8x16_t a) {
+  uint8_t m = a.v[0]; int i;
+  for (i = 1; i < 16; i++) if (a.v[i] > m) m = a.v[i];
+  return m;
+}
+
+#endif /* VS_NEON_EMU_H */

--- a/tests/test_boxblur.c
+++ b/tests/test_boxblur.c
@@ -1,3 +1,88 @@
+/* internal to boxblur.c, not part of boxblur.h */
+void boxblur_vert_C(unsigned char* dest, const unsigned char* src,
+                    int width, int height, int dest_strive, int src_strive, int size);
+
+/* Reference implementations: the original column-at-a-time vertical pass and
+   the horizontal pass, transcribed verbatim from boxblur.c before the vertical
+   pass was turned inside out for cache locality and vectorization.  The
+   rewrite is required to be bit identical, so these are what it is checked
+   against -- any difference at all is a regression. */
+static void boxblur_vert_reference(unsigned char* dest, const unsigned char* src,
+                                   int width, int height, int dest_strive,
+                                   int src_strive, int size){
+  int i,j,k;
+  int acc;
+  const unsigned char *start, *end;
+  unsigned char *current;
+  int size2 = size/2;
+  for(i=0; i< width; i++){
+    start = end = src + i;
+    current = dest + i;
+    acc= (*start)*(size2+1);
+    for(k=0; k<size2; k++){
+      acc+=(*end);
+      end+=src_strive;
+    }
+    for(j=0; j< height; j++){
+      acc = acc - (*start) + (*end);
+      if(j > size2) start+=src_strive;
+      if(j < height - size2 - 1) end+=src_strive;
+      *current = acc/size;
+      current+=dest_strive;
+    }
+  }
+}
+
+/* Bit-exact equivalence of boxblur_vert_C with the original column walk, over
+   a spread of sizes and geometries: odd and even widths, widths that are not a
+   multiple of any vector width, strides wider than the image, and the smallest
+   heights the kernel size still permits. */
+static void test_boxblur_vert_equivalence(void){
+  static const int widths[]  = { 1, 2, 7, 16, 17, 31, 64, 100, 127, 256 };
+  static const int heights[] = { 4, 5, 16, 33, 64, 127 };
+  static const int sizes[]   = { 3, 5, 9, 15, 31 };
+  int wi, hi, si, pad, i;
+
+  fprintf(stderr,"*** boxblur_vert_C must be bit identical to the column walk\n");
+  for(wi=0; wi<(int)(sizeof(widths)/sizeof(widths[0])); wi++){
+    for(hi=0; hi<(int)(sizeof(heights)/sizeof(heights[0])); hi++){
+      for(si=0; si<(int)(sizeof(sizes)/sizeof(sizes[0])); si++){
+        for(pad=0; pad<2; pad++){        /* stride == width, and stride > width */
+          int w = widths[wi], h = heights[hi], size = sizes[si];
+          int stride = w + (pad ? 13 : 0);
+          unsigned char *src, *d1, *d2;
+          int differs = 0;
+
+          /* the caller (boxblurPlanar) clamps size this way; respect it so we
+             only test geometries that can actually occur */
+          if(size/2 >= h) continue;
+
+          src = (unsigned char*)malloc((size_t)stride*h);
+          d1  = (unsigned char*)malloc((size_t)stride*h);
+          d2  = (unsigned char*)malloc((size_t)stride*h);
+          for(i=0; i<stride*h; i++)
+            src[i] = (unsigned char)((i*37 + i/stride*11 + (i%stride)*7) & 0xFF);
+          memset(d1, 0xAA, (size_t)stride*h);
+          memset(d2, 0xAA, (size_t)stride*h);
+
+          boxblur_vert_reference(d1, src, w, h, stride, stride, size);
+          boxblur_vert_C        (d2, src, w, h, stride, stride, size);
+
+          for(i=0; i<h && !differs; i++)
+            if(memcmp(d1 + (size_t)i*stride, d2 + (size_t)i*stride, w) != 0)
+              differs = 1;
+          if(differs)
+            fprintf(stderr,"  BOXBLUR MISMATCH w=%i h=%i size=%i stride=%i\n",
+                    w, h, size, stride);
+          test_bool(!differs);
+
+          free(src); free(d1); free(d2);
+        }
+      }
+    }
+  }
+}
+
 // runs the boxblur routine and returns the time
 int runboxblur( VSFrame frame1, VSFrame dest,
                 VSFrameInfo fi, int numruns){
@@ -19,7 +104,8 @@ void test_boxblur(const TestData* testdata){
   vsFrameAllocate(&dest,&testdata->fi);
   //    omp_set_dynamic( 0 );
   //    omp_set_num_threads( 1 );
-  fprintf(stderr,"********** boxblur speedtest:\n");
+  fprintf(stderr,"********** boxblur:\n");
+  test_boxblur_vert_equivalence();
   time = runboxblur(testdata->frames[4], dest, testdata->fi, numruns);
   fprintf(stderr,"***C    time for %i runs: %i ms\n", numruns, time);
   storePGMImage(testOut("boxblured.pgm"), dest.data[0], testdata->fi);

--- a/tests/test_simd_equivalence.c
+++ b/tests/test_simd_equivalence.c
@@ -37,27 +37,43 @@
 #ifdef SIMD_HAVE_ANY_KERNEL
 
 /* The table of kernels to check.  Every kernel compiled into this build is
-   checked against the plain C reference, independently of which one the
-   runtime dispatcher would actually pick on this machine -- that is the whole
-   point, since the dispatcher can only ever select one of them per run. */
+   checked against the plain C reference -- not only the one the dispatcher
+   would pick, since it can select just one per run.
+
+   But "compiled in" is not the same as "runnable here": what a build machine's
+   *compiler* can emit routinely exceeds what its *CPU* can execute, and a CI
+   runner with a recent GCC on a pre-AVX-512 core is the normal case rather
+   than an exotic one.  Calling such a kernel directly, as this test does,
+   bypasses the runtime dispatch that protects the library itself and gets
+   SIGILL.  So each entry carries the feature bit it needs and is skipped
+   unless vs_cpu_flags() reports it.
+
+   `requires == VS_CPU_NONE` means "always safe to call": that is the NEON
+   kernel when it was built against the scalar emulation in neon_emu.h, which
+   is plain C and runs anywhere. */
 typedef struct {
   const char*         name;
+  unsigned int        requires;
   vsCompareSubImgFn   cmp;
   vsContrastSubImg1Fn con;
 } SimdKernel;
 
 static const SimdKernel simd_kernels[] = {
 #ifdef VS_HAVE_SSE2
-  { "SSE2",   compareSubImg_thr_sse2,   contrastSubImg1_SSE    },
+  { "SSE2",   VS_CPU_SSE2,   compareSubImg_thr_sse2,   contrastSubImg1_SSE    },
 #endif
 #ifdef VS_HAVE_AVX2
-  { "AVX2",   compareSubImg_thr_avx2,   contrastSubImg1_avx2   },
+  { "AVX2",   VS_CPU_AVX2,   compareSubImg_thr_avx2,   contrastSubImg1_avx2   },
 #endif
 #ifdef VS_HAVE_AVX512
-  { "AVX512", compareSubImg_thr_avx512, contrastSubImg1_avx512 },
+  { "AVX512", VS_CPU_AVX512, compareSubImg_thr_avx512, contrastSubImg1_avx512 },
 #endif
 #ifdef VS_HAVE_NEON
-  { "NEON",   compareSubImg_thr_neon,   contrastSubImg1_neon   },
+#ifdef VS_NEON_EMULATION
+  { "NEON(emulated)", VS_CPU_NONE, compareSubImg_thr_neon, contrastSubImg1_neon },
+#else
+  { "NEON",   VS_CPU_NEON,   compareSubImg_thr_neon,   contrastSubImg1_neon   },
+#endif
 #endif
 };
 #define SIMD_NUM_KERNELS ((int)(sizeof(simd_kernels)/sizeof(simd_kernels[0])))
@@ -247,16 +263,28 @@ static void simd_test_contrast(const TestData* testdata, const SimdKernel* k){
 
 void test_simd_equivalence(const TestData* testdata){
 #ifdef SIMD_HAVE_ANY_KERNEL
-  int i;
-  fprintf(stderr,"********** SIMD vs C equivalence (%i kernel(s) compiled in):\n",
-          SIMD_NUM_KERNELS);
+  int i, checked = 0;
+  unsigned int cpu = vs_cpu_flags();
+  fprintf(stderr,"********** SIMD vs C equivalence (%i kernel(s) compiled in, "
+          "this CPU: %s):\n", SIMD_NUM_KERNELS, vs_cpu_flags_name(cpu));
   for (i = 0; i < SIMD_NUM_KERNELS; i++) {
     const SimdKernel* k = &simd_kernels[i];
+    /* Calling a kernel the CPU cannot execute is a SIGILL, not a test
+       failure -- skip loudly so a permanently-skipped kernel is visible
+       rather than quietly passing as "nothing to do". */
+    if (k->requires != VS_CPU_NONE && !(cpu & k->requires)) {
+      fprintf(stderr,"*** [%s] SKIPPED: compiled in, but not supported by this CPU\n",
+              k->name);
+      continue;
+    }
     simd_test_compare_strict(testdata, k);
     simd_test_compare_threshold(testdata, k);
     simd_test_compare_argmin(testdata, k);
     simd_test_contrast(testdata, k);
+    checked++;
   }
+  fprintf(stderr,"********** %i of %i kernel(s) checked on this machine\n",
+          checked, SIMD_NUM_KERNELS);
 #else
   (void)testdata;
   fprintf(stderr,"********** SIMD vs C equivalence: no SIMD kernels in this build\n");

--- a/tests/test_simd_equivalence.c
+++ b/tests/test_simd_equivalence.c
@@ -29,7 +29,38 @@
  *           very same (tx,ty) and the same final minerror.
  */
 
-#ifdef USE_SSE2
+#if defined(VS_HAVE_SSE2) || defined(VS_HAVE_AVX2) || defined(VS_HAVE_AVX512) \
+ || defined(VS_HAVE_NEON)
+#define SIMD_HAVE_ANY_KERNEL 1
+#endif
+
+#ifdef SIMD_HAVE_ANY_KERNEL
+
+/* The table of kernels to check.  Every kernel compiled into this build is
+   checked against the plain C reference, independently of which one the
+   runtime dispatcher would actually pick on this machine -- that is the whole
+   point, since the dispatcher can only ever select one of them per run. */
+typedef struct {
+  const char*         name;
+  vsCompareSubImgFn   cmp;
+  vsContrastSubImg1Fn con;
+} SimdKernel;
+
+static const SimdKernel simd_kernels[] = {
+#ifdef VS_HAVE_SSE2
+  { "SSE2",   compareSubImg_thr_sse2,   contrastSubImg1_SSE    },
+#endif
+#ifdef VS_HAVE_AVX2
+  { "AVX2",   compareSubImg_thr_avx2,   contrastSubImg1_avx2   },
+#endif
+#ifdef VS_HAVE_AVX512
+  { "AVX512", compareSubImg_thr_avx512, contrastSubImg1_avx512 },
+#endif
+#ifdef VS_HAVE_NEON
+  { "NEON",   compareSubImg_thr_neon,   contrastSubImg1_neon   },
+#endif
+};
+#define SIMD_NUM_KERNELS ((int)(sizeof(simd_kernels)/sizeof(simd_kernels[0])))
 
 /* only multiples of 16 are valid, see file header */
 static const int simd_field_sizes[]  = { 16, 32, 48, 64, 80 };
@@ -42,7 +73,7 @@ static const int simd_field_pos[][2] = { {400,300}, {200,200}, {900,500}, {640,3
 /* mimics the search of calcFieldTransPlanar (non-spiral variant):
    start at (0,0), then scan with a tightening minerror that is handed to the
    compare function as threshold. Returns the selected shift and the minerror. */
-static void simd_argmin_scan(cmpSubImgFunc cmpsubfunc,
+static void simd_argmin_scan(vsCompareSubImgFn cmpsubfunc,
                              unsigned char* I1, unsigned char* I2,
                              const Field* field, int width1, int width2, int height,
                              int maxShift, int stepSize,
@@ -71,7 +102,7 @@ static void simd_argmin_scan(cmpSubImgFunc cmpsubfunc,
 
 /* threshold == UINT_MAX: no early exit possible on either side,
    so the returned sums must be bit-for-bit equal. */
-static void simd_test_compare_strict(const TestData* testdata){
+static void simd_test_compare_strict(const TestData* testdata, const SimdKernel* k){
   int s, p, dx, dy;
   int mismatches = 0;
   unsigned char* I1 = testdata->frames[0].data[0];
@@ -80,7 +111,7 @@ static void simd_test_compare_strict(const TestData* testdata){
   int w2 = testdata->frames[1].linesize[0];
   int h  = testdata->fi.height;
 
-  fprintf(stderr,"*** compareSubImg: strict equality (threshold=UINT_MAX)\n");
+  fprintf(stderr,"*** [%s] compareSubImg: strict equality (threshold=UINT_MAX)\n", k->name);
   for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
     for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
       Field f;
@@ -91,11 +122,11 @@ static void simd_test_compare_strict(const TestData* testdata){
         for (dx = -16; dx <= 16; dx += 8) {     /* includes 0 */
           unsigned int refval = compareSubImg_thr(I1, I2, &f, w1, w2, h,
                                                  1, dx, dy, UINT_MAX);
-          unsigned int optval = compareSubImg_thr_sse2(I1, I2, &f, w1, w2, h,
-                                                       1, dx, dy, UINT_MAX);
+          unsigned int optval = k->cmp(I1, I2, &f, w1, w2, h,
+                                          1, dx, dy, UINT_MAX);
           if (refval != optval && mismatches++ < 10)
-            fprintf(stderr,"  MISMATCH size=%i pos=(%i,%i) d=(%i,%i): C=%u SSE2=%u\n",
-                    f.size, f.x, f.y, dx, dy, refval, optval);
+            fprintf(stderr,"  MISMATCH [%s] size=%i pos=(%i,%i) d=(%i,%i): C=%u opt=%u\n",
+                    k->name, f.size, f.x, f.y, dx, dy, refval, optval);
           test_bool(refval == optval);
         }
       }
@@ -106,7 +137,7 @@ static void simd_test_compare_strict(const TestData* testdata){
 /* finite threshold: the returned numbers may legally differ (early exit).
    Assert only what the caller relies on: both must agree on whether the
    result is <= threshold. */
-static void simd_test_compare_threshold(const TestData* testdata){
+static void simd_test_compare_threshold(const TestData* testdata, const SimdKernel* k){
   int s, p, t, dx, dy;
   unsigned char* I1 = testdata->frames[0].data[0];
   unsigned char* I2 = testdata->frames[1].data[0];
@@ -114,7 +145,7 @@ static void simd_test_compare_threshold(const TestData* testdata){
   int w2 = testdata->frames[1].linesize[0];
   int h  = testdata->fi.height;
 
-  fprintf(stderr,"*** compareSubImg: finite threshold, <=threshold decision must agree\n");
+  fprintf(stderr,"*** [%s] compareSubImg: finite threshold, <=threshold decision must agree\n", k->name);
   for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
     for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
       Field f;
@@ -134,8 +165,8 @@ static void simd_test_compare_threshold(const TestData* testdata){
           for (dx = -8; dx <= 8; dx += 8) {
             unsigned int refval = compareSubImg_thr(I1, I2, &f, w1, w2, h,
                                                     1, dx, dy, thr);
-            unsigned int optval = compareSubImg_thr_sse2(I1, I2, &f, w1, w2, h,
-                                                         1, dx, dy, thr);
+            unsigned int optval = k->cmp(I1, I2, &f, w1, w2, h,
+                                            1, dx, dy, thr);
             /* the guarantee: an early-exited result is > threshold */
             test_bool((refval <= thr) == (optval <= thr));
           }
@@ -148,7 +179,7 @@ static void simd_test_compare_threshold(const TestData* testdata){
 /* the property that really matters: the search in calcFieldTransPlanar must
    pick the same shift and end with the same minerror, whichever
    implementation drives it. */
-static void simd_test_compare_argmin(const TestData* testdata){
+static void simd_test_compare_argmin(const TestData* testdata, const SimdKernel* k){
   int s, p;
   unsigned char* I1 = testdata->frames[0].data[0];
   unsigned char* I2 = testdata->frames[1].data[0];
@@ -156,7 +187,7 @@ static void simd_test_compare_argmin(const TestData* testdata){
   int w2 = testdata->frames[1].linesize[0];
   int h  = testdata->fi.height;
 
-  fprintf(stderr,"*** compareSubImg: argmin of a calcFieldTransPlanar-like scan must match\n");
+  fprintf(stderr,"*** [%s] compareSubImg: argmin of a calcFieldTransPlanar-like scan must match\n", k->name);
   for (s = 0; s < SIMD_NUM_FIELD_SIZES; s++) {
     for (p = 0; p < SIMD_NUM_FIELD_POS; p++) {
       Field f;
@@ -167,12 +198,12 @@ static void simd_test_compare_argmin(const TestData* testdata){
       f.y    = simd_field_pos[p][1];
       simd_argmin_scan(compareSubImg_thr,      I1, I2, &f, w1, w2, h, 12, 2,
                        &txC, &tyC, &minC);
-      simd_argmin_scan(compareSubImg_thr_sse2, I1, I2, &f, w1, w2, h, 12, 2,
+      simd_argmin_scan(k->cmp,                 I1, I2, &f, w1, w2, h, 12, 2,
                        &txO, &tyO, &minO);
       if (txC != txO || tyC != tyO || minC != minO)
-        fprintf(stderr,"  ARGMIN MISMATCH size=%i pos=(%i,%i): "
-                "C=(%i,%i,%u) SSE2=(%i,%i,%u)\n",
-                f.size, f.x, f.y, txC, tyC, minC, txO, tyO, minO);
+        fprintf(stderr,"  ARGMIN MISMATCH [%s] size=%i pos=(%i,%i): "
+                "C=(%i,%i,%u) opt=(%i,%i,%u)\n",
+                k->name, f.size, f.x, f.y, txC, tyC, minC, txO, tyO, minO);
       test_bool(txC == txO);
       test_bool(tyC == tyO);
       test_bool(minC == minO);
@@ -188,9 +219,9 @@ static void simd_test_compare_argmin(const TestData* testdata){
    reordering of floating point arithmetic anywhere.  Hence we assert exact
    equality rather than an epsilon: any nonzero difference means the SIMD
    min/max reduction is wrong, which is exactly what we want to catch. */
-static void simd_test_contrast(const TestData* testdata){
+static void simd_test_contrast(const TestData* testdata, const SimdKernel* k){
   int s, p, fr;
-  fprintf(stderr,"*** contrastSubImg: strict equality C vs SSE2\n");
+  fprintf(stderr,"*** [%s] contrastSubImg: strict equality vs C\n", k->name);
   for (fr = 0; fr < 2; fr++) {
     unsigned char* I = testdata->frames[fr].data[0];
     int w = testdata->frames[fr].linesize[0];
@@ -202,27 +233,32 @@ static void simd_test_contrast(const TestData* testdata){
         f.x    = simd_field_pos[p][0];
         f.y    = simd_field_pos[p][1];
         double cC = contrastSubImg(I, &f, w, h, 1);
-        double cO = contrastSubImg1_SSE(I, &f, w, h);
+        double cO = k->con(I, &f, w, h);
         if (cC != cO)
-          fprintf(stderr,"  CONTRAST MISMATCH frame=%i size=%i pos=(%i,%i): "
-                  "C=%.17g SSE2=%.17g\n", fr, f.size, f.x, f.y, cC, cO);
+          fprintf(stderr,"  CONTRAST MISMATCH [%s] frame=%i size=%i pos=(%i,%i): "
+                  "C=%.17g opt=%.17g\n", k->name, fr, f.size, f.x, f.y, cC, cO);
         test_bool(cC == cO);
       }
     }
   }
 }
 
-#endif /* USE_SSE2 */
+#endif /* SIMD_HAVE_ANY_KERNEL */
 
 void test_simd_equivalence(const TestData* testdata){
-#ifdef USE_SSE2
-  fprintf(stderr,"********** SSE2 vs C equivalence:\n");
-  simd_test_compare_strict(testdata);
-  simd_test_compare_threshold(testdata);
-  simd_test_compare_argmin(testdata);
-  simd_test_contrast(testdata);
+#ifdef SIMD_HAVE_ANY_KERNEL
+  int i;
+  fprintf(stderr,"********** SIMD vs C equivalence (%i kernel(s) compiled in):\n",
+          SIMD_NUM_KERNELS);
+  for (i = 0; i < SIMD_NUM_KERNELS; i++) {
+    const SimdKernel* k = &simd_kernels[i];
+    simd_test_compare_strict(testdata, k);
+    simd_test_compare_threshold(testdata, k);
+    simd_test_compare_argmin(testdata, k);
+    simd_test_contrast(testdata, k);
+  }
 #else
   (void)testdata;
-  fprintf(stderr,"********** SSE2 vs C equivalence: SSE2 not enabled, nothing to compare\n");
+  fprintf(stderr,"********** SIMD vs C equivalence: no SIMD kernels in this build\n");
 #endif
 }


### PR DESCRIPTION
Experimental branch exploring what is left to gain from CPU SIMD. Measurements on an i7-7800X (Skylake-X, 6c/12t), GCC 13.3, `-O3`, synthetic textured frames.

| Resolution | Threads | Before | After | Speedup |
|---|---|---|---|---|
| 1280x720  | 9 | 11.85 ms | 5.91 ms | **2.01x** |
| 1920x1080 | 9 | 32.34 ms | 17.86 ms | **1.81x** |
| 3840x2160 | 9 | 305.90 ms | 202.24 ms | **1.51x** |
| 1920x1080 | 1 | 68.94 ms | 49.42 ms | **1.39x** |

1080p motion detection goes from 31 fps to 56 fps.

## ARM/Apple Silicon had no SIMD at all

The finding worth reading even if the rest is skipped. `motiondetect_opt.c` contained:

```c
#ifdef __ARM_NEON__
#include "sse2neon.h"
#define USE_SSE2
#endif
```

That `#define` is local to that one translation unit. `motiondetect.c` — where `compareSubImg` is actually *called*, and where `fieldSize` is rounded up to a multiple of 16 — never saw it. Verified with the preprocessor:

```
$ gcc -E -Isrc x.c | grep WHICH     # no -DUSE_SSE2, i.e. an ARM build
WHICH: compareSubImg_thr                 <- the scalar C version
```

So on every ARM build, including all Apple Silicon, the shimmed kernels were compiled and then never called. There is a second, independent bug in the same three lines: `__ARM_NEON__` (trailing underscores) is defined by Clang but **not** by GCC on AArch64, so a GCC AArch64 build did not even reach the shim.

Replaced with native NEON kernels (`vabdq_u8`/`vpadalq_u8`) wired through the runtime dispatcher, with the architecture test in one place checking both spellings.

**Verified on real hardware.** CI now builds and runs on a native `ubuntu-24.04-arm` runner: it selects `SIMD: NEON` and passes **1320/1320** equivalence checks against the C reference on real silicon. A qemu-user armv7 job covers the 32-bit reduction fallbacks (`vs_haddq_u32`, `vs_hminq_u8`, `vs_hmaxq_u8`) that AArch64 never compiles — also 1320/1320.

(`tests/neon_emu.h`, a scalar emulation of the nine intrinsics used, remains: it keeps the kernel compiling and checked on x86 developer machines too. It was the only verification available before the ARM runners were added.)

No *controlled* ARM speed figure is claimed — CI prints per-dispatch-level timings, but a shared runner is not a measurement environment.

## Runtime dispatch

SSE2 used to be selected by the preprocessor with `-msse2` applied to the whole library, so a distribution binary could never use anything newer. Kernels are now chosen at runtime from CPUID (checking XCR0, so the OS really is preserving the wide registers), and only the AVX2/AVX-512 *kernel files* carry `-mavx2` etc. — the binary still runs on an SSE2-only host.

`VIDSTAB_SIMD=none|sse2|avx2|avx512|neon` overrides the choice; that is how every kernel is tested and benchmarked on one machine.

Field size is now rounded to a multiple of 16 **unconditionally** rather than only in SSE2 builds. The kernel is picked at runtime, so letting field geometry depend on the host CPU would make one input produce different `.trf` output on different machines.

## AVX-512 is built and tested but not the default

Measured **~18% slower** than AVX2 end to end on this Skylake-X, consistently across repeated runs, single- and multi-threaded. The kernels are memory bound so the extra width buys little, while issuing 512-bit instructions drops the core clock on parts with AVX-512 frequency licensing — and that penalty applies to the whole frame, including the scalar code around the kernel.

Newer cores (Ice Lake+, Zen 4/5) do not throttle this way and would likely come out ahead, but there is no reliable runtime probe for "does 512-bit width cost me frequency here", and a family/model table ages badly. Reachable via `VIDSTAB_SIMD=avx512`. **Worth re-checking on a Zen 4/5 or Ice Lake+ machine, where it may deserve to be the default.**

## boxblur

Was ~10.5 ms/frame at 1080p and entirely serial — the `#pragma omp parallel for` in `hori` was commented out with "(no speedup)". That may have been true when written, but once the motion search scales across 9 cores, 10 ms of serial work dominates.

- `hori`: rows are independent accumulator chains, parallelised directly.
- `vert`: rewritten from a column walk (a new cache line per pixel, one serial dependency chain per column) to a row-sequential sweep, then parallelised over column blocks.

**10.45 -> 2.59 ms/frame** at 9 threads.

## Testing and CI

All five kernels (C, SSE2, AVX2, AVX-512, NEON) return **bit-identical** results, early exits included. The check cadence was deliberately left at every row to keep that exactly testable — batching it every 4 rows is legal under the documented contract but measured only ~1.5%, not worth giving up the property.

The dispatcher selects one kernel per run, and "the compiler can emit it" is not "the CPU can run it". The equivalence test skips kernels the CPU cannot execute and prints `N of M kernel(s) checked`, so a permanently-skipped kernel cannot pass as a silent no-op.

| Job | Kernels executed |
|---|---|
| `x86_64` | SSE2, AVX2, AVX-512 (runner dependent), NEON-emulated; plus reruns at `VIDSTAB_SIMD=none` and `=sse2` |
| `aarch64` (native ARM) | NEON on real hardware |
| `armv7-qemu` | NEON 32-bit reduction fallbacks |

`x86_64` and `aarch64` also run a benchmark step: informational only, `continue-on-error`, no threshold asserted, so it can never fail the build. Runners are shared VMs, so only the ratio between dispatch levels within one run is meaningful.

Other test changes:
- `test_simd_equivalence` covers every compiled-in kernel instead of SSE2 only: 1320 -> 5280 checks on x86.
- `test_boxblur` previously asserted nothing (`0/0 checks`); it now pins the rewrite against a verbatim copy of the old algorithm over 500 geometries.
- Full suite passes on the SIMD and the scalar-only (`-DSSE2_FOUND=FALSE`) build; both build warning-free.

## Notes for review

- `src/sse2neon.h` (9199 lines) is now unused. Deleting it felt like a maintainer call, so it is left in place.
- `USE_SSE2_ASM` is deliberately left out of the runtime dispatch: it ignores `linesize2` (pre-existing TODO) and so is only correct when both frames share a stride.
- `bench/` is a measurement-only directory; its CMake target is `EXCLUDE_FROM_ALL`.
- The `armv7-qemu` job runs a targeted subset rather than `--all`, because `--all` surfaced a pre-existing non-SIMD bug — now filed as #168 (an unbounded frame index from a corrupt `.trf` overflows the growth loop in `vs_vector_set`). Widen it back to `--all` once that is fixed.
- Full measurements and the list of what was *not* done are in `docs/superpowers/simd-optimization-report.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
