### PR TITLE
Bound the frame index read from a transform file (#168)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,8 @@
-1.3	L1-optimal camera path (Grundmann et al., CVPR 2011) implemented and
+1.3	A corrupt transform file can no longer drive an absurd allocation.
+	API change: vs_vector_set() and vs_vector_set_dup() return
+	VS_OK/VS_ERROR and report the replaced element through a
+	`void **old' out parameter.
+	L1-optimal camera path (Grundmann et al., CVPR 2011) implemented and
 	enabled: camPathAlgo=VSOptimalL1 now really runs the optimization
 	instead of falling back to the gaussian filter.  No new config
 	fields: the optimization takes its zoom budget from zoom/optZoom

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -91,6 +91,14 @@ const char* modname = "vid.stab - serialization";
  */
 #define VS_MAX_LOCALMOTIONS_PER_FRAME (1<<20)
 
+/*
+ * sanity limit for the frame index in a transform file. 1<<22 frames is more
+ * than 19 hours of 60fps material; a larger index means the file is corrupt
+ * and we must not size the frame vector after it - the index is used as a
+ * vector position, so an unbounded one turns into an absurd allocation.
+ */
+#define VS_MAX_FRAMES (1<<22)
+
 int vsPrepareFileText(const VSMotionDetect* md, FILE* f);
 int vsPrepareFileBinary(const VSMotionDetect* md, FILE* f);
 int vsWriteToFileText(const VSMotionDetect* md, FILE* f, const LocalMotions* lms);
@@ -494,6 +502,16 @@ int vsReadFromFileBinary(FILE* f, LocalMotions* lms){
   return frameNum;
 }
 
+/* releases a partially filled VSManyLocalMotions and everything in it */
+static void freeManyLocalMotions(VSManyLocalMotions* mlms){
+  int i;
+  for(i=0; i<vs_vector_size(mlms); i++){
+    LocalMotions* lms = (LocalMotions*)vs_vector_get(mlms,i);
+    if(lms) vs_vector_del(lms);
+  }
+  vs_vector_del(mlms);
+}
+
 int vsReadLocalMotionsFile(FILE* f, VSManyLocalMotions* mlms){
   const int serializationMode = vsGuessSerializationMode(f);
   int version = vsReadFileVersion(f, serializationMode);
@@ -506,7 +524,8 @@ int vsReadLocalMotionsFile(FILE* f, VSManyLocalMotions* mlms){
   }
   assert(mlms);
   // initial number of frames, but it will automatically be increaseed
-  vs_vector_init(mlms,1024);
+  if(vs_vector_init(mlms,1024)!=VS_OK)
+    return VS_ERROR;
   int index;
   int oldindex = 0;
   LocalMotions lms;
@@ -515,11 +534,25 @@ int vsReadLocalMotionsFile(FILE* f, VSManyLocalMotions* mlms){
       vs_log_info(modname,"VID.STAB file: index of frames is not continuous %i -< %i",
                   oldindex, index);
     }
-    if(index<1){
-      vs_log_info(modname,"VID.STAB file: Frame number < 1 (%i)", index);
+    if(index<1 || index>VS_MAX_FRAMES){
+      /* the index is used as a position in mlms, so an implausible one is
+         rejected here rather than passed on as a vector size */
+      vs_log_info(modname,"VID.STAB file: implausible frame number (%i), "
+                  "expect 1..%i", index, VS_MAX_FRAMES);
       vs_vector_del(&lms); // the motions are not stored, so release them
     } else {
-      vs_vector_set_dup(mlms,index-1,&lms, sizeof(LocalMotions));
+      void* old = 0;
+      if(vs_vector_set_dup(mlms,index-1,&lms, sizeof(LocalMotions), &old)!=VS_OK){
+        vs_log_error(modname,"VID.STAB file: cannot store the localmotions of "
+                     "frame %i", index);
+        vs_vector_del(&lms);
+        freeManyLocalMotions(mlms); // the caller does not own mlms on error
+        return VS_ERROR;
+      }
+      if(old){ // the same frame occurs twice in the file
+        vs_vector_del((LocalMotions*)old);
+        vs_free(old);
+      }
     }
     oldindex=index;
   }

--- a/src/vsvector.c
+++ b/src/vsvector.c
@@ -81,7 +81,9 @@ int vs_vector_size(const VSVector *V){
 
 int vs_vector_append(VSVector *V, void *data){
   assert(V && data);
-  if(!V->data || V->buffersize < 1) vs_vector_init(V,4);
+  if(!V->data || V->buffersize < 1){
+    if(vs_vector_init(V,4)!=VS_OK) return VS_ERROR;
+  }
   if(V->nelems >= V->buffersize){
     if(vs_vector_resize(V, V->buffersize*2)!=VS_OK) return VS_ERROR;
   }
@@ -92,11 +94,14 @@ int vs_vector_append(VSVector *V, void *data){
 
 int vs_vector_append_dup(VSVector *V, void *data, int data_size){
   assert(V && data);
-  if(!V->data || V->buffersize < 1) vs_vector_init(V,4);
   void* d = vs_malloc(data_size);
   if(!d) return VS_ERROR;
   memcpy(d, data, data_size);
-  return vs_vector_append(V, d);
+  if(vs_vector_append(V, d)!=VS_OK){
+    vs_free(d); // the copy never made it into the vector
+    return VS_ERROR;
+  }
+  return VS_OK;
 }
 
 
@@ -108,13 +113,27 @@ void *vs_vector_get(const VSVector *V, int pos){
     return V->data[pos];
 }
 
-void* vs_vector_set(VSVector *V, int pos, void *data){
-  assert(V && data && pos>=0);
-  if(!V->data || V->buffersize < 1) vs_vector_init(V,4);
+int vs_vector_set(VSVector *V, int pos, void *data, void **old){
+  assert(V && data);
+  if(old) *old = 0;
+  /* A position is not trusted: it can come from a file (a frame index in a
+     .trf, say). Reject an implausible one instead of sizing the buffer after
+     it - the growth loop below would otherwise overflow int and hand the
+     allocator a negative size. */
+  if(pos < 0 || pos >= VS_VECTOR_MAX_SIZE){
+    vs_log_error("VS_Vector","position %i out of range [0,%i)!",
+                 pos, VS_VECTOR_MAX_SIZE);
+    return VS_ERROR;
+  }
+  if(!V->data || V->buffersize < 1){
+    if(vs_vector_init(V,4)!=VS_OK) return VS_ERROR;
+  }
   if(V->buffersize <= pos) {
     int nsize = V->buffersize;
-    while(nsize <= pos) nsize *=2;
-    if(vs_vector_resize(V, nsize)!=VS_OK) return 0; // insuficient error handling here! VS_ERROR
+    /* double, but stop before the multiplication would overflow */
+    while(nsize <= pos && nsize <= VS_VECTOR_MAX_SIZE/2) nsize *= 2;
+    if(nsize <= pos) nsize = pos+1;
+    if(vs_vector_resize(V, nsize)!=VS_OK) return VS_ERROR;
   }
   if(pos >= V->nelems){ // insert after end of vector
     int i;
@@ -123,32 +142,42 @@ void* vs_vector_set(VSVector *V, int pos, void *data){
     }
     V->nelems=pos+1;
   }
-  void* old = V->data[pos];
+  if(old) *old = V->data[pos];
   V->data[pos] = data;
-  return old;
+  return VS_OK;
 }
 
-void* vs_vector_set_dup(VSVector *V, int pos, void *data, int data_size){
-  void* d = vs_malloc(data_size);
-  if(!d) return 0; // insuficient error handling here! VS_ERROR
+int vs_vector_set_dup(VSVector *V, int pos, void *data, int data_size,
+                      void **old){
+  int result;
+  void* d;
+  if(old) *old = 0;
+  d = vs_malloc(data_size);
+  if(!d) return VS_ERROR;
   memcpy(d, data, data_size);
-  return vs_vector_set(V, pos, d);
+  result = vs_vector_set(V, pos, d, old);
+  if(result != VS_OK) vs_free(d); // the copy never made it into the vector
+  return result;
 }
 
 
 int vs_vector_resize(VSVector *V, int newsize){
   assert(V && V->data);
   if(newsize<1) newsize=1;
-  V->data = (void**)vs_realloc(V->data, newsize * sizeof(void*));
+  /* into a temporary: a failed resize must leave V usable, not with
+     data==NULL and a nonzero buffersize - the next vs_vector_set() would
+     re-initialize it and silently drop everything stored so far */
+  void** newdata = (void**)vs_realloc(V->data, newsize * sizeof(void*));
+  if (!newdata){
+    vs_log_error("VS_Vector","out of memory!");
+    return VS_ERROR;
+  }
+  V->data=newdata;
   V->buffersize=newsize;
   if(V->nelems>V->buffersize){
     V->nelems=V->buffersize;
   }
-  if (!V->data){
-    vs_log_error("VS_Vector","out of memory!");
-    return VS_ERROR;
-  } else
-    return VS_OK;
+  return VS_OK;
 }
 
 VSVector vs_vector_filter(const VSVector *V, short (*pred)(void*, void*), void* param){

--- a/src/vsvector.h
+++ b/src/vsvector.h
@@ -25,6 +25,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <limits.h>
 #include "vidstab_api.h"
 
 /**
@@ -122,17 +123,39 @@ VS_API int vs_vector_append(VSVector *V, void *data);
 VS_API int vs_vector_append_dup(VSVector *V, void *data, int data_size);
 
 
-/* vs_vector_set:
- *      the newly inserted element BECOMES the position `pos' in the vector.
- *      and the old item is returned
+/*
+ * largest position/size a vector can hold. The buffer is an array of pointers
+ * indexed by int, so both the index and the byte size of the buffer have to
+ * stay representable. A position beyond this is not a large vector, it is a
+ * bogus index (typically taken from a corrupt file) and is rejected rather
+ * than turned into an absurd allocation.
  */
-VS_API void* vs_vector_set(VSVector *V, int pos, void *data);
+#define VS_VECTOR_MAX_SIZE ((int)(INT_MAX / sizeof(void*)))
+
+/* vs_vector_set:
+ *      the newly inserted element BECOMES the position `pos' in the vector,
+ *      which grows as needed. The vector does not take ownership of the data.
+ *
+ * Parameters:
+ *        V: pointer to vector to be used
+ *      pos: position to set, 0 <= pos < VS_VECTOR_MAX_SIZE
+ *     data: pointer to the data. Only the POINTER is stored, no deep copy.
+ *      old: if non-NULL, receives the element previously at `pos' (NULL if
+ *           there was none), so the caller can release it. It is set to NULL
+ *           when the call fails.
+ * Return Value:
+ *     VS_OK on success,
+ *     VS_ERROR if `pos' is out of range or the vector could not be grown.
+ *     On VS_ERROR the vector is left unchanged and still usable.
+ */
+VS_API int vs_vector_set(VSVector *V, int pos, void *data, void **old);
 
 /* vs_vector_set_dup:
- *      the newly inserted element is copied and BECOMES the position `pos' in the vector
- *      and the old item is returned
+ *      like vs_vector_set but copies `data_size' bytes of data. The copy is
+ *      released again if the element cannot be stored.
  */
-VS_API void* vs_vector_set_dup(VSVector *V, int pos, void *data, int data_size);
+VS_API int vs_vector_set_dup(VSVector *V, int pos, void *data, int data_size,
+                             void **old);
 
 /*
  * vs_vector_get:

--- a/tests/test_serialize_robust.c
+++ b/tests/test_serialize_robust.c
@@ -142,6 +142,35 @@ int test_serialize_robust(){
     fclose(f);
     fprintf(stderr,"** corrupt list length rejected OKAY\n");
   }
+
+  /* ---- 3b. a corrupt (implausibly large) *frame index* must be rejected the
+       same way instead of being used to size the frame vector (issue #168).
+       Without the bound, index-1 goes straight into vs_vector_set(), whose
+       growth loop overflows int and asks the allocator for a negative size.
+       On a 64-bit host with overcommit that absurd allocation often succeeds
+       and the bug stays invisible; on 32-bit it fails, and the failing resize
+       used to wipe the vector - which is how this surfaced as an ARM-only
+       test failure. ---- */
+  {
+    int32_t bogus = INT_MAX-1;
+    unsigned char* copy = vs_malloc(len);
+    memcpy(copy,buf,len);
+    memcpy(copy+24,&bogus,4);   /* header(24) -> frameNum of the first record */
+    sr_spit(testOut("srtest_bigindex.trf"), copy, len);
+    vs_free(copy);
+    f = fopen(testOut("srtest_bigindex.trf"),"rb");
+    test_bool(f!=0);
+    test_bool(vsReadLocalMotionsFile(f,&mlms)==VS_OK);
+    /* the bogus record is dropped, the two well-formed ones that follow it
+       are still read - and the vector must not have been reset in between */
+    test_bool(vs_vector_size(&mlms)==SR_NFRAMES);
+    test_bool(VSMLMGet(&mlms,0)==0);
+    for(i=1; i<vs_vector_size(&mlms); i++)
+      test_bool(vs_vector_size(VSMLMGet(&mlms,i))==SR_NLM);
+    sr_free_mlms(&mlms);
+    fclose(f);
+    fprintf(stderr,"** corrupt frame index rejected OKAY\n");
+  }
   vs_free(buf);
 
   /* ---- 4. ascii file with CRLF line endings read from a binary handle ---- */

--- a/tests/test_vsvector.c
+++ b/tests/test_vsvector.c
@@ -1,0 +1,74 @@
+/*
+ * test_vsvector.c
+ *
+ * Regression tests for issue #168: vs_vector_set() sized its buffer from the
+ * requested position by doubling, which overflows int for a large position and
+ * hands a negative size to the allocator. A failing resize additionally used to
+ * assign the failed realloc result straight onto V->data, leaving the vector
+ * with data==NULL but a nonzero buffersize - so the *next* set() re-initialized
+ * it and silently dropped everything stored so far.
+ */
+
+static int vv_count_nonnull(VSVector* v){
+  int i, n = 0;
+  for(i=0; i<vs_vector_size(v); i++)
+    if(vs_vector_get(v,i)) n++;
+  return n;
+}
+
+int test_vsvector_bounds(){
+  VSVector v;
+  int payload = 42;
+  void* old;
+
+  /* ---- 1. an implausible position is rejected, not turned into an
+       allocation. INT_MAX-1 is what a corrupt frame index in a .trf can
+       produce; doubling towards it overflows int. ---- */
+  vs_vector_init(&v,4);
+  test_bool(vs_vector_set(&v, INT_MAX-1, &payload, 0) == VS_ERROR);
+  test_bool(vs_vector_set(&v, INT_MAX,   &payload, 0) == VS_ERROR);
+  test_bool(vs_vector_set(&v, -1,        &payload, 0) == VS_ERROR);
+  fprintf(stderr,"** implausible vector position rejected OKAY\n");
+
+  /* the vector must be untouched by the rejected calls */
+  test_bool(vs_vector_size(&v) == 0);
+  test_bool(vs_vector_set(&v, 0, &payload, 0) == VS_OK);
+  test_bool(vs_vector_get(&v,0) == &payload);
+  test_bool(vs_vector_size(&v) == 1);
+
+  /* ---- 2. a rejected set must not destroy already stored elements ---- */
+  test_bool(vs_vector_set(&v, 7, &payload, 0) == VS_OK);
+  test_bool(vs_vector_size(&v) == 8);
+  test_bool(vs_vector_set(&v, INT_MAX-1, &payload, 0) == VS_ERROR);
+  test_bool(vs_vector_size(&v) == 8);          /* not reset to 0 */
+  test_bool(vs_vector_get(&v,0) == &payload);  /* still there */
+  test_bool(vs_vector_get(&v,7) == &payload);
+  test_bool(vv_count_nonnull(&v) == 2);
+  fprintf(stderr,"** vector survives a rejected set OKAY\n");
+
+  /* ---- 3. the old element is reported so the caller can free it ---- */
+  old = (void*)-1;
+  test_bool(vs_vector_set(&v, 3, &payload, &old) == VS_OK);
+  test_bool(old == 0);                       /* gap element, was empty */
+  test_bool(vs_vector_set(&v, 3, &payload, &old) == VS_OK);
+  test_bool(old == &payload);                /* now reports what it replaced */
+  vs_vector_fini(&v);
+
+  /* ---- 4. set_dup must not leak its copy when the position is rejected.
+       Run it often enough that a leaked copy would show up under valgrind /
+       ASan; the point here is that it returns an error at all. ---- */
+  {
+    int i;
+    vs_vector_init(&v,4);
+    for(i=0; i<1000; i++)
+      test_bool(vs_vector_set_dup(&v, INT_MAX-1, &payload, sizeof(payload), 0)
+                == VS_ERROR);
+    test_bool(vs_vector_size(&v) == 0);
+    test_bool(vs_vector_set_dup(&v, 2, &payload, sizeof(payload), 0) == VS_OK);
+    test_bool(*(int*)vs_vector_get(&v,2) == 42);
+    vs_vector_del(&v);
+    fprintf(stderr,"** set_dup rejects without leaking OKAY\n\n");
+  }
+
+  return 1;
+}

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -40,6 +40,7 @@
 #include "test_motiondetect.c"
 #include "test_store_restore.c"
 #include "test_serialize_robust.c"
+#include "test_vsvector.c"
 #include "test_contrast.c"
 #include "test_boxblur.c"
 #include "test_omp.c"
@@ -157,6 +158,10 @@ int main(int argc, char** argv){
 
   if(all || contains(argv,argc,"--testSRO", "serialization robustness")){
     UNIT(test_serialize_robust());
+  }
+
+  if(all || contains(argv,argc,"--testVEC", "vsvector bounds")){
+    UNIT(test_vsvector_bounds());
   }
 
   if(all || contains(argv,argc,"--testCT", "contrastImg")){


### PR DESCRIPTION
Fixes #168.

A frame index read from a `.trf` went straight into `vs_vector_set()` as a vector position, checked only for a lower bound — while the localmotions list length right beside it was already bounded by `VS_MAX_LOCALMOTIONS_PER_FRAME`. A corrupt or hostile file could therefore size the frame vector after an arbitrary `int`.

## What was actually wrong

Investigating turned up one cause beyond the three in the issue, and corrected one detail of it.

1. **The growth loop overflows.** `while(nsize <= pos) nsize *= 2` is signed overflow for a large `pos`, and UBSan flags it.

2. **The negative size never reached the allocator** — contrary to the issue's description. `vs_vector_resize()` opens with `if(newsize<1) newsize=1;` *before* the multiplication, so a negative `nsize` was clamped to 1. That is not harmless though: it silently shrank the buffer to a single slot and clamped `nelems` with it, discarding the vector's contents with no error.

3. **A position that does not overflow still asks for an absurd allocation.** This is what the test suite actually hits: `pos = 1071644671` doubles cleanly to `1073741824`, i.e. an 8.6 GB request.

4. **A failed resize destroyed the vector** (not in the issue). `vs_vector_resize()` assigned the failed `realloc` result straight onto `V->data`, leaving `data == NULL` with `buffersize` still set. The next `vs_vector_set()` then saw `!V->data`, called `vs_vector_init()` and reset `nelems` to 0 — dropping frames already stored successfully.

Point 4 is why this surfaced as a 32-bit-only failure. Nothing in the bug is platform specific, only whether the oversized allocation happens to succeed: a 64-bit host with overcommit satisfies it and limps on, a 32-bit one declines, and the failing resize then wiped `mlms`, so `test_serialize_robust.c:139` (`vs_vector_size(&mlms)>=1`) failed.

## The fix

- `serialize.c`: bound the index with `VS_MAX_FRAMES` (`1<<22`, over 19 h of 60 fps material) and reject the record rather than allocate for it, mirroring how the list length is already handled.
- `vsvector.c`: overflow-safe growth loop; `vs_vector_set()` rejects an out-of-range position at the boundary where the untrusted value enters; `vs_vector_resize()` reallocs through a temporary so a failure leaves the vector valid and usable.
- Error propagation: `vs_vector_set()`/`vs_vector_set_dup()` return `VS_OK`/`VS_ERROR` and report the replaced element through an added `void **old` out parameter. Returning it directly made allocation failure indistinguishable from "there was no old element" — which is what the `// insuficient error handling here! VS_ERROR` comments were about. `vsReadLocalMotionsFile()` propagates the failure and cleans up `mlms`, since `filter_transform.c:200` does not touch it on `VS_ERROR`.
- Leaks fixed on the way: `set_dup()`/`append_dup()` freed nothing when the element could not be stored, and a duplicate frame index leaked the `LocalMotions` it replaced.

Answering the issue's last point: `test_serialize_robust`'s expectation stays "recovers with >=1 frame". With the index bounded, the bogus record is dropped before any allocation, so recovery no longer depends on an absurd allocation succeeding and the expectation now holds on 32-bit and 64-bit alike.

## API change

`vs_vector_set()` and `vs_vector_set_dup()` change signature. `vsvector.h` is installed, so this is nominally an ABI break, but the only caller anywhere in the tree is `serialize.c` — the sole `vs_vector_*` function used by the transcode plugins and the ffmpeg filter is `vs_vector_del()`. **`SOVERSION` is deliberately left at 1.3**; the change is recorded in the Changelog.

## Verification

Verified on real 32-bit armv7 (`gcc-arm-linux-gnueabihf` + `qemu-arm-static`), the configuration #167's CI job uses:

| | `--testSRO` on armv7 |
|---|---|
| master (b5303bd) | **aborts** — `test_serialize_robust.c:139: Test Failed: vs_vector_size(&mlms)>=1`, then `vs_vector_get: Assertion 'V && V->data' failed`, exit 134 |
| this branch | **passes**, exit 0, no oversized allocation attempted at all |

That reproduces the issue's report exactly, and matches what capping the address space (`ulimit -v`) does on x86-64 — so the cheap proxy was faithful.

- armv7 under qemu: `--testSRO --testVEC --testSR` 6/6.
- x86-64: full suite 36/36.
- New `--testVEC` and the extended `--testSRO` clean under ASan+UBSan — zero UBSan runtime errors, zero leaks. (The suite's other ASan leaks all trace to `test_store_restore.c:16`, which calls `vsMotionDetectInit` with no matching cleanup — pre-existing and untouched here.)

Note for a future armv7 CI job: `--all` does not yet pass on 32-bit, but for an unrelated pre-existing reason. `test_draw.c:245` compares a checksum accumulated in `unsigned long` against `PLANAR_SHOW_CHECKSUM` (`4339987323UL`), which exceeds 2^32-1, so on a 32-bit target the accumulator wraps to 45020027 while the constant widens — the test cannot pass there. The drawing itself is correct (`nonzero` matches exactly). Unrelated to this PR and left alone.

## New tests

- `tests/test_vsvector.c` (`--testVEC`): drives `vs_vector_set()` with `INT_MAX-1` directly, and asserts that a rejected set leaves already-stored elements intact rather than emptying the vector.
- `tests/test_serialize_robust.c`: a `.trf` whose first record carries a corrupt frame index; the bogus record is dropped and the well-formed records after it are still read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
