### PR TITLE
transformPacked: interpolate a whole pixel at a time, and skip the bound check inside the frame

### DIFF
--- a/bench/bench_transform.c
+++ b/bench/bench_transform.c
@@ -1,0 +1,177 @@
+/* bench_transform.c
+ *
+ * Timing for the transform stage, in particular the packed (RGB24/BGR24/RGBA)
+ * path, whose per-pixel interpolation runs through interpolateN().
+ * Not part of the test suite -- a measurement tool.
+ *
+ * Usage: bench_transform [width height nframes]
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <math.h>
+
+#include "transform.h"
+#include "transform_internal.h"
+#include "transformfixedpoint.h"
+#include "transformfloat.h"
+#include "frameinfo.h"
+
+static double now_s(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec + ts.tv_nsec * 1e-9;
+}
+
+static unsigned int rstate = 12345;
+static unsigned int xrand(void) {
+  rstate = rstate * 1103515245u + 12345u;
+  return (rstate >> 16) & 0x7FFF;
+}
+
+static void fill(VSFrame* f, const VSFrameInfo* fi) {
+  int p, y, x;
+  for (p = 0; p < fi->planes; p++) {
+    int w = (p == 0) ? fi->width * fi->bytesPerPixel : fi->width / 2;
+    int h = (p == 0) ? fi->height : fi->height / 2;
+    for (y = 0; y < h; y++) {
+      unsigned char* row = f->data[p] + y * f->linesize[p];
+      for (x = 0; x < w; x++)
+        row[x] = (unsigned char)xrand();
+    }
+  }
+}
+
+/* FNV-1a over every byte of every plane -- the point of running the same
+   benchmark against a modified interpolator is that this must not change. */
+static unsigned long long frame_hash(const VSFrame* f, const VSFrameInfo* fi) {
+  unsigned long long h = 14695981039346656037ULL;
+  int p, y, x;
+  for (p = 0; p < fi->planes; p++) {
+    int w = (p == 0) ? fi->width * fi->bytesPerPixel : fi->width / 2;
+    int hgt = (p == 0) ? fi->height : fi->height / 2;
+    for (y = 0; y < hgt; y++) {
+      const unsigned char* row = f->data[p] + y * f->linesize[p];
+      for (x = 0; x < w; x++) {
+        h ^= row[x];
+        h *= 1099511628211ULL;
+      }
+    }
+  }
+  return h;
+}
+
+static VSTransform mk_transform(void) {
+  VSTransform t;
+  memset(&t, 0, sizeof(t));
+  /* deliberately not identity and not axis aligned, so every destination
+     pixel takes the interpolating path */
+  t.x     = 7.3;
+  t.y     = -4.7;
+  t.alpha = 1.5 * M_PI / 180.0;
+  t.zoom  = 2.0;
+  t.extra = 0;
+  return t;
+}
+
+typedef int (*trfn)(VSTransformData*, VSTransform);
+
+static void bench_t(const char* name, trfn fn, VSPixelFormat pf,
+                    int width, int height, int nframes,
+                    VSTransform t, int crop) {
+  VSFrameInfo fi;
+  VSFrame src, dest;
+  VSTransformData td;
+  VSTransformConfig conf = vsTransformGetDefaultConfig("bench");
+  double t0, t1;
+  int i;
+  unsigned long long chk = 0;
+
+  conf.crop = crop;
+  vsFrameInfoInit(&fi, width, height, pf);
+  vsFrameAllocate(&src, &fi);
+  vsFrameAllocate(&dest, &fi);
+  fill(&src, &fi);
+
+  if (vsTransformDataInit(&td, &conf, &fi, &fi) != VS_OK) {
+    fprintf(stderr, "vsTransformDataInit failed\n");
+    exit(1);
+  }
+
+  /* one warm up pass, not timed */
+  vsTransformPrepare(&td, &src, &dest);
+  fn(&td, t);
+  vsTransformFinish(&td);
+
+  t0 = now_s();
+  for (i = 0; i < nframes; i++) {
+    vsTransformPrepare(&td, &src, &dest);
+    fn(&td, t);
+    vsTransformFinish(&td);
+  }
+  t1 = now_s();
+
+  chk = frame_hash(&dest, &fi);
+  printf("%-26s %4dx%-4d  %8.3f ms/frame   [%016llx]\n", name, width, height,
+         (t1 - t0) * 1000.0 / nframes, chk);
+
+  vsTransformDataCleanup(&td);
+  vsFrameFree(&src);
+  vsFrameFree(&dest);
+}
+
+/* A set of transforms chosen to hit every branch of the interpolator:
+   interior pixels, the last row/column (where the "ceil" neighbour is one
+   past the end), and source coordinates far outside the frame. */
+static void verify(void) {
+  VSPixelFormat fmts[3] = {PF_RGB24, PF_BGR24, PF_RGBA};
+  const char* names[3]  = {"RGB24", "BGR24", "RGBA "};
+  int f, c, i;
+  for (f = 0; f < 3; f++) {
+    for (c = 0; c <= 1; c++) {
+      for (i = 0; i < 5; i++) {
+        VSTransform t;
+        char label[64];
+        memset(&t, 0, sizeof(t));
+        switch (i) {
+          case 0: t.x = 7.3;  t.y = -4.7; t.alpha = 1.5*M_PI/180.0; t.zoom = 2.0; break;
+          case 1: t.x = 0.5;  t.y =  0.5; break;               /* half pixel, all borders */
+          case 2: t.x = -400; t.y = -300; break;               /* mostly outside */
+          case 3: t.alpha = 45*M_PI/180.0; break;              /* corners outside */
+          case 4: t.zoom = -60; break;                         /* zoom out, big borders */
+        }
+        snprintf(label, sizeof(label), "verify %s crop=%d case=%d", names[f], c, i);
+        bench_t(label, transformPacked, fmts[f], 61, 37, 2, t, c);
+        snprintf(label, sizeof(label), "verify %s crop=%d case=%d flt", names[f], c, i);
+        bench_t(label, transformPacked_float, fmts[f], 61, 37, 2, t, c);
+      }
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  int width = 1920, height = 1080, nframes = 20;
+  VSTransform t = mk_transform();
+
+  if (argc >= 2 && strcmp(argv[1], "verify") == 0) {
+    verify();
+    return 0;
+  }
+  if (argc >= 3) {
+    width  = atoi(argv[1]);
+    height = atoi(argv[2]);
+  }
+  if (argc >= 4)
+    nframes = atoi(argv[3]);
+
+  bench_t("packed RGB24 fixedpoint", transformPacked, PF_RGB24,
+          width, height, nframes, t, 0);
+  bench_t("packed RGBA  fixedpoint", transformPacked, PF_RGBA,
+          width, height, nframes, t, 0);
+  bench_t("packed RGB24 float", transformPacked_float, PF_RGB24,
+          width, height, nframes, t, 0);
+  bench_t("planar YUV420 fixedpoint", transformPlanar, PF_YUV420P,
+          width, height, nframes, t, 0);
+  return 0;
+}

--- a/bench/build.sh
+++ b/bench/build.sh
@@ -21,3 +21,9 @@ EXTRA_DEFS="-DVS_HAVE_AVX2 -DVS_HAVE_AVX512 -DVS_HAVE_NEON"
 mkdir -p bld
 gcc -O3 -std=gnu99 -DUSE_OMP -fopenmp -DUSE_IPM -DVS_HAVE_LPSOLVER \
     $EXTRA_DEFS -Isrc -Itests -o bld/bench bench/bench_motiondetect.c $SRCS $OBJS -lm "$@"
+
+# The transform benchmark. -DTESTING keeps the float implementation under its
+# own name, so both can be timed (and compared) in one binary.
+gcc -O3 -std=gnu99 -DUSE_OMP -fopenmp -DUSE_IPM -DVS_HAVE_LPSOLVER -DTESTING \
+    $EXTRA_DEFS -Isrc -Itests -o bld/bench_transform bench/bench_transform.c \
+    $SRCS src/transformfloat.c $OBJS -lm "$@"

--- a/src/transformfixedpoint.c
+++ b/src/transformfixedpoint.c
@@ -220,6 +220,24 @@ void interpolateZero(uint8_t *rv, fp16 x, fp16 y,
 
 
 /**
+ * blendBiLinN: the bi-linear blend of four already fetched samples.
+ *
+ * Factored out so that interpolateN() (one channel, range checked) and
+ * interpolateNall() (all channels of one pixel, indices hoisted) share one
+ * copy of the arithmetic and cannot drift apart.
+ *   v1 = (x_c,y_c)  v2 = (x_c,y_f)  v3 = (x_f,y_c)  v4 = (x_f,y_f)
+ */
+static uint8_t blendBiLinN(short v1, short v2, short v3, short v4,
+                           fp16 x, fp16 x_f, fp16 x_c,
+                           fp16 y, fp16 y_f, fp16 y_c)
+{
+  fp16 s  = fp16To8(v1*(x - x_f)+v3*(x_c - x))*fp16To8(y - y_f) +
+    fp16To8(v2*(x - x_f) + v4*(x_c - x))*fp16To8(y_c - y);
+  int32_t res = fp16ToIRound(s);
+  return (res >= 0) ? ((res < 255) ? res : 255) : 0;
+}
+
+/**
  * interpolateN: Bi-linear interpolation function for N channel image.
  *
  * Parameters:
@@ -248,20 +266,66 @@ void interpolateN(uint8_t *rv, fp16 x, fp16 y,
   } else {
     int32_t ix_c = ix_f + 1;
     int32_t iy_c = iy_f + 1;
-    /* the "ceil" neighbours may be one past the last row/column; use the
-       range checked accessor, their interpolation weight is 0 in that case */
-    short v1 = PIXELN(img, img_linesize, ix_c, iy_c, width, height, N, channel, def);
-    short v2 = PIXELN(img, img_linesize, ix_c, iy_f, width, height, N, channel, def);
-    short v3 = PIXELN(img, img_linesize, ix_f, iy_c, width, height, N, channel, def);
-    short v4 = PIXELN(img, img_linesize, ix_f, iy_f, width, height, N, channel, def);
-    fp16 x_f = iToFp16(ix_f);
-    fp16 x_c = iToFp16(ix_c);
-    fp16 y_f = iToFp16(iy_f);
-    fp16 y_c = iToFp16(iy_c);
-    fp16 s  = fp16To8(v1*(x - x_f)+v3*(x_c - x))*fp16To8(y - y_f) +
-      fp16To8(v2*(x - x_f) + v4*(x_c - x))*fp16To8(y_c - y);
-    int32_t res = fp16ToIRound(s);
-    *rv = (res >= 0) ? ((res < 255) ? res : 255) : 0;
+    short v1, v2, v3, v4;
+    /* ix_f/iy_f are in range by the test above, so only the "ceil" neighbours
+       can be one past the last row/column.  Away from that border no bound can
+       be violated and the unchecked accessor is used; on it the range checked
+       one supplies def, exactly as before. */
+    if (ix_c < width && iy_c < height) {
+      v1 = PIXN(img, img_linesize, ix_c, iy_c, N, channel);
+      v2 = PIXN(img, img_linesize, ix_c, iy_f, N, channel);
+      v3 = PIXN(img, img_linesize, ix_f, iy_c, N, channel);
+      v4 = PIXN(img, img_linesize, ix_f, iy_f, N, channel);
+    } else {
+      v1 = PIXELN(img, img_linesize, ix_c, iy_c, width, height, N, channel, def);
+      v2 = PIXELN(img, img_linesize, ix_c, iy_f, width, height, N, channel, def);
+      v3 = PIXELN(img, img_linesize, ix_f, iy_c, width, height, N, channel, def);
+      v4 = PIXELN(img, img_linesize, ix_f, iy_f, width, height, N, channel, def);
+    }
+    *rv = blendBiLinN(v1, v2, v3, v4, x, iToFp16(ix_f), iToFp16(ix_c),
+                      y, iToFp16(iy_f), iToFp16(iy_c));
+  }
+}
+
+/**
+ * interpolateNall: interpolateN() for every channel of one destination pixel.
+ *
+ * transformPacked() used to call interpolateN() once per channel, which
+ * recomputed the source indices and the interpolation weights N times for the
+ * same pixel.  Here they are computed once and only the four sample loads and
+ * the blend happen per channel.
+ *
+ * Parameters: as interpolateN(), except
+ *           dest: the N consecutive destination channels of one pixel
+ *           crop: if nonzero, out of range pixels become 16 (black), otherwise
+ *                 the destination keeps the value it already had
+ */
+static void interpolateNall(uint8_t *dest, fp16 x, fp16 y,
+                            const uint8_t *img, int img_linesize,
+                            int width, int height, uint8_t N, char crop)
+{
+  int32_t ix_f = fp16ToI(x);
+  int32_t iy_f = fp16ToI(y);
+  uint8_t k;
+  if (ix_f < 0 || ix_f > width-1 || iy_f < 0 || iy_f > height - 1) {
+    if (crop)
+      for (k = 0; k < N; k++)
+        dest[k] = 16;
+    /* else: leave the destination untouched, like interpolateN(.., def=*dest) */
+  } else if (ix_f + 1 < width && iy_f + 1 < height) {
+    /* interior: no sample can be out of range, so no per sample bound check */
+    fp16 x_f = iToFp16(ix_f), x_c = iToFp16(ix_f + 1);
+    fp16 y_f = iToFp16(iy_f), y_c = iToFp16(iy_f + 1);
+    const uint8_t *rowf = img + ix_f*N + iy_f*img_linesize;
+    const uint8_t *rowc = rowf + img_linesize;
+    for (k = 0; k < N; k++)
+      dest[k] = blendBiLinN(rowc[N+k], rowf[N+k], rowc[k], rowf[k],
+                            x, x_f, x_c, y, y_f, y_c);
+  } else {
+    /* last row or column: the checked path, one channel at a time */
+    for (k = 0; k < N; k++)
+      interpolateN(&dest[k], x, y, img, img_linesize, width, height,
+                   N, k, crop ? 16 : dest[k]);
   }
 }
 
@@ -277,7 +341,7 @@ void interpolateN(uint8_t *rv, fp16 x, fp16 y,
  */
 int transformPacked(VSTransformData* td, VSTransform t)
 {
-  int x = 0, y = 0, k = 0;
+  int x = 0, y = 0;
   uint8_t *D_1, *D_2;
 
   if (t.alpha==0 && t.x==0 && t.y==0 && t.zoom == 0){
@@ -319,13 +383,11 @@ int transformPacked(VSTransformData* td, VSTransform t)
       fp16 x_s  =  zcos_a * x_d1 + zsin_a * y_d1 + c_tx;
       fp16 y_s  = -zsin_a * x_d1 + zcos_a * y_d1 + c_ty;
 
-      for (k = 0; k < channels; k++) { // iterate over colors
-        // linesize is in bytes, only the column is scaled by the channel count
-        uint8_t *dest = &D_2[x * channels + y * td->destbuf.linesize[0] + k];
-        interpolateN(dest, x_s, y_s, D_1, td->src.linesize[0],
-                     td->fiSrc.width, td->fiSrc.height,
-                     channels, k, td->conf.crop ? 16 : *dest);
-      }
+      // linesize is in bytes, only the column is scaled by the channel count
+      interpolateNall(&D_2[x * channels + y * td->destbuf.linesize[0]],
+                      x_s, y_s, D_1, td->src.linesize[0],
+                      td->fiSrc.width, td->fiSrc.height,
+                      channels, td->conf.crop);
     }
   }
   return VS_OK;

--- a/src/transformfloat.c
+++ b/src/transformfloat.c
@@ -190,10 +190,20 @@ void _FLT(interpolateN)(uint8_t *rv, float x, float y,
     int x_c = x_f+1;
     int y_f = myfloor(y);
     int y_c = y_f+1;
-    short v1 = PIXELN(img, img_linesize, x_c, y_c, width, height, N, channel, def);
-    short v2 = PIXELN(img, img_linesize, x_c, y_f, width, height, N, channel, def);
-    short v3 = PIXELN(img, img_linesize, x_f, y_c, width, height, N, channel, def);
-    short v4 = PIXELN(img, img_linesize, x_f, y_f, width, height, N, channel, def);
+    short v1, v2, v3, v4;
+    /* away from the frame border none of the four samples can be out of
+       range, so the per sample bound check is skipped there */
+    if (x_f >= 0 && y_f >= 0 && x_c < width && y_c < height) {
+      v1 = PIXN(img, img_linesize, x_c, y_c, N, channel);
+      v2 = PIXN(img, img_linesize, x_c, y_f, N, channel);
+      v3 = PIXN(img, img_linesize, x_f, y_c, N, channel);
+      v4 = PIXN(img, img_linesize, x_f, y_f, N, channel);
+    } else {
+      v1 = PIXELN(img, img_linesize, x_c, y_c, width, height, N, channel, def);
+      v2 = PIXELN(img, img_linesize, x_c, y_f, width, height, N, channel, def);
+      v3 = PIXELN(img, img_linesize, x_f, y_c, width, height, N, channel, def);
+      v4 = PIXELN(img, img_linesize, x_f, y_f, width, height, N, channel, def);
+    }
     float s  = (v1*(x - x_f)+v3*(x_c - x))*(y - y_f) +
       (v2*(x - x_f) + v4*(x_c - x))*(y_c - y);
     int32_t res = (int32_t)s;


### PR DESCRIPTION
### Why

8da5ae2c fixed a heap overflow in `interpolateN()` by replacing the unchecked `PIXN()` with the range checked `PIXELN()` for all four bilinear samples. That sits in the innermost loop of the packed (RGB24/BGR24/RGBA) transform, so the question was what the check costs — and whether we can get back to `PIXN`.

We can, but it turned out not to be where the time went.

### Measurements

New `bench/bench_transform.c`, 1080p, best of five, Ryzen 9 9900X, GCC 15.2 `-O3`, ms/frame:

| | before | `PIXN` only | this PR |
|---|---|---|---|
| packed RGB24 fixedpoint | 17.93 | 17.28 | **11.72** |
| packed RGBA fixedpoint | 23.05 | 21.88 | **13.84** |
| packed RGB24 float | 38.86 | 33.27 | — |
| planar YUV420 (control) | 9.08 | 9.08 | 9.08 |

The bound check was worth ~4%. What cost 35% was next to it: `transformPacked()` called `interpolateN()` once per channel, and each call recomputed the source indices and all four interpolation weights for the *same* pixel — 3x over for RGB24, 4x for RGBA.

### What changed

* `interpolateN()` uses the unchecked accessor again when `ix_f+1 < width && iy_f+1 < height`. The outer test already establishes `ix_f`/`iy_f` are in range, so only the "ceil" neighbours can leave the frame; on the last row/column the checked accessor still supplies `def`. One predictable branch replaces four bound checks.
* New `interpolateNall()` does all N channels of one destination pixel — indices and weights once, then four loads and a blend per channel. `transformPacked()` calls it once per pixel. The border case delegates to `interpolateN()` unchanged.
* The blend moved into `blendBiLinN()`, shared by both, so the fixed point arithmetic exists once.
* `transformfloat.c` gets the same interior fast path. It is a test-only reference (not in the library sources), so it keeps the per-channel structure.

### The check is still load-bearing

A variant with the check simply deleted diverges on 18 of the 60 verification cases below — it reads past the buffer exactly as before 8da5ae2c. Only *interior* pixels can skip it.

### Verification

* `bench_transform verify` hashes every byte of the result frame over 3 packed formats x crop on/off x 5 transforms chosen to hit interior pixels, the last row/column, and source coordinates far outside the frame: **60/60 bit-identical** to master.
* `./tests --all` — 38/38.
* Benchmark clean under ASan + UBSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)