### PR TITLE
Fix virtual tripod mode: do not stabilize frames before the reference frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ NOTE: 10-bit 4:2:2 video must be downsampled to 8-bit 4:2:0 to avoid distortions
   <dd>Set minimum contrast. Any measurement field having contrast below this value is discarded. Must be a floating point value in the range 0-1. Default value is 0.3.</dd>
   <dt><b>tripod</b></dt>
   <dd>  Set reference frame number for tripod mode.  If enabled, the motion of the frames is compared to a reference frame in the filtered stream, identified by the specified number. The intention is to compensate all movements in a more-or-less static scene and keep the camera view absolutely still. If set to 0, it is disabled. The frames are counted starting from 1.
+  <br>Frames before the reference frame are not stabilized: no correction is applied to them (they are still zoomed/cropped like the rest of the clip), and stabilization begins at the reference frame, where the view snaps to the reference pose.
   <br>NOTE: If this mode is used in first pass then it should also be used in second pass.</dd>
   <dt><b>show</b></dt>
-  <dd>Show fields and transforms in the resulting frames for visual analysis. It accepts an integer in the range 0-2. Default value is 0, which disables any visualization.</dd>
+  <dd>Show fields and transforms in the resulting frames for visual analysis. It accepts an integer in the range 0-2. Default value is 0, which disables any visualization.
+  <br>In tripod mode, frames before the reference frame show no overlay, since no motion is measured for them.</dd>
 </dl>
 
 
@@ -198,7 +200,8 @@ ffmpeg -i input.mp4 -vf format=yuv420p,vidstabdetect -f null -
   <br><i><b>bicubic</b></i>: Cubic in both directions (slow speed).
   <dt><b>tripod</b></dt>
   <dd>Enables virtual tripod mode if set to 1, which is equivalent to <b>relative=0:smoothing=0</b>. Default value is 0.
-  <br>NOTE: If this mode has been used in first pass then only it should be used in second pass.</dd>
+  <br>The stored transforms are used as-is: no smoothing or accumulation is applied, they are simply passed through, including the leading zero transforms for frames before the reference frame. Which frames are not stabilized is decided during the first pass.
+  <br>NOTE: If this mode has been used in first pass then it should also be used in second pass.</dd>
   <dt><b>debug</b></dt>
   <dd>Increase log verbosity if set to 1. Also the detected global motions are written to the temporary file  <b>global_motions.trf</b> . Default value is 0. </dd>
 

--- a/src/motiondetect.c
+++ b/src/motiondetect.c
@@ -199,7 +199,16 @@ int vsMotionDetection(VSMotionDetect* md, LocalMotions* motions, VSFrame *frame)
     // BoxBlurNoColor);
   }
 
