### PR TITLE
tests: let CMake pick the OpenMP flag and runtime

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,7 +60,16 @@ if(USE_OMP)
     add_compile_options(/openmp)
     add_definitions(-DUSE_OMP)
   else()
-    add_definitions(-fopenmp -DUSE_OMP)
+    # Let CMake work out the toolchain's OpenMP flag and runtime, the same way
+    # the library does.  Hardcoding -fopenmp and then linking gomp compiles
+    # clang against libomp while forcing GCC's runtime on the link line, and
+    # the __kmpc_* symbols clang emits go unresolved.
+    find_package(OpenMP)
+    if(OpenMP_C_FOUND)
+      add_definitions(${OpenMP_C_FLAGS} -DUSE_OMP)
+    else()
+      message(WARNING "USE_OMP is on but no OpenMP was found; building without it")
+    endif()
   endif()
 endif()
 
@@ -112,11 +121,11 @@ add_executable (bench EXCLUDE_FROM_ALL ../bench/bench_motiondetect.c
   ${VIDSTAB_SIMD_SOURCES}
   ${LP_SOURCES})
 # MSVC has the math functions in the C runtime and drives OpenMP from /openmp,
-# so neither libm nor libgomp exists to be linked there.
+# so neither libm nor an OpenMP runtime exists to be linked there.
 if(NOT MSVC)
 target_link_libraries(bench m)
-if(USE_OMP)
-target_link_libraries(bench gomp)
+if(USE_OMP AND TARGET OpenMP::OpenMP_C)
+target_link_libraries(bench OpenMP::OpenMP_C)
 endif()
 endif()
 
@@ -126,8 +135,8 @@ endif()
 if(GLPK_FOUND AND VIDSTAB_LPSOLVER STREQUAL "glpk")
 target_link_libraries(tests GLPK::GLPK)
 endif()
-if(USE_OMP AND NOT MSVC)
-target_link_libraries(tests gomp)
+if(USE_OMP AND NOT MSVC AND TARGET OpenMP::OpenMP_C)
+target_link_libraries(tests OpenMP::OpenMP_C)
 endif()
 
 # Everything the tests write goes into this directory (TEST_OUTPUT_DIR in


### PR DESCRIPTION
The test project still hardcoded `-fopenmp` on the compile line and linked `gomp` explicitly — the arrangement the library moved away from when #65 was fixed, but which was never applied to `tests/`.

Under clang the two disagree: `-fopenmp` compiles against libomp and emits `__kmpc_*` calls, while the link line forces GCC's libgomp, so the test binary fails to link:

```
undefined reference to `__kmpc_fork_call'
undefined reference to `__kmpc_for_static_fini'
```

gcc happened to agree with itself, which is why this went unnoticed.

Now uses `find_package(OpenMP)` and links `OpenMP::OpenMP_C` for both `tests` and `bench`, so each toolchain gets its own flag and its own runtime.

Verified:

| build | OpenMP found | runtime linked | suite |
|---|---|---|---|
| gcc | `-fopenmp` (4.5) | `libgomp.so.1` | 36/36 |
| clang | `-fopenmp=libomp` (5.1) | `libomp.so.5` | 36/36 |
| clang, `USE_OMP=OFF` | n/a | none | builds |

The clang 36/36 includes `--testOMP`, which previously could not be built at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)