### PR TITLE
Do not attempt L1 camera path optimization on absolute transforms

### DIFF
--- a/src/transform.c
+++ b/src/transform.c
@@ -229,13 +229,21 @@ int cameraPathOptimization(VSTransformData* td, VSTransformations* trans){
    case VSAvg: return cameraPathAvg(td,trans);
    case VSOptimalL1:
 #ifdef VS_HAVE_LPSOLVER
-    /* cameraPathOptimalL1 leaves trans untouched unless it succeeds, so
-       falling back to the gaussian filter is safe.  It fails for absolute
-       transforms, for sequences shorter than 4 frames, and if the LP turns
-       out to be infeasible. */
-    if(cameraPathOptimalL1(td,trans)==VS_OK) return VS_OK;
-    vs_log_msg(td->conf.modName,
-               "L1 camera path optimization unavailable, using gaussian filter");
+    /* L1 optimizes a camera path built by composing relative transforms, so
+       absolute ones put it out of scope by construction rather than by
+       failure.  That is the tripod configuration (relative=0:smoothing=0),
+       where the stored transforms are already the final per-frame corrections
+       and the gaussian filter leaves them untouched -- exactly what tripod
+       wants.  Go there directly, so a correct setup stays quiet. */
+    if(td->conf.relative){
+      /* cameraPathOptimalL1 leaves trans untouched unless it succeeds, so
+         falling back to the gaussian filter is safe.  It fails for sequences
+         shorter than 4 frames, without a zoom budget, and if the LP turns out
+         to be infeasible. */
+      if(cameraPathOptimalL1(td,trans)==VS_OK) return VS_OK;
+      vs_log_msg(td->conf.modName,
+                 "L1 camera path optimization unavailable, using gaussian filter");
+    }
 #endif // without an LP solver we always use the gaussian filter
     /* fall through */
    case VSGaussian: return cameraPathGaussian(td,trans);


### PR DESCRIPTION
Tripod mode is `relative=0:smoothing=0`, and the L1 optimizer builds its camera path by composing *relative* transforms — so it cannot run there by construction, not by failure. Dispatch attempted it anyway, so every tripod run logged:

```
[vidstabtransform] L1 camera path optimization requires relative transforms
[vidstabtransform] L1 camera path optimization unavailable, using gaussian filter
```

for a configuration that is entirely correct. With `smoothing=0` the gaussian path leaves the stored transforms untouched, which is exactly what tripod wants.

L1 is now skipped when the transforms are absolute, so a correct setup stays quiet.

## Not silenced

- Genuine L1 failures still report: too few frames, no zoom budget, infeasible LP. Verified — a 3-frame clip still logs `L1 camera path optimization needs at least 4 frames, got 3`.
- `cameraPathOptimalL1()` keeps rejecting absolute transforms for any direct caller (`tests/test_campathopt.c:341` pins that contract).
- Non-tripod runs still use L1 normally.

## Behavior

Unchanged — the fallback already produced this result. Suite: 35/35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)