-  if (md->hasSeenOneFrame) {
+  /* Tripod lead-in: frames before the reference frame emit no motion.
+     Detection is a single streaming pass, so a frame at index < virtualTripod
+     cannot be measured against the reference at index virtualTripod-1, which
+     has not been read yet. These frames are left uncorrected; stabilization
+     begins at the reference frame. For the default virtualTripod=1 the
+     lead-in is frame 0 alone. */
+  int tripodLeadIn = md->conf.virtualTripod >= 1
+                     && md->frameNum < md->conf.virtualTripod;
+
+  if (md->hasSeenOneFrame && !tripodLeadIn) {
     LocalMotions motionscoarse;
     LocalMotions motionsfine;
     vs_vector_init(&motionsfine,0);

--- a/tests/generate_synthetic.c
+++ b/tests/generate_synthetic.c
@@ -182,3 +182,84 @@ void dumpFramesAsPPM(const VSFrame* frames, const VSFrameInfo* fi, int numFrames
     test_bool(storePPMImage(name, &frames[i], fi));
   }
 }
+
+/* --- virtual tripod mode ---------------------------------------------------
+   A bounded, drift-free absolute camera path: frame i is the base scene warped
+   by synTripodTransform(i), NOT by a chain of per-frame warps. That is the
+   right model for a tripod scene (a static camera plus jitter), and it keeps
+   the ground truth A_i exact instead of accumulating resampling error the way
+   generateCircleFrames() does -- which matters because the tripod assertions
+   compare against A_i directly.
+
+   A_0 is the identity (frame 0 is the base image every other frame is warped
+   from). Large accumulated drift is deliberately out of scope -- it is not
+   what tripod mode is for, and the L1 camera path reaches a near-static
+   result without tripod mode anyway. */
+#define SYN_TRIPOD_NUM_FRAMES 12
+#define SYN_TRIPOD_REF 4   /* 1-based reference frame for the tripod=R case */
+
+/* The leading segment (frames 0..SYN_TRIPOD_REF-1) is four deliberately
+   well-separated poses: each is at least 14px from the reference pose, so a
+   frame measured against its predecessor instead of against the reference
+   misses by 4.5x-9.5x TRIPOD_TOL_XY. The earlier sinusoidal path put frames 2
+   and 3 at or under tolerance, where the test passed by coincidence and flipped
+   between pixel formats on detection noise.
+
+   The trailing segment (frames >= SYN_TRIPOD_REF) is a small wobble around the
+   reference pose, so those frames are recovered cleanly.
+
+   A_0 is exactly the identity: frame 0 is the base image every other frame is
+   warped from. Peak amplitude is |x|<=23.9px, |y|<=19.0px, |alpha|<=1.1deg --
+   comfortably inside maxShift (VS_MAX(16, minDimension/7) = 68px at 640x480,
+   see motiondetect.c:134) and far enough from the canvas edges that the painted
+   circles never clip out. */
+static const double SYN_TRIPOD_LEAD[SYN_TRIPOD_REF][3] = {
+  {   0.0,   0.0,  0.0 },  /* frame 0: the base image, must be the identity */
+  {  20.0,   0.0,  1.1 },
+  {   0.0,  18.0, -0.9 },
+  { -18.0, -14.0,  0.4 }   /* the reference pose (index SYN_TRIPOD_REF-1) */
+};
+
+static VSTransform synTripodTransform(int i){
+  VSTransform t = null_transform();
+  if(i < SYN_TRIPOD_REF){
+    t.x     = SYN_TRIPOD_LEAD[i][0];
+    t.y     = SYN_TRIPOD_LEAD[i][1];
+    t.alpha = SYN_TRIPOD_LEAD[i][2] * M_PI / 180.0;
+  } else {
+    double s = (double)i;
+    t.x     = SYN_TRIPOD_LEAD[SYN_TRIPOD_REF-1][0] + 6.0 * sin(s * 0.9);
+    t.y     = SYN_TRIPOD_LEAD[SYN_TRIPOD_REF-1][1] + 5.0 * sin(s * 1.3 + 0.5);
+    t.alpha = (SYN_TRIPOD_LEAD[SYN_TRIPOD_REF-1][2] + 0.5 * sin(s * 0.7)) * M_PI / 180.0;
+  }
+  t.zoom = 0;
+  return t;
+}
+
+/* Frame 0 is the base scene; frame i is frame 0 warped by synTripodTransform(i).
+   Note this warps from frame 0 every time rather than chaining frame to frame
+   the way generateCircleFrames() does -- see the comment on synTripodTransform
+   above for why. VS_Zero interpolation matches the other synthetic generators. */
+void generateTripodFrames(VSFrame* frames, VSFrameInfo* fi, VSPixelFormat pf,
+                          int width, int height, int numFrames){
+  int i;
+  VSTransformConfig conf;
+  VSTransformData td;
+
+  test_bool(vsFrameInfoInit(fi, width, height, pf) != 0);
+  for(i=0; i<numFrames; i++)
+    vsFrameAllocate(&frames[i], fi);
+
+  paintSynBase(&frames[0], fi);
+
+  conf = vsTransformGetDefaultConfig("gen_syn_tripod");
+  conf.interpolType = VS_Zero;
+  test_bool(vsTransformDataInit(&td, &conf, fi, fi) == VS_OK);
+  for(i=1; i<numFrames; i++){
+    VSTransform t = synTripodTransform(i);
+    test_bool(vsTransformPrepare(&td, &frames[0], &frames[i]) == VS_OK);
+    test_bool(vsDoTransform(&td, t) == VS_OK);
+    test_bool(vsTransformFinish(&td) == VS_OK);
+  }
+  vsTransformDataCleanup(&td);
+}

--- a/tests/test_tripod.c
+++ b/tests/test_tripod.c
@@ -1,0 +1,250 @@
+/* Virtual tripod mode regression tests.
+
+   Included as a translation unit by tests.c (after generate_synthetic.c and
+   test_synthetic.c), so it needs no includes of its own.
+
+   See docs/superpowers/specs/2026-08-03-tripod-mode-tests-design.md and
+   GitHub issues #85 / #27. */
+
+/* Tripod mode on the transform side is defined as relative=0:smoothing=0 (see
+   transform.h:171). optZoom and zoom are switched off too: optZoom defaults to
+   1, and that path ends up adding a zoom term to every transform (see the
+   `else if (td->conf.zoom != 0)` branch in vsPreprocessTransforms), which would
+   make a pass-through assertion fail for reasons that have nothing to do with
+   the camera-path logic under test. maxShift/maxAngle are already -1 (no
+   clamping) by default; they are set explicitly to document the intent. */
+static VSTransformConfig tripodTransformConfig(const char* name, VSCamPathAlgo algo){
+  VSTransformConfig c = vsTransformGetDefaultConfig(name);
+  c.relative    = 0;   /* tripod */
+  c.smoothing   = 0;   /* tripod */
+  c.optZoom     = 0;
+  c.zoom        = 0;
+  c.maxShift    = -1;
+  c.maxAngle    = -1;
+  c.camPathAlgo = algo;
+  return c;
+}
+
+/* Runs the real library entry point vsPreprocessTransforms() over `in` and
+   copies the result to `out`. This is the same call ffmpeg's vidstabtransform
+   filter makes. */
+static void runTripodPreprocess(VSTransformConfig* conf, const VSFrameInfo* fi,
+                                const VSTransform* in, VSTransform* out, int n){
+  VSTransformData td;
+  VSTransformations trans;
+  int i;
+
+  test_bool(vsTransformDataInit(&td, conf, fi, fi) == VS_OK);
+  vsTransformationsInit(&trans);
+  trans.ts  = (VSTransform*)vs_malloc(sizeof(VSTransform) * n);
+  trans.len = n;
+  for(i=0; i<n; i++) trans.ts[i] = in[i];
+
+  test_bool(vsPreprocessTransforms(&td, &trans) == VS_OK);
+  for(i=0; i<n; i++) out[i] = trans.ts[i];
+
+  vsTransformationsCleanup(&trans);
+  vsTransformDataCleanup(&td);
+}
+
+/* In tripod mode vsPreprocessTransforms() must be a pure pass-through: no
+   relative-to-absolute integration, no smoothing, no camera-path optimization.
+   Each stored transform is already the absolute correction for its frame. */
+static void checkTripodPassThrough(VSCamPathAlgo algo, const char* algoName){
+  const int N = SYN_TRIPOD_NUM_FRAMES;
+  VSFrameInfo fi;
+  VSTransform in[SYN_TRIPOD_NUM_FRAMES], out[SYN_TRIPOD_NUM_FRAMES];
+  VSTransformConfig conf;
+  int i;
+
+  fprintf(stderr, "--- tripod transform pass-through, camPathAlgo=%s ---\n", algoName);
+  test_bool(vsFrameInfoInit(&fi, SYN_WIDTH, SYN_HEIGHT, PF_YUV420P) != 0);
+
+  /* the stored convention is the correction, i.e. the negated camera motion --
+     see test_synthetic.c:73, which compares detection output against
+     -getTestFrameTransform(i) for the same reason. */
+  for(i=0; i<N; i++) in[i] = mult_transform_(synTripodTransform(i), -1.0);
+
+  conf = tripodTransformConfig("test_tripod_trans", algo);
+  runTripodPreprocess(&conf, &fi, in, out, N);
+
+  for(i=0; i<N; i++){
+    VSTransform d = sub_transforms(&out[i], &in[i]);
+    int ok = fabs(d.x)<1e-9 && fabs(d.y)<1e-9
+          && fabs(d.alpha)<1e-9 && fabs(d.zoom)<1e-9;
+    if(!ok){
+      fprintf(stderr, "frame %i  in: ", i); storeVSTransform(stderr, &in[i]);
+      fprintf(stderr, "         out: ");    storeVSTransform(stderr, &out[i]);
+    }
+    test_bool(ok);
+  }
+}
+
+/* Negative control. With the library default relative=1 the very same input
+   must come out *different* (integrated into an absolute path). Without this,
+   a regression that silently ignored `relative` would leave the pass-through
+   assertion above trivially satisfied and green. VSGaussian with smoothing=0
+   is used so that the integration step is the only thing that differs. */
+static void checkTripodRelativeControl(void){
+  const int N = SYN_TRIPOD_NUM_FRAMES;
+  VSFrameInfo fi;
+  VSTransform in[SYN_TRIPOD_NUM_FRAMES], out[SYN_TRIPOD_NUM_FRAMES];
+  VSTransformConfig conf;
+  int i, differs = 0;
+
+  fprintf(stderr, "--- tripod negative control: relative=1 must differ ---\n");
+  test_bool(vsFrameInfoInit(&fi, SYN_WIDTH, SYN_HEIGHT, PF_YUV420P) != 0);
+  for(i=0; i<N; i++) in[i] = mult_transform_(synTripodTransform(i), -1.0);
+
+  conf = tripodTransformConfig("test_tripod_relctl", VSGaussian);
+  conf.relative = 1;
+  runTripodPreprocess(&conf, &fi, in, out, N);
+
+  for(i=0; i<N; i++){
+    VSTransform d = sub_transforms(&out[i], &in[i]);
+    if(fabs(d.x) > 1.0 || fabs(d.y) > 1.0) differs = 1;
+  }
+  test_bool(differs);
+}
+
+void test_tripod_transforms(void){
+  checkTripodPassThrough(VSOptimalL1, "VSOptimalL1");
+  checkTripodPassThrough(VSGaussian,  "VSGaussian");
+  checkTripodPassThrough(VSAvg,       "VSAvg");
+  checkTripodRelativeControl();
+}
+
+/* Decided tripod semantics (issue #85): frames before the reference frame
+   (i <= reference-1, i.e. the lead-in including the reference frame itself)
+   are not stabilized and emit a zero transform. From the reference frame on,
+   every emitted motion is the correction that maps frame i back onto the
+   reference frame, i.e. -(A_i - A_ref) = A_ref - A_i. Composing the two warps
+   is approximated here by component-wise subtraction, exactly as the library
+   itself does throughout (add_transforms / sub_transforms); at these
+   amplitudes (<=23.9px, <=1.1deg) the neglected cross term is about 0.3px,
+   far inside tolXY. */
+static VSTransform tripodExpected(int i, int reference){
+  if(i <= reference - 1) return null_transform();
+  VSTransform ai = synTripodTransform(i);
+  VSTransform ar = synTripodTransform(reference - 1);
+  return sub_transforms(&ar, &ai);
+}
+
+/* Generates the tripod sequence and runs vsMotionDetection() over it frame by
+   frame with virtualTripod set, collecting the raw per-frame transform. Same
+   one-md-instance-per-sequence convention as checkRecoveredMotion() in
+   test_synthetic.c. Frames are freed as they are consumed. */
+static void detectTripodPath(VSPixelFormat pf, int reference,
+                             VSTransform* raw, int n){
+  VSFrameInfo fi;
+  VSFrame frames[SYN_TRIPOD_NUM_FRAMES];
+  VSMotionDetectConfig mdconf;
+  VSMotionDetect md;
+  int i;
+
+  /* frames[] is fixed at SYN_TRIPOD_NUM_FRAMES; guard against a caller
+     passing a larger n, which would overflow it. All current callers pass
+     SYN_TRIPOD_NUM_FRAMES, so this is latent only. */
+  test_bool(n <= SYN_TRIPOD_NUM_FRAMES);
+
+  generateTripodFrames(frames, &fi, pf, SYN_WIDTH, SYN_HEIGHT, n);
+
+  mdconf = vsMotionDetectGetDefaultConfig("test_tripod_md");
+  mdconf.virtualTripod = reference;
+  /* vsMotionDetectInit() reads md.serializationMode before writing it
+     (src/motiondetect.c:111), which valgrind flags as a use of an
+     uninitialised value; zero the struct first to keep this test
+     valgrind-clean. The underlying read-before-write is a library-side
+     issue, out of scope here. */
+  memset(&md, 0, sizeof(md));
+  test_bool(vsMotionDetectInit(&md, &mdconf, &fi) == VS_OK);
+  md.conf.numThreads = 1;
+
+  for(i=0; i<n; i++){
+    LocalMotions lms;
+    test_bool(vsMotionDetection(&md, &lms, &frames[i]) == VS_OK);
+    raw[i] = vsSimpleMotionsToTransform(fi, "test_tripod_md", &lms);
+    vs_vector_del(&lms);
+    vsFrameFree(&frames[i]);
+  }
+  vsMotionDetectionCleanup(&md);
+}
+
+/* tolXY/tolAlpha are the values established empirically in test_synthetic.c
+   (see the long comment at test_synthetic.c:120): the headroom on tolXY covers
+   genuine C-vs-SSE2 block-matching divergence (CMakeLists.txt SSE2_FOUND /
+   CMakeModules/FindSSE.cmake), not slop in the test. This scene warps from
+   frame 0 rather than chaining, so it accumulates less error than the sequence
+   those numbers were measured on and they are, if anything, generous here. */
+#define TRIPOD_TOL_XY    4.0
+#define TRIPOD_TOL_ALPHA 0.005
+
+/* Asserts the recovered path is absolute with respect to the reference frame
+   for EVERY frame. Returns the number of frames that failed (0 = all good) so
+   callers can report the failure pattern, which is what localizes the bug. */
+static int checkTripodDetection(VSPixelFormat pf, int reference){
+  const int N = SYN_TRIPOD_NUM_FRAMES;
+  VSTransform raw[SYN_TRIPOD_NUM_FRAMES];
+  int i, bad = 0;
+
+  fprintf(stderr, "--- tripod detection, %s, virtualTripod=%i ---\n",
+          synFormatName(pf), reference);
+  detectTripodPath(pf, reference, raw, N);
+
+  for(i=0; i<N; i++){
+    VSTransform exp = tripodExpected(i, reference);
+    VSTransform d   = sub_transforms(&raw[i], &exp);
+    int ok = fabs(d.x)<TRIPOD_TOL_XY && fabs(d.y)<TRIPOD_TOL_XY
+          && fabs(d.alpha)<TRIPOD_TOL_ALPHA;
+    /* Strengthen the lead-in check: frames up to and including the reference
+       frame itself must be *exactly* zero (not merely within tolerance), so a
+       regression that emitted small-but-nonzero motions there is caught. */
+    if(i <= reference - 1){
+      int exact = raw[i].x==0.0 && raw[i].y==0.0 && raw[i].alpha==0.0
+               && raw[i].zoom==0.0;
+      if(!exact) ok = 0;
+    }
+    /* Complementary check: the first stabilized frame (the reference index
+       itself) must NOT be exactly zero. If the reference index silently
+       drifts forward by one, this frame would report zero instead of the
+       expected nonzero correction, and the tolerance-based check alone would
+       not reliably catch it (see the module comment above). */
+    if(i == reference){
+      int allZero = raw[i].x==0.0 && raw[i].y==0.0 && raw[i].alpha==0.0;
+      if(allZero) ok = 0;
+    }
+    fprintf(stderr, "frame %2i %s got: ", i, ok ? "ok  " : "FAIL");
+    storeVSTransform(stderr, &raw[i]);
+    if(!ok){
+      fprintf(stderr, "            want: "); storeVSTransform(stderr, &exp);
+      if(i == reference){
+        fprintf(stderr, "            (expected nonzero: this is the first stabilized frame)\n");
+      }
+      bad++;
+    }
+  }
+  return bad;
+}
+
+void test_tripod_detection(void){
+  /* virtualTripod=1 is the self-consistent case: the reference is frame 1 and
+     frame 0 emits a dummy motion, so every frame really is measured against
+     the reference. This is why the default tripod setting mostly works and the
+     bug looked intermittent. */
+  test_bool(checkTripodDetection(PF_YUV420P, 1) == 0);
+  test_bool(checkTripodDetection(PF_RGBA,    1) == 0);
+
+  /* Fixed behavior for issue #85. Detection is a single streaming pass, so
+     when frames 0..R-1 are processed the reference frame (at index R-1) has
+     not been read yet and they *cannot* be measured against it. Rather than
+     measuring them against their predecessor -- which produced a .trf file
+     mixing relative and absolute conventions that the transform stage (which
+     reads everything as absolute, relative=0) misinterpreted -- frames
+     0..R-1 now emit a zero transform: no stabilization is applied until the
+     reference frame is reached. Frames R.. are measured against the
+     reference at index R-1, exactly as before. Expect frames 0,1,2 (and the
+     reference frame itself at index R-1=3) to report exactly zero, and
+     frames 4.. to match the reference-relative expectation. */
+  test_bool(checkTripodDetection(PF_YUV420P, SYN_TRIPOD_REF) == 0);
+  test_bool(checkTripodDetection(PF_RGBA,    SYN_TRIPOD_REF) == 0);
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -49,6 +49,7 @@
 #include "test_packed.c"
 #include "test_draw.c"
 #include "test_synthetic.c"
+#include "test_tripod.c"
 #ifdef VS_HAVE_LPSOLVER
 #include "test_campathopt.c"
 #endif
@@ -179,6 +180,11 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testSYNSQ", "synthetic circles+squares across pixel formats")){
     UNIT(test_synthetic_circles_squares());
+  }
+
+  if(all || contains(argv,argc,"--testTRIPOD", "virtual tripod mode")){
+    UNIT(test_tripod_transforms());
+    UNIT(test_tripod_detection());
   }
 
   if(contains(argv,argc,"--dumpSynthetic", "dump synthetic frames as PPM for visual inspection")){


### PR DESCRIPTION
Fixes #85.

## The bug

With `tripod=R`, detection measured frames `0..R-1` against their **predecessor** but frames `R..` against the **reference** at index `R-1`. One `.trf` file, two coordinate conventions — and the transform stage reads every entry as absolute (`relative=0`), so the leading entries were misinterpreted. That is the burst of shake in #85.

`tripod=1` happens to be self-consistent: its lead-in is only frame 0, which already emitted a dummy motion. That is why the default mostly worked and the bug looked intermittent.

## The fix

Frames before the reference now emit no motion at all. Detection is a single streaming pass, so they *cannot* be measured against a reference that has not been read yet — they are left uncorrected, and stabilization begins at the reference frame.

The change reuses the predicate that already guarded the `prev` refresh, so the last frame that refreshes `prev` is the last frame that emits nothing. `tripod=1` is unaffected.

## Worth a look before merging

The lead-in frames are **uncorrected, not untouched**: under the default `optzoom=1` they still receive the global zoom/crop. So `tripod=400` yields 399 zoomed-but-unstabilized frames and then a snap to the reference pose. Documented in the README; flagging it because it is a user-visible consequence of the chosen semantics.

Also: with `show=1`, lead-in frames now render no overlay, since no motion is measured for them.

## Tests

`--testTRIPOD` adds two tests over a scene where every frame is a known absolute warp of frame 0:

- the transform stage in tripod configuration must be a pure pass-through, across all three `camPathAlgo` values, with a `relative=1` control so the assertion cannot go vacuous
- detection must recover each frame's displacement from the reference, at `tripod=1` and `tripod=4`, on `PF_YUV420P` and `PF_RGBA`

The four leading poses are deliberately well separated from the reference pose, so a frame measured against the wrong baseline misses by several times the tolerance instead of landing near it — an earlier version of the scene passed by coincidence and flipped between pixel formats on detection noise. Lead-in frames are asserted **exactly** zero and the first stabilized frame nonzero, which pins the reference index against drift in either direction; both directions were mutation-tested.

Suite: 35/35, no new warnings. Verified on the plain-C path as well as SSE2, and valgrind-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